### PR TITLE
fix(taker): consider taker.fee_rate from config.toml

### DIFF
--- a/jmcore/src/jmcore/settings.py
+++ b/jmcore/src/jmcore/settings.py
@@ -647,11 +647,16 @@ class TakerSettings(BaseModel):
         ge=1.0,
         description="Multiply estimated fee by this factor",
     )
+    fee_rate: float | None = Field(
+        default=None,
+        gt=0.0,
+        description="Manual fee rate in sat/vB (mutually exclusive with fee_block_target)",
+    )
     fee_block_target: int | None = Field(
         default=None,
         ge=1,
         le=1008,
-        description="Target blocks for fee estimation",
+        description="Target blocks for fee estimation (mutually exclusive with fee_rate)",
     )
     bondless_makers_allowance: float = Field(
         default=0.2,

--- a/jmcore/tests/test_settings.py
+++ b/jmcore/tests/test_settings.py
@@ -306,6 +306,20 @@ neutrino_scan_lookback_blocks = 75000
         assert settings.bitcoin.neutrino_prefetch_lookback_blocks == 50000
         assert settings.bitcoin.neutrino_scan_lookback_blocks == 75000
 
+    def test_toml_taker_fee_rate_setting(
+        self, temp_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that taker.fee_rate is loaded from TOML config."""
+        config_path = temp_data_dir / "config.toml"
+        config_path.write_text("""
+[taker]
+fee_rate = 1.1
+""")
+
+        settings = JoinMarketSettings()
+
+        assert settings.taker.fee_rate == 1.1
+
     def test_env_overrides_toml(self, temp_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that environment variables override TOML config."""
         config_path = temp_data_dir / "config.toml"

--- a/taker/src/taker/cli.py
+++ b/taker/src/taker/cli.py
@@ -151,18 +151,21 @@ def build_taker_config(
     effective_max_rel_fee = (
         max_rel_fee if max_rel_fee is not None else settings.taker.max_cj_fee_rel
     )
-    # Only set fee_block_target when fee_rate is not provided (they are mutually exclusive)
-    effective_fee_rate = fee_rate if fee_rate is not None else settings.taker.fee_rate
+    # Resolve fee settings together so CLI overrides can switch modes cleanly:
+    # CLI fee_rate > CLI block_target > config fee_rate > config/default block_target.
+    effective_fee_rate: float | None = None
     effective_block_target: int | None = None
-    if effective_fee_rate is None:
+    if fee_rate is not None:
+        effective_fee_rate = fee_rate
+    elif block_target is not None:
+        effective_block_target = block_target
+    elif settings.taker.fee_rate is not None:
+        effective_fee_rate = settings.taker.fee_rate
+    else:
         effective_block_target = (
-            block_target
-            if block_target is not None
-            else (
-                settings.taker.fee_block_target
-                if settings.taker.fee_block_target is not None
-                else settings.wallet.default_fee_block_target
-            )
+            settings.taker.fee_block_target
+            if settings.taker.fee_block_target is not None
+            else settings.wallet.default_fee_block_target
         )
     effective_bondless = (
         bondless_makers_allowance

--- a/taker/src/taker/cli.py
+++ b/taker/src/taker/cli.py
@@ -152,8 +152,9 @@ def build_taker_config(
         max_rel_fee if max_rel_fee is not None else settings.taker.max_cj_fee_rel
     )
     # Only set fee_block_target when fee_rate is not provided (they are mutually exclusive)
+    effective_fee_rate = fee_rate if fee_rate is not None else settings.taker.fee_rate
     effective_block_target: int | None = None
-    if fee_rate is None:
+    if effective_fee_rate is None:
         effective_block_target = (
             block_target
             if block_target is not None
@@ -213,7 +214,7 @@ def build_taker_config(
         counterparty_count=effective_counterparties,
         max_cj_fee=MaxCjFee(abs_fee=effective_max_abs_fee, rel_fee=effective_max_rel_fee),
         tx_fee_factor=settings.taker.tx_fee_factor,
-        fee_rate=fee_rate,  # CLI only, no settings equivalent
+        fee_rate=effective_fee_rate,
         fee_block_target=effective_block_target,
         bondless_makers_allowance=effective_bondless,
         bond_value_exponent=effective_bond_exp,

--- a/taker/tests/test_cli.py
+++ b/taker/tests/test_cli.py
@@ -180,6 +180,25 @@ class TestBuildTakerConfig:
         assert config.fee_rate == 7.5
         assert config.fee_block_target is None
 
+    def test_cli_block_target_overrides_taker_fee_rate_setting(
+        self, sample_mnemonic: str, mock_settings: MagicMock
+    ) -> None:
+        """CLI --block-target must override taker.fee_rate from settings."""
+        mock_settings.taker.fee_rate = 1.1
+
+        config = build_taker_config(
+            settings=mock_settings,
+            mnemonic=sample_mnemonic,
+            passphrase="",
+            destination="bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            amount=100000,
+            mixdepth=0,
+            block_target=8,
+        )
+
+        assert config.fee_rate is None
+        assert config.fee_block_target == 8
+
     def test_taker_fee_block_target_setting_overrides_wallet_default(
         self, sample_mnemonic: str, mock_settings: MagicMock
     ) -> None:

--- a/taker/tests/test_cli.py
+++ b/taker/tests/test_cli.py
@@ -59,6 +59,7 @@ class TestBuildTakerConfig:
         settings.taker.counterparty_count = 4
         settings.taker.max_cj_fee_abs = 1000
         settings.taker.max_cj_fee_rel = "0.002"
+        settings.taker.fee_rate = None  # Not set in config
         settings.taker.fee_block_target = None  # Not set in config
         settings.taker.bondless_makers_allowance = 0.1
         settings.taker.bond_value_exponent = 1.3
@@ -139,6 +140,45 @@ class TestBuildTakerConfig:
 
         assert config.fee_rate is None
         assert config.fee_block_target == 6
+
+    def test_taker_fee_rate_setting_honored_without_cli_flag(
+        self, sample_mnemonic: str, mock_settings: MagicMock
+    ) -> None:
+        """Regression: taker.fee_rate from config.toml must be honored when no CLI
+        flag is passed, and must suppress the fee_block_target fallback."""
+        mock_settings.taker.fee_rate = 1.1  # Set in config.toml
+        mock_settings.taker.fee_block_target = None
+
+        config = build_taker_config(
+            settings=mock_settings,
+            mnemonic=sample_mnemonic,
+            passphrase="",
+            destination="bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            amount=100000,
+            mixdepth=0,
+        )
+
+        assert config.fee_rate == 1.1
+        assert config.fee_block_target is None
+
+    def test_cli_fee_rate_overrides_taker_fee_rate_setting(
+        self, sample_mnemonic: str, mock_settings: MagicMock
+    ) -> None:
+        """CLI --fee-rate must take precedence over taker.fee_rate from settings."""
+        mock_settings.taker.fee_rate = 1.1
+
+        config = build_taker_config(
+            settings=mock_settings,
+            mnemonic=sample_mnemonic,
+            passphrase="",
+            destination="bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            amount=100000,
+            mixdepth=0,
+            fee_rate=7.5,
+        )
+
+        assert config.fee_rate == 7.5
+        assert config.fee_block_target is None
 
     def test_taker_fee_block_target_setting_overrides_wallet_default(
         self, sample_mnemonic: str, mock_settings: MagicMock


### PR DESCRIPTION
TakerSettings never declared fee_rate, so the key documented in config.toml.template was silently dropped by the extra="ignore" loader and build_taker_config only ever read it from the --fee-rate CLI flag. Setting fee_rate in config.toml fell through to the fee_block_target estimate and overwrote the manual rate.