### PR TITLE
Set default bondless allowance to 0 and default to only considering 0 fee offers for the bondless selection

### DIFF
--- a/taker/README.md
+++ b/taker/README.md
@@ -205,6 +205,26 @@ jm-taker coinjoin \
   --max-rel-fee 0.0005
 ```
 
+### Bondless Maker Selection
+
+The taker uses fidelity bonds to select makers, but occasionally selects makers randomly to give bondless makers a chance. This is controlled by `--bondless-allowance` (default 12.5%).
+
+To reduce the economic incentive for sybil attacks by bondless makers, the `--bondless-zero-fee` option (enabled by default) ensures that bondless maker spots only go to makers charging zero absolute fees. This removes the incentive to run many bondless bots to collect more fees.
+
+```bash
+# Disable zero-fee requirement for bondless spots (not recommended)
+jm-taker coinjoin \
+  --mnemonic-file ~/.joinmarket-ng/wallets/taker.mnemonic \
+  --amount 1000000 \
+  --no-bondless-zero-fee
+
+# Adjust bondless maker allowance
+jm-taker coinjoin \
+  --mnemonic-file ~/.joinmarket-ng/wallets/taker.mnemonic \
+  --amount 1000000 \
+  --bondless-allowance 0.2
+```
+
 ## Docker Deployment
 
 A production-ready `docker-compose.yml` is provided in this directory with:
@@ -317,6 +337,9 @@ Note: Takers only need Tor SOCKS proxy (port 9050) - they don't serve a hidden s
 | `MIN_MAKERS` | `4` | Minimum number of makers |
 | `MAX_CJ_FEE_REL` | `0.001` | Maximum relative fee (0.1%) |
 | `MAX_CJ_FEE_ABS` | `5000` | Maximum absolute fee in sats |
+| `BONDLESS_MAKERS_ALLOWANCE` | `0.125` | Fraction of time to choose makers randomly (0.0-1.0) |
+| `BOND_VALUE_EXPONENT` | `1.3` | Exponent for fidelity bond value calculation |
+| `BONDLESS_REQUIRE_ZERO_FEE` | `true` | Require zero absolute fee for bondless maker spots |
 | `TOR_SOCKS_HOST` | `127.0.0.1` | Tor SOCKS proxy host |
 | `TOR_SOCKS_PORT` | `9050` | Tor SOCKS proxy port |
 | `SENSITIVE_LOGGING` | - | Enable sensitive logging (set to `1` or `true`) |
@@ -346,6 +369,9 @@ jm-taker tumble --help
 | `--backend` | full_node | Backend: full_node or neutrino |
 | `--max-abs-fee` | 500 | Max absolute fee per maker (sats) |
 | `--max-rel-fee` | 0.001 | Max relative fee (0.1%) |
+| `--bondless-allowance` | 0.125 | Fraction of time to choose makers randomly (0.0-1.0) |
+| `--bond-exponent` | 1.3 | Exponent for fidelity bond value calculation |
+| `--bondless-zero-fee` | enabled | Require zero absolute fee for bondless spots |
 
 Use env vars for RPC credentials (see jmwallet README).
 

--- a/taker/src/taker/cli.py
+++ b/taker/src/taker/cli.py
@@ -182,9 +182,27 @@ def coinjoin(
     bondless_makers_allowance: Annotated[
         float,
         typer.Option(
-            "--bondless-allowance", help="Fraction of time to choose makers randomly (0.0-1.0)"
+            "--bondless-allowance",
+            envvar="BONDLESS_MAKERS_ALLOWANCE",
+            help="Fraction of time to choose makers randomly (0.0-1.0)",
         ),
     ] = 0.125,
+    bond_value_exponent: Annotated[
+        float,
+        typer.Option(
+            "--bond-exponent",
+            envvar="BOND_VALUE_EXPONENT",
+            help="Exponent for fidelity bond value calculation (default 1.3)",
+        ),
+    ] = 1.3,
+    bondless_require_zero_fee: Annotated[
+        bool,
+        typer.Option(
+            "--bondless-zero-fee/--no-bondless-zero-fee",
+            envvar="BONDLESS_REQUIRE_ZERO_FEE",
+            help="For bondless spots, require zero absolute fee (default: enabled)",
+        ),
+    ] = True,
     yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation prompt")] = False,
     log_level: Annotated[str, typer.Option("--log-level", "-l", help="Log level")] = "INFO",
 ) -> None:
@@ -248,6 +266,8 @@ def coinjoin(
         counterparty_count=counterparties,
         max_cj_fee=MaxCjFee(abs_fee=max_abs_fee, rel_fee=max_rel_fee),
         bondless_makers_allowance=bondless_makers_allowance,
+        bond_value_exponent=bond_value_exponent,
+        bondless_makers_allowance_require_zero_fee=bondless_require_zero_fee,
     )
 
     asyncio.run(_run_coinjoin(config, amount, destination, mixdepth, counterparties, yes))

--- a/taker/src/taker/config.py
+++ b/taker/src/taker/config.py
@@ -66,6 +66,15 @@ class TakerConfig(WalletConfig):
         le=1.0,
         description="Fraction of time to choose makers randomly (not by fidelity bond)",
     )
+    bond_value_exponent: float = Field(
+        default=1.3,
+        gt=0.0,
+        description="Exponent for fidelity bond value calculation (default 1.3)",
+    )
+    bondless_makers_allowance_require_zero_fee: bool = Field(
+        default=True,
+        description="For bondless maker spots, require zero absolute fee (percentage fee OK)",
+    )
 
     # PoDLE settings
     taker_utxo_retries: int = Field(

--- a/taker/src/taker/taker.py
+++ b/taker/src/taker/taker.py
@@ -308,7 +308,11 @@ class Taker:
         )
 
         # Orderbook manager
-        self.orderbook_manager = OrderbookManager(config.max_cj_fee)
+        self.orderbook_manager = OrderbookManager(
+            config.max_cj_fee,
+            bondless_makers_allowance=config.bondless_makers_allowance,
+            bondless_require_zero_fee=config.bondless_makers_allowance_require_zero_fee,
+        )
 
         # PoDLE manager for commitment tracking
         self.podle_manager = PoDLEManager(config.data_dir)


### PR DESCRIPTION
Supersedes https://github.com/m0wer/joinmarket-ng/pull/43.

 Relates to https://github.com/m0wer/joinmarket-ng/issues/35.

Every parameter is easily configurable trough taker CLI args or environment variables.