### PR TITLE
feat(taker): per-slot probabilistic bondless maker selection

### DIFF
--- a/config.toml.template
+++ b/config.toml.template
@@ -325,7 +325,7 @@
 # fee_block_target = 6        # Target blocks for fee estimation (1-1008, omit to use default)
 
 # Fidelity bond settings
-# bondless_makers_allowance = 0.0  # 0.0-1.0 (0 = require bonds, 1 = allow all)
+# bondless_makers_allowance = 0.2  # 0.0-1.0: per-slot probability of picking a bondless maker
 # bond_value_exponent = 1.3
 # bondless_require_zero_fee = true
 

--- a/docs/technical/protocol.md
+++ b/docs/technical/protocol.md
@@ -205,10 +205,22 @@ After collecting offers, the taker selects makers through three phases:
 
 | Algorithm | Behavior |
 |-----------|----------|
-| `fidelity_bond_weighted` (default) | Mixed strategy: ~87.5% slots filled by bond-weighted selection, remaining slots randomly from all offers |
+| `fidelity_bond_weighted` (default) | Per-slot coin flip: each slot independently picks bonded (weighted) or uniform-random based on `bondless_makers_allowance` |
 | `cheapest` | Lowest fee first |
 | `weighted` | Exponentially weighted by inverse fee |
 | `random` | Uniform random selection |
+
+**Fidelity bond selection details** (`fidelity_bond_weighted`):
+
+The default algorithm uses a per-slot Bernoulli trial (matching the reference JoinMarket implementation):
+
+1. **Pre-filter**: When `bondless_require_zero_fee` is enabled (default), bondless offers (no fidelity bond) that charge a non-zero absolute fee are removed. This prevents attackers from flooding the orderbook with fee-charging bondless offers.
+2. **Per-slot selection**: For each of the `n` slots independently:
+   - With probability `bondless_makers_allowance` (default 0.2): pick uniformly at random from **all** remaining offers (bonded and bondless compete equally).
+   - Otherwise: pick from the bonded pool weighted by `fidelity_bond_value`.
+3. **Fallback**: If the chosen pool is empty, the other pool is tried, then uniform random.
+
+This design ensures that when few bondless makers exist, each has naturally low individual selection probability (~`allowance / total_offers` per slot), avoiding taker fingerprinting. When many bondless zero-fee makers are available, roughly `n * bondless_makers_allowance` appear in the final set (e.g., 2 out of 10 with 20% allowance). The uniform-random slots also benefit smaller bonded makers.
 
 **Key Point**: Selection probability is proportional to the **maker identity (nick)**, not the number of offers. A maker with 5 offers has the same selection probability as a maker with 1 offer (assuming both pass filters).
 

--- a/jmcore/src/jmcore/data/config.toml.template
+++ b/jmcore/src/jmcore/data/config.toml.template
@@ -325,7 +325,7 @@
 # fee_block_target = 6        # Target blocks for fee estimation (1-1008, omit to use default)
 
 # Fidelity bond settings
-# bondless_makers_allowance = 0.0  # 0.0-1.0 (0 = require bonds, 1 = allow all)
+# bondless_makers_allowance = 0.2  # 0.0-1.0: per-slot probability of picking a bondless maker
 # bond_value_exponent = 1.3
 # bondless_require_zero_fee = true
 

