### PR TITLE
fix(taker): align tx fee factor with JoinMarket default

### DIFF
--- a/config.toml.template
+++ b/config.toml.template
@@ -334,7 +334,7 @@
 # Network/miner transaction fee settings
 # fee_rate takes precedence over fee_block_target when set
 # fee_rate = 10.0             # Manual fee rate in sat/vB (omit to use estimation)
-# tx_fee_factor = 3.0         # Fee estimation multiplier (minimum: 1.0)
+# tx_fee_factor = 0.2         # Fee randomization factor (0 disables; 0.2 = up to +20%)
 # fee_block_target = 6        # Target blocks for fee estimation (1-1008, omit to use default)
 
 # Fidelity bond settings

--- a/docs/README-taker.md
+++ b/docs/README-taker.md
@@ -68,6 +68,10 @@ Configuration merges as: `config.toml` < environment variables < CLI flags.
 
 Backend setup and defaults: [Installation](install.md#configure-backend).
 
+`taker.tx_fee_factor` controls additive fee randomization, not a direct multiplier. A value
+of `0.2` picks a session fee rate between the base rate and `base_rate * 1.2`; `0` disables
+randomization.
+
 For all option details, use auto-generated command help below (`jm-taker coinjoin --help`, `jm-taker tumble --help`).
 
 ## Docker Deployment

--- a/jmcore/src/jmcore/data/config.toml.template
+++ b/jmcore/src/jmcore/data/config.toml.template
@@ -328,7 +328,7 @@
 # Network/miner transaction fee settings
 # fee_rate takes precedence over fee_block_target when set
 # fee_rate = 10.0             # Manual fee rate in sat/vB (omit to use estimation)
-# tx_fee_factor = 3.0         # Fee estimation multiplier (minimum: 1.0)
+# tx_fee_factor = 0.2         # Fee randomization factor (0 disables; 0.2 = up to +20%)
 # fee_block_target = 6        # Target blocks for fee estimation (1-1008, omit to use default)
 
 # Fidelity bond settings

--- a/jmcore/src/jmcore/settings.py
+++ b/jmcore/src/jmcore/settings.py
@@ -643,9 +643,12 @@ class TakerSettings(BaseModel):
         return v
 
     tx_fee_factor: float = Field(
-        default=3.0,
-        ge=1.0,
-        description="Multiply estimated fee by this factor",
+        default=0.2,
+        ge=0.0,
+        description=(
+            "Fee randomization factor. 0 disables randomization; "
+            "0.2 randomizes up to 20% above the base rate."
+        ),
     )
     fee_rate: float | None = Field(
         default=None,


### PR DESCRIPTION
The taker.tx_fee_factor setting was documented as a fee estimation multiplier with a default of 3.0, but the implementation treats it as an additive randomization factor: base_rate * (1 + tx_fee_factor).

That made the default randomize between the base fee rate and 4x the base fee rate, which was wider and less intuitive than the setting description suggested.

Use JoinMarket's original 0.2 default instead, giving users fee randomization between 1x and 1.2x of the base rate. Also allow 0.0 to disable randomization and clarify the config/docs wording so users see this as a randomization factor rather than a direct multiplier.

The initial default value could, in my view, create several negative situations for the end user. A ×4 fee rate randomization might produce excessively high fees in coinjoins, causing users to overpay, potentially by hundreds of dollars. Also, for numbers > 1 the function is also very counter intuitive for the user, and a possibility could be also to limit the max value to 1.0 .

Changelog: Restore JoinMarket-style 0.2 taker fee randomization default and clarify tx_fee_factor documentation