--- a/jmcore/src/jmcore/settings.py
+++ b/jmcore/src/jmcore/settings.py
@@ -654,10 +654,10 @@ class TakerSettings(BaseModel):
         description="Target blocks for fee estimation",
     )
     bondless_makers_allowance: float = Field(
-        default=0.0,
+        default=0.2,
         ge=0.0,
         le=1.0,
-        description="Fraction of time to choose makers randomly",
+        description="Per-slot probability of selecting a bondless (zero-fee) maker",
     )
     bond_value_exponent: float = Field(
         default=1.3,

--- a/taker/src/taker/config.py
+++ b/taker/src/taker/config.py
@@ -99,10 +99,10 @@ class TakerConfig(WalletConfig):
         "Defaults to 3 when connected to full node.",
     )
     bondless_makers_allowance: float = Field(
-        default=0.0,
+        default=0.2,
         ge=0.0,
         le=1.0,
-        description="Fraction of time to choose makers randomly (not by fidelity bond)",
+        description="Per-slot probability of selecting a bondless (zero-fee) maker",
     )
     bond_value_exponent: float = Field(
         default=1.3,

--- a/taker/src/taker/orderbook.py
+++ b/taker/src/taker/orderbook.py
@@ -363,141 +363,139 @@ def weighted_order_choose(
 def fidelity_bond_weighted_choose(
     offers: list[Offer],
     n: int,
-    bondless_makers_allowance: float = 0.125,
+    bondless_makers_allowance: float = 0.2,
     bondless_require_zero_fee: bool = True,
     cj_amount: int = 0,
 ) -> list[Offer]:
     """
-    Choose n offers with mixed fidelity bond and random selection.
+    Choose n offers using per-slot probabilistic selection.
 
-    Strategy:
-    1. Calculate proportion of bonded slots: round(n * (1 - bondless_makers_allowance))
-    2. Fill bonded slots using weighted selection by bond value
-    3. Fill remaining slots randomly from ALL remaining offers (bonded or bondless)
+    **Pre-filtering** (when ``bondless_require_zero_fee`` is True):
+    Bondless offers (``fidelity_bond_value == 0``) that charge a non-zero
+    absolute fee are removed before selection.  This prevents an attacker
+    from flooding the orderbook with fee-charging bondless offers to steal
+    fees while still allowing genuine zero-fee bondless makers to participate.
+    Relative-fee offers are kept because their effective fee depends on the
+    CoinJoin amount and is evaluated elsewhere.
 
-    "Bondless" means bond-agnostic (equal probability), not anti-bond. The bondless
-    slots give all remaining makers equal opportunity regardless of their bond status.
+    **Per-slot selection** (for each of the *n* slots independently):
 
-    This ensures high-bond makers are prioritized while still allowing new/bondless
-    makers to participate in a predictable proportion.
+    * With probability ``bondless_makers_allowance``: pick **uniformly at
+      random** from all remaining offers (bonded and bondless alike).  This
+      gives every surviving offer equal probability, so a rare bondless maker
+      naturally has low selection odds (``~ allowance / total_offers`` per
+      slot).
+    * Otherwise: pick from the bonded pool (``fidelity_bond_value > 0``)
+      **weighted by bond value**.
+
+    Fallback: if the chosen pool is empty the other pool is tried, then
+    uniform random over everything remaining.
+
+    This mirrors the reference JoinMarket implementation and ensures:
+
+    * High-bond makers are strongly favoured (~80% of slots with default
+      0.2 allowance).
+    * When many bondless zero-fee makers exist, roughly
+      ``n * bondless_makers_allowance`` of them appear in the final set
+      (e.g. 2 out of 10).
+    * When only a few bondless makers exist, each has low individual
+      selection probability (proportional to ``1 / total_remaining``),
+      avoiding taker fingerprinting.
+    * Smaller bonded makers also benefit from the uniform-random slots.
 
     Args:
-        offers: Eligible offers
-        n: Number of offers to choose
-        bondless_makers_allowance: Proportion of slots for random selection (0.0-1.0)
-        bondless_require_zero_fee: If True, bondless spots only select zero-fee offers
-        cj_amount: CoinJoin amount for fee filtering (unused currently)
+        offers: Eligible offers (already filtered and deduped).
+        n: Number of offers to choose.
+        bondless_makers_allowance: Per-slot probability of uniform-random
+            selection (0.0-1.0).
+        bondless_require_zero_fee: If True, pre-filter removes bondless
+            offers with non-zero absolute fee.
+        cj_amount: CoinJoin amount (reserved for future fee filtering).
 
     Returns:
-        Selected offers
+        Selected offers.
     """
     if len(offers) <= n:
         return offers[:]
 
-    # Log bonded offers for debugging
-    bonded_offers = [o for o in offers if o.fidelity_bond_value > 0]
-    logger.debug(
-        f"Found {len(bonded_offers)} offers with fidelity bond: "
-        f"{[o.counterparty for o in bonded_offers]}"
-    )
-
-    # Calculate split: prioritize bonded makers, fill remainder with random
-    # Use round() for fair rounding instead of floor
-    num_bonded = round(n * (1 - bondless_makers_allowance))
-    num_bondless = n - num_bonded
-
-    logger.debug(
-        f"Selection split: {num_bonded} bonded, {num_bondless} bondless "
-        f"(allowance={bondless_makers_allowance})"
-    )
+    # --- Pre-filter: remove bondless offers charging a fee ---
+    if bondless_require_zero_fee:
+        filtered: list[Offer] = []
+        removed = 0
+        for o in offers:
+            if o.fidelity_bond_value == 0 and _is_nonzero_absolute_fee(o):
+                removed += 1
+            else:
+                filtered.append(o)
+        if removed:
+            logger.debug(f"Pre-filter: removed {removed} bondless offers with non-zero fee")
+        if len(filtered) <= n:
+            return filtered[:]
+        remaining = filtered
+    else:
+        remaining = offers[:]
 
     selected: list[Offer] = []
-    remaining_offers = offers[:]  # Copy to modify
 
-    # 1. Select Bonded Makers (weighted by bond value)
-    if num_bonded > 0:
-        # Build pool of (offer, bond_value) pairs
-        pool = [(o, o.fidelity_bond_value) for o in remaining_offers]
-        # Remove zero-bond offers from bonded pool
-        bonded_pool = [(o, w) for o, w in pool if w > 0]
+    bonded_count = sum(1 for o in remaining if o.fidelity_bond_value > 0)
+    logger.debug(
+        f"Selection pool: {len(remaining)} offers ({bonded_count} bonded, "
+        f"{len(remaining) - bonded_count} bondless), picking {n} with "
+        f"bondless_allowance={bondless_makers_allowance}"
+    )
 
-        total_bond = sum(w for _, w in bonded_pool)
+    for _i in range(n):
+        if not remaining:
+            logger.warning(f"Exhausted offer pool after {len(selected)}/{n} picks")
+            break
 
-        if total_bond == 0 or len(bonded_pool) == 0:
-            logger.debug(
-                f"No fidelity bonds found for {num_bonded} bonded slots, "
-                "will fill from bondless pool"
-            )
-            # Don't increment num_bondless here, we'll handle shortage at the end
+        picked: Offer | None = None
+
+        if random.random() < bondless_makers_allowance:
+            # Bondless slot: pick uniformly from ALL remaining offers.
+            # Bonded and bondless compete on equal footing here, so a rare
+            # bondless maker has probability ~1/len(remaining).
+            picked = random.choice(remaining)
         else:
-            # Weighted selection without replacement
-            for _ in range(min(num_bonded, len(bonded_pool))):
-                if not bonded_pool:
-                    break
+            # Bonded slot: pick weighted by bond value
+            picked = _pick_weighted_bonded(remaining)
 
-                current_total = sum(w for _, w in bonded_pool)
-                r = random.uniform(0, current_total)
-                cumulative = 0
+        if picked is None:
+            # Bonded pool empty -- fall back to uniform random
+            picked = random.choice(remaining)
 
-                for i, (offer, weight) in enumerate(bonded_pool):
-                    cumulative += weight
-                    if r <= cumulative:
-                        selected.append(offer)
-                        remaining_offers.remove(offer)
-                        bonded_pool.pop(i)
-                        break
+        selected.append(picked)
+        remaining.remove(picked)
 
-    # 2. Fill remaining slots (bondless selection - uniform random from all remaining)
-    slots_remaining = n - len(selected)
-    if slots_remaining > 0:
-        if not remaining_offers:
-            logger.warning(
-                f"Not enough offers to fill {slots_remaining} remaining slots "
-                f"(selected {len(selected)}/{n})"
-            )
-            return selected
-
-        # For bondless slots: select uniformly from all remaining offers
-        # (both bonded and bondless makers have equal probability)
-        candidates = remaining_offers
-
-        # Optionally filter to zero-fee offers only
-        if bondless_require_zero_fee:
-            zero_fee_candidates = [
-                o
-                for o in candidates
-                if (
-                    o.ordertype in (OfferType.SW0_ABSOLUTE, OfferType.SWA_ABSOLUTE)
-                    and int(o.cjfee) == 0
-                )
-                or (
-                    o.ordertype not in (OfferType.SW0_ABSOLUTE, OfferType.SWA_ABSOLUTE)
-                    # For relative offers, we can't strictly say fee is 0 without amount,
-                    # but usually 'zero fee' implies 0 absolute.
-                    # The original logic included relative fee offers in the eligible list.
-                    # We'll stick to that.
-                )
-            ]
-
-            if len(zero_fee_candidates) >= slots_remaining:
-                candidates = zero_fee_candidates
-                logger.debug(
-                    f"Bondless slots: filtered to {len(candidates)} zero-fee offers "
-                    f"(bonded + bondless)"
-                )
-            else:
-                logger.warning(
-                    f"Not enough zero-fee offers for bondless selection "
-                    f"({len(zero_fee_candidates)} < {slots_remaining}), "
-                    "using all remaining offers"
-                )
-
-        # Uniform random selection for remaining slots
-        picked = random_order_choose(candidates, slots_remaining)
-        selected.extend(picked)
-
-    logger.debug(f"Final selection: {len(selected)} makers chosen")
+    logger.debug(
+        f"Final selection: {len(selected)} makers "
+        f"({sum(1 for o in selected if o.fidelity_bond_value > 0)} bonded, "
+        f"{sum(1 for o in selected if o.fidelity_bond_value == 0)} bondless)"
+    )
     return selected
+
+
+def _is_nonzero_absolute_fee(offer: Offer) -> bool:
+    """Check if an offer charges a non-zero absolute fee."""
+    return (
+        offer.ordertype in (OfferType.SW0_ABSOLUTE, OfferType.SWA_ABSOLUTE)
+        and int(offer.cjfee) != 0
+    )
+
+
+def _pick_weighted_bonded(pool: list[Offer]) -> Offer | None:
+    """Pick one offer from *pool* weighted by fidelity_bond_value."""
+    bonded = [(o, o.fidelity_bond_value) for o in pool if o.fidelity_bond_value > 0]
+    if not bonded:
+        return None
+    total = sum(w for _, w in bonded)
+    r = random.uniform(0, total)
+    cumulative = 0
+    for offer, weight in bonded:
+        cumulative += weight
+        if r <= cumulative:
+            return offer
+    return bonded[-1][0]  # float rounding guard
 
 
 def choose_orders(
@@ -508,7 +506,7 @@ def choose_orders(
     choose_fn: Callable[[list[Offer], int], list[Offer]] | None = None,
     ignored_makers: set[str] | None = None,
     min_nick_version: int | None = None,
-    bondless_makers_allowance: float = 0.125,
+    bondless_makers_allowance: float = 0.2,
     bondless_require_zero_fee: bool = True,
     required_features: set[str] | None = None,
 ) -> tuple[dict[str, Offer], int]:
@@ -589,7 +587,7 @@ def choose_sweep_orders(
     choose_fn: Callable[[list[Offer], int], list[Offer]] | None = None,
     ignored_makers: set[str] | None = None,
     min_nick_version: int | None = None,
-    bondless_makers_allowance: float = 0.125,
+    bondless_makers_allowance: float = 0.2,
     bondless_require_zero_fee: bool = True,
     required_features: set[str] | None = None,
 ) -> tuple[dict[str, Offer], int, int]:
@@ -718,7 +716,7 @@ class OrderbookManager:
     def __init__(
         self,
         max_cj_fee: MaxCjFee,
-        bondless_makers_allowance: float = 0.125,
+        bondless_makers_allowance: float = 0.2,
         bondless_require_zero_fee: bool = True,
         data_dir: Any = None,  # Path | None, but avoid import
         own_wallet_nicks: set[str] | None = None,

--- a/taker/tests/test_orderbook.py
+++ b/taker/tests/test_orderbook.py
@@ -742,10 +742,10 @@ class TestOrderbookManager:
 
 
 class TestMixedBondedBondlessSelection:
-    """Tests for the mixed bonded/bondless selection strategy."""
+    """Tests for the per-slot probabilistic bonded/bondless selection."""
 
-    def test_deterministic_split(self) -> None:
-        """Test that the split between bonded and bondless is deterministic."""
+    def test_always_fills_n_slots(self) -> None:
+        """Regardless of coin flips, we always fill exactly n slots."""
         offers = [
             Offer(
                 counterparty=f"Maker{i}",
@@ -760,12 +760,11 @@ class TestMixedBondedBondlessSelection:
             for i in range(10)
         ]
 
-        # With 3 makers and 0.125 allowance: bonded = floor(3 * 0.875) = 2
-        selected = fidelity_bond_weighted_choose(
-            offers=offers, n=3, bondless_makers_allowance=0.125, bondless_require_zero_fee=False
-        )
-
-        assert len(selected) == 3
+        for _ in range(20):
+            selected = fidelity_bond_weighted_choose(
+                offers=offers, n=3, bondless_makers_allowance=0.2, bondless_require_zero_fee=False
+            )
+            assert len(selected) == 3
 
     def test_fills_all_slots(self) -> None:
         """Ensure we always fill all n slots when enough offers exist."""
@@ -835,8 +834,7 @@ class TestMixedBondedBondlessSelection:
         offers = [high_bond] + low_bonds
 
         # Run 100 times, high bond should be selected almost always
-        # With allowance=0.2, bonded slots = floor(3 * 0.8) = 2
-        # HighBond should win at least one of these slots nearly every time
+        # Each slot has 80% chance of being bonded, and HighBond dominates
         high_bond_count = 0
         for _ in range(100):
             selected = fidelity_bond_weighted_choose(
@@ -848,8 +846,8 @@ class TestMixedBondedBondlessSelection:
         # Should be selected in >90% of runs
         assert high_bond_count > 90
 
-    def test_bondless_fills_remaining_with_zero_fee(self) -> None:
-        """Bondless slots should fill from zero-fee offers when required."""
+    def test_bondless_zero_fee_filter(self) -> None:
+        """Non-zero-fee bondless offers are pre-filtered out entirely."""
         bonded = [
             Offer(
                 counterparty=f"Bonded{i}",
@@ -861,10 +859,10 @@ class TestMixedBondedBondlessSelection:
                 cjfee=0,
                 fidelity_bond_value=100000,
             )
-            for i in range(2)
+            for i in range(5)
         ]
 
-        # Zero fee bondless
+        # Zero fee bondless -- should survive pre-filter
         zero_fee = [
             Offer(
                 counterparty=f"ZeroFee{i}",
@@ -873,13 +871,13 @@ class TestMixedBondedBondlessSelection:
                 minsize=1000,
                 maxsize=1000000,
                 txfee=0,
-                cjfee=0,  # Zero fee
+                cjfee=0,
                 fidelity_bond_value=0,
             )
             for i in range(3)
         ]
 
-        # Non-zero fee bondless (should be excluded from bondless slots)
+        # Non-zero fee bondless -- should be pre-filtered out
         nonzero_fee = [
             Offer(
                 counterparty=f"NonZeroFee{i}",
@@ -888,7 +886,7 @@ class TestMixedBondedBondlessSelection:
                 minsize=1000,
                 maxsize=1000000,
                 txfee=0,
-                cjfee=100,  # Non-zero fee
+                cjfee=100,
                 fidelity_bond_value=0,
             )
             for i in range(3)
@@ -896,26 +894,18 @@ class TestMixedBondedBondlessSelection:
 
         offers = bonded + zero_fee + nonzero_fee
 
-        # With n=3, allowance=0.4: bonded=floor(3*0.6)=1, bondless=2
-        # Should pick 1 bonded + 2 from zero_fee (not nonzero_fee)
-        for _ in range(10):
+        # NonZeroFee makers should never appear (pre-filtered)
+        for _ in range(20):
             selected = fidelity_bond_weighted_choose(
-                offers=offers, n=3, bondless_makers_allowance=0.4, bondless_require_zero_fee=True
+                offers=offers, n=3, bondless_makers_allowance=0.5, bondless_require_zero_fee=True
             )
             assert len(selected) == 3
-
-            # Check that nonzero_fee makers are not in bondless slots
-            # (Note: they could be in bonded slots since they have bond=0,
-            # but bonded prioritizes bond>0)
             selected_nicks = {o.counterparty for o in selected}
             nonzero_nicks = {o.counterparty for o in nonzero_fee}
-
-            # Since bonded slots pick from bond>0 only, and bondless require zero fee,
-            # nonzero_fee makers should not appear
             assert len(selected_nicks & nonzero_nicks) == 0
 
-    def test_insufficient_bonded_fills_from_bondless(self) -> None:
-        """If not enough bonded offers, fill remainder from bondless pool."""
+    def test_insufficient_bonded_fills_from_all(self) -> None:
+        """If not enough bonded offers, fill remainder from all remaining."""
         # Only 1 bonded maker
         bonded = Offer(
             counterparty="OnlyBonded",
@@ -945,15 +935,160 @@ class TestMixedBondedBondlessSelection:
 
         offers = [bonded] + bondless
 
-        # With n=4, allowance=0.25: bonded=floor(4*0.75)=3, bondless=1
-        # But we only have 1 bonded offer, so remaining 3 slots filled from bondless
-        selected = fidelity_bond_weighted_choose(
-            offers=offers, n=4, bondless_makers_allowance=0.25, bondless_require_zero_fee=False
+        # With low bondless allowance, the bonded maker should be selected
+        # most of the time (80% of slots try bonded first)
+        bonded_count = 0
+        for _ in range(100):
+            selected = fidelity_bond_weighted_choose(
+                offers=offers, n=4, bondless_makers_allowance=0.2, bondless_require_zero_fee=False
+            )
+            assert len(selected) == 4
+            if bonded in selected:
+                bonded_count += 1
+
+        # Bonded maker should be selected in most runs
+        assert bonded_count > 70
+
+    def test_per_slot_coin_flip_varies_bondless_count(self) -> None:
+        """The number of bondless picks should vary across runs (not deterministic)."""
+        bonded = [
+            Offer(
+                counterparty=f"Bonded{i}",
+                oid=0,
+                ordertype=OfferType.SW0_ABSOLUTE,
+                minsize=1000,
+                maxsize=1000000,
+                txfee=0,
+                cjfee=0,
+                fidelity_bond_value=100000,
+            )
+            for i in range(20)
+        ]
+
+        bondless = [
+            Offer(
+                counterparty=f"Bondless{i}",
+                oid=0,
+                ordertype=OfferType.SW0_ABSOLUTE,
+                minsize=1000,
+                maxsize=1000000,
+                txfee=0,
+                cjfee=0,
+                fidelity_bond_value=0,
+            )
+            for i in range(20)
+        ]
+
+        offers = bonded + bondless
+
+        bondless_counts: set[int] = set()
+        for _ in range(100):
+            selected = fidelity_bond_weighted_choose(
+                offers=offers,
+                n=10,
+                bondless_makers_allowance=0.3,
+                bondless_require_zero_fee=False,
+            )
+            assert len(selected) == 10
+            num_bondless = sum(1 for o in selected if o.fidelity_bond_value == 0)
+            bondless_counts.add(num_bondless)
+
+        # With per-slot coin flip (p=0.3), we should see varying counts
+        assert len(bondless_counts) >= 3
+
+    def test_zero_allowance_selects_only_bonded(self) -> None:
+        """With allowance=0, all slots should use bonded weighted selection."""
+        bonded = [
+            Offer(
+                counterparty=f"Bonded{i}",
+                oid=0,
+                ordertype=OfferType.SW0_ABSOLUTE,
+                minsize=1000,
+                maxsize=1000000,
+                txfee=0,
+                cjfee=0,
+                fidelity_bond_value=100000,
+            )
+            for i in range(10)
+        ]
+
+        bondless = [
+            Offer(
+                counterparty=f"Bondless{i}",
+                oid=0,
+                ordertype=OfferType.SW0_ABSOLUTE,
+                minsize=1000,
+                maxsize=1000000,
+                txfee=0,
+                cjfee=0,
+                fidelity_bond_value=0,
+            )
+            for i in range(10)
+        ]
+
+        offers = bonded + bondless
+
+        for _ in range(20):
+            selected = fidelity_bond_weighted_choose(
+                offers=offers, n=5, bondless_makers_allowance=0.0, bondless_require_zero_fee=False
+            )
+            assert len(selected) == 5
+            # All should be bonded
+            assert all(o.fidelity_bond_value > 0 for o in selected)
+
+    def test_bondless_slot_picks_uniformly_from_all(self) -> None:
+        """Bondless (uniform) slots pick from ALL offers, not just bondless."""
+        # 50 bonded + 1 bondless. With high allowance, the bondless maker
+        # should appear rarely because they compete with 50 others uniformly.
+        bonded = [
+            Offer(
+                counterparty=f"Bonded{i}",
+                oid=0,
+                ordertype=OfferType.SW0_ABSOLUTE,
+                minsize=1000,
+                maxsize=1000000,
+                txfee=0,
+                cjfee=0,
+                fidelity_bond_value=100000,
+            )
+            for i in range(50)
+        ]
+
+        bondless_maker = Offer(
+            counterparty="RareBondless",
+            oid=0,
+            ordertype=OfferType.SW0_ABSOLUTE,
+            minsize=1000,
+            maxsize=1000000,
+            txfee=0,
+            cjfee=0,
+            fidelity_bond_value=0,
         )
 
-        assert len(selected) == 4
-        # OnlyBonded should always be selected (in bonded phase)
-        assert bonded in selected
+        offers = bonded + [bondless_maker]
+
+        # Run many times: bondless maker should appear infrequently
+        appearances = 0
+        runs = 500
+        for _ in range(runs):
+            selected = fidelity_bond_weighted_choose(
+                offers=offers,
+                n=10,
+                bondless_makers_allowance=0.2,
+                bondless_require_zero_fee=False,
+            )
+            if bondless_maker in selected:
+                appearances += 1
+
+        # With 51 offers, P(per uniform slot) = 1/51 ≈ 0.02
+        # Expected uniform slots per run = 10 * 0.2 = 2
+        # P(picked in run) ≈ 1 - (1 - 1/51)^2 ≈ 0.039
+        # So appearances should be roughly 2-6% of runs
+        # Allow generous bounds for statistical test
+        assert appearances < runs * 0.15, (
+            f"Bondless maker appeared {appearances}/{runs} times "
+            f"({appearances / runs:.1%}), expected <15%"
+        )
 
 
 class TestFilterOffersByNickVersion:


### PR DESCRIPTION
Replace the deterministic bonded/bondless slot split with a per-slot coin flip approach (matching the reference JoinMarket implementation). Each slot independently decides with probability
bondless_makers_allowance whether to pick from the zero-fee pool or the bond-weighted pool. This ensures that when few bondless makers exist, they are picked with proportionally low probability, avoiding taker fingerprinting.

Change the default bondless_makers_allowance from 0.0 to 0.2 so that on average 2 out of 10 counterparties are selected from bondless zero-fee offers when enough are available on the orderbook.

Changelog: Enable per-slot probabilistic bondless maker selection with 20% default allowance