### PR TITLE
docs: add Specter DIY details for fidelity bond spend signing

### DIFF
--- a/docs/technical/privacy.md
+++ b/docs/technical/privacy.md
@@ -148,9 +148,9 @@ Allows cold storage of bond private key while hot wallet handles per-session pro
 
 > **IMPORTANT -- HARDWARE WALLET LIMITATIONS:**
 >
-> Most hardware wallets **cannot sign** fidelity bond spending transactions. Bond UTXOs are P2WSH outputs with CLTV timelock witness scripts, and most firmware rejects custom witness scripts. **Only Ledger Nano S/X and Blockstream Jade** support this (see [HWI support matrix](https://hwi.readthedocs.io/en/latest/devices/index.html#support-matrix)). Trezor (all models), Coldcard, BitBox02, and KeepKey **cannot** sign bond redemptions ([Trezor firmware issue #416](https://github.com/trezor/trezor-firmware/issues/416), open since 2019).
+> Most hardware wallets **cannot sign** fidelity bond spending transactions. Bond UTXOs are P2WSH outputs with CLTV timelock witness scripts, and most firmware rejects custom witness scripts. **Ledger Nano S/X and Blockstream Jade** support this through HWI (see [HWI support matrix](https://hwi.readthedocs.io/en/latest/devices/index.html#support-matrix)). **Specter DIY** also provides a hardware-wallet signing path by scanning the PSBT as a QR code and returning a signed PSBT. This Specter DIY flow is QR-based and does not rely on upstream HWI support. Trezor (all models), Coldcard, BitBox02, and KeepKey **cannot** sign bond redemptions ([Trezor firmware issue #416](https://github.com/trezor/trezor-firmware/issues/416), open since 2019).
 >
-> If your hardware wallet cannot sign CLTV scripts, you will need to enter your BIP39 mnemonic into the `sign_bond_mnemonic.py` script to spend the bond. This does not mean funds are lost -- it is an inconvenience that degrades security from "hardware wallet cold storage" to "software signing on a (potentially offline) computer". **Plan ahead**: use a CLTV compatible hardware wallet for full cold storage, or create a dedicated mnemonic/passphrase specifically for the bond so that mnemonic exposure does not risk your main wallet.
+> If your hardware wallet cannot sign CLTV scripts through either HWI or a device-native QR PSBT flow, you will need to enter your BIP39 mnemonic into the `sign_bond_mnemonic.py` script to spend the bond. This does not mean funds are lost -- it is an inconvenience that degrades security from "hardware wallet cold storage" to "software signing on a (potentially offline) computer". **Plan ahead**: use a CLTV compatible hardware wallet for full cold storage, or create a dedicated mnemonic/passphrase specifically for the bond so that mnemonic exposure does not risk your main wallet.
 >
 > **Before locking real funds**, complete the full workflow end-to-end including a test spend (without broadcasting) to confirm your tooling works. See "Test the full flow" below.
 
@@ -222,15 +222,19 @@ For maximum security, keep the bond UTXO private key on a hardware wallet. The b
      --fee-rate 1.0 \
      --test-unfunded \
      --master-fingerprint <fingerprint_from_step_1> \
-     --derivation-path "<path_from_step_1>"
+     --derivation-path "<path_from_step_1>" \
+     --output unsigned-bond-test.psbt
    ```
    Then verify you can sign it:
    ```bash
    # Ledger/Jade users -- test HWI signing:
-   python scripts/sign_bond_psbt.py <psbt_base64>
+   python scripts/sign_bond_psbt.py "$(tr -d '\n' < unsigned-bond-test.psbt)"
+
+   # Specter DIY users -- test QR PSBT signing:
+   qrencode -t ANSIUTF8 "$(tr -d '\n' < unsigned-bond-test.psbt)"
 
    # All other devices -- test mnemonic signing:
-   python scripts/sign_bond_mnemonic.py <psbt_base64>
+   python scripts/sign_bond_mnemonic.py "$(tr -d '\n' < unsigned-bond-test.psbt)"
    ```
    **Do not broadcast** the test transaction -- just confirm that signing succeeds and produces valid output. Use `bitcoin-cli decoderawtransaction <signed_hex>` to inspect. `--test-unfunded` uses a synthetic input so you can validate derivation path, signer compatibility, and the full signing toolchain **before funding**.
 
@@ -243,7 +247,7 @@ For maximum security, keep the bond UTXO private key on a hardware wallet. The b
 
 **Security benefits:**
 - Bond UTXO private key NEVER leaves the hardware wallet (with CLTV compatible devices)
-- No mnemonic exposure to online systems (when using HWI signing on an offline machine)
+- No mnemonic exposure to online systems (when using HWI or QR signing on an offline machine)
 - Certificate expires after configurable period (~2 years default)
 - If hot wallet is compromised, attacker can only impersonate bond until expiry
 - Bond funds remain safe in cold storage
@@ -263,7 +267,7 @@ When your certificate expires, repeat steps 4-6 with a new message. The bond fun
 
 **Spending Bonds:**
 
-> **Tested:** Bond creation verified with Sparrow Wallet and a hardware wallet (HWI >= 3.1.0). Bond redemption verified with `sign_bond_mnemonic.py`. Trezor cannot sign the redemption transaction due to the CLTV firmware limitation.
+> **Tested:** Bond creation verified with Sparrow Wallet and a hardware wallet (HWI >= 3.1.0). Bond redemption verified with `sign_bond_mnemonic.py`. Specter DIY can sign through the QR PSBT workflow; this guide does not claim or require Specter DIY support in upstream HWI. Trezor cannot sign the redemption transaction due to the CLTV firmware limitation.
 
 After locktime expires, generate a PSBT for external signing:
 
@@ -286,6 +290,7 @@ For pre-funding dry-run signer tests, add `--test-unfunded` (optionally `--test-
 |--------|:--------------------:|-------|
 | Ledger Nano S/X | Yes | Bitcoin App 2.1+ requires standard BIP44/49/84/86 derivation for the key |
 | Blockstream Jade | Yes | Fully supported |
+| Specter DIY | Yes | QR PSBT workflow; upstream HWI support is not required or claimed |
 | BitBox01 | Yes | Discontinued; not recommended for new setups |
 | Trezor (all models) | **No** | Firmware rejects non-multisig P2WSH; [issue #416](https://github.com/trezor/trezor-firmware/issues/416) open since 2019 |
 | Coldcard | **No** | Firmware only supports single-key and multisig |
@@ -303,9 +308,29 @@ python scripts/sign_bond_psbt.py <psbt_base64>
 
 Connect and unlock your device first. Close Sparrow or other wallet software that holds the USB connection. The script enumerates devices, signs, and outputs the transaction hex. If your wallet uses a BIP39 passphrase, add `--passphrase` to the script invocation.
 
-**Option B -- Mnemonic signing (works with any device):**
+**Option B -- Specter DIY QR signing:**
 
-For Trezor, Coldcard, BitBox02, KeepKey, or if HWI signing fails:
+Specter DIY can sign the bond PSBT by QR code exchange. Save the PSBT when generating the spend:
+
+```bash
+jm-wallet spend-bond <bond_address> <destination_address> \
+  --fee-rate 1.0 \
+  --master-fingerprint <4_byte_hex> \
+  --derivation-path "m/84'/0'/0'/0/0" \
+  --output unsigned-bond.psbt
+```
+
+Render the unsigned PSBT as a QR code:
+
+```bash
+qrencode -t ANSIUTF8 "$(tr -d '\n' < unsigned-bond.psbt)"
+```
+
+Scan the QR on Specter DIY, inspect the transaction details, and sign it. Then scan the signed PSBT output back to the online machine, for example with Sparrow's File -> Open transaction -> from QR flow, and finalize or extract the signed transaction hex there.
+
+**Option C -- Mnemonic signing (works with any device):**
+
+For Trezor, Coldcard, BitBox02, KeepKey, or if HWI/QR signing fails:
 
 ```bash
 python scripts/sign_bond_mnemonic.py <psbt_base64>

--- a/docs/technical/privacy.md
+++ b/docs/technical/privacy.md
@@ -326,7 +326,20 @@ Render the unsigned PSBT as a QR code:
 qrencode -t ANSIUTF8 "$(tr -d '\n' < unsigned-bond.psbt)"
 ```
 
-Scan the QR on Specter DIY, inspect the transaction details, and sign it. Then scan the signed PSBT output back to the online machine, for example with Sparrow's File -> Open transaction -> from QR flow, and finalize or extract the signed transaction hex there.
+Scan the QR on Specter DIY, inspect the transaction details, and sign it. Then scan or copy the signed PSBT output back to the online machine and save it as `signed-bond.psbt`.
+
+Bitcoin Core's `finalizepsbt` may not finalize this custom CLTV P2WSH witness script even when the PSBT contains a valid partial signature. Use the bond finalizer script to build the final witness transaction:
+
+```bash
+python scripts/finalize_bond_psbt.py --file signed-bond.psbt
+```
+
+The script outputs the final raw transaction hex. Inspect it before broadcasting:
+
+```bash
+bitcoin-cli decoderawtransaction <signed_hex>
+bitcoin-cli sendrawtransaction <signed_hex>
+```
 
 **Option C -- Mnemonic signing (works with any device):**
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,6 +32,8 @@ These scripts support the cold storage fidelity bond workflow. See [`docs/techni
 
 - **sign_bond_psbt.py** - Sign a fidelity bond spending PSBT using a hardware wallet (via HWI). Supports Ledger and Jade; Trezor/Coldcard/BitBox02/KeepKey cannot sign CLTV scripts.
 
+- **finalize_bond_psbt.py** - Finalize a signed fidelity bond spending PSBT, such as one returned by Specter DIY's QR signing flow. Builds the final CLTV P2WSH witness transaction when Bitcoin Core's `finalizepsbt` cannot finalize the custom witness script.
+
 - **sign_bond_mnemonic.py** - Sign a fidelity bond spending PSBT using a BIP39 mnemonic. Use when hardware wallet signing is not available. Reads the mnemonic interactively (hidden input) and outputs a fully signed raw transaction.
 
 - **sign_bond_cert_reference.py** - Sign a fidelity bond certificate using a BIP39 mnemonic (for migration from the reference implementation). Derives the private key at `m/84'/0'/0'/2/<timenumber>` and signs the certificate in Electrum recoverable format accepted by `jm-wallet import-certificate`. Use this instead of `wallet-tool.py signmessage`, which has a bug preventing it from signing with fidelity bond paths.

--- a/scripts/finalize_bond_psbt.py
+++ b/scripts/finalize_bond_psbt.py
@@ -238,7 +238,9 @@ def parse_signed_bond_psbt(psbt_b64: str) -> dict[str, bytes]:
         elif key_type == 0x02:  # PSBT_IN_PARTIAL_SIG
             pubkey = key[1:]
             if len(pubkey) != 33:
-                raise ValueError("Partial signature key does not contain a compressed pubkey")
+                raise ValueError(
+                    "Partial signature key does not contain a compressed pubkey"
+                )
             partial_sig_pubkeys.append(pubkey)
             partial_sigs.append(value)
         elif key_type == 0x05:  # PSBT_IN_WITNESS_SCRIPT
@@ -260,7 +262,9 @@ def parse_signed_bond_psbt(psbt_b64: str) -> dict[str, bytes]:
 
     signature = partial_sigs[0]
     if partial_sig_pubkeys[0] != script_pubkey:
-        raise ValueError("Partial signature pubkey does not match witness_script pubkey")
+        raise ValueError(
+            "Partial signature pubkey does not match witness_script pubkey"
+        )
     if not signature or signature[-1] != 0x01:
         raise ValueError("Partial signature is missing SIGHASH_ALL byte")
 
@@ -289,7 +293,9 @@ def finalize_bond_psbt(psbt_b64: str) -> str:
     # PSBT unsigned txs are non-witness serializations. For the single-input
     # bond spend, insert marker/flag after nVersion and one witness stack before
     # nLockTime.
-    signed_tx = unsigned_tx[:4] + b"\x00\x01" + unsigned_tx[4:-4] + witness + unsigned_tx[-4:]
+    signed_tx = (
+        unsigned_tx[:4] + b"\x00\x01" + unsigned_tx[4:-4] + witness + unsigned_tx[-4:]
+    )
     return signed_tx.hex()
 
 

--- a/scripts/finalize_bond_psbt.py
+++ b/scripts/finalize_bond_psbt.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Finalize a signed fidelity bond spending PSBT.
+
+This script is for hardware-wallet flows where the device returns a signed
+PSBT containing a partial signature, but Bitcoin Core's ``finalizepsbt`` does
+not finalize the custom CLTV P2WSH witness script.
+
+It builds the final witness stack for the single-input, single-output bond
+sweep:
+
+    [signature, witness_script]
+
+and outputs the final raw transaction hex ready for inspection and broadcast.
+
+Usage:
+  python scripts/finalize_bond_psbt.py <signed_psbt_base64>
+  python scripts/finalize_bond_psbt.py --file signed-bond.psbt
+
+Broadcast:
+  bitcoin-cli testmempoolaccept '["<signed_tx_hex>"]'
+  bitcoin-cli sendrawtransaction "<signed_tx_hex>"
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import struct
+import sys
+from pathlib import Path
+
+
+def _read_varint(data: bytes, pos: int) -> tuple[int, int]:
+    """Read a Bitcoin compact size integer."""
+    if pos >= len(data):
+        raise ValueError("Unexpected end of data while reading compact size")
+
+    first = data[pos]
+    if first < 0xFD:
+        return first, pos + 1
+    if first == 0xFD:
+        if pos + 3 > len(data):
+            raise ValueError("Truncated compact size uint16")
+        return struct.unpack("<H", data[pos + 1 : pos + 3])[0], pos + 3
+    if first == 0xFE:
+        if pos + 5 > len(data):
+            raise ValueError("Truncated compact size uint32")
+        return struct.unpack("<I", data[pos + 1 : pos + 5])[0], pos + 5
+    if pos + 9 > len(data):
+        raise ValueError("Truncated compact size uint64")
+    return struct.unpack("<Q", data[pos + 1 : pos + 9])[0], pos + 9
+
+
+def _encode_varint(n: int) -> bytes:
+    """Encode a Bitcoin compact size integer."""
+    if n < 0xFD:
+        return bytes([n])
+    if n <= 0xFFFF:
+        return b"\xfd" + struct.pack("<H", n)
+    if n <= 0xFFFFFFFF:
+        return b"\xfe" + struct.pack("<I", n)
+    return b"\xff" + struct.pack("<Q", n)
+
+
+def _read_psbt_pair(data: bytes, pos: int) -> tuple[bytes | None, bytes | None, int]:
+    """Read one PSBT key-value pair. Empty key means map separator."""
+    key_len, pos = _read_varint(data, pos)
+    if key_len == 0:
+        return None, None, pos
+    if pos + key_len > len(data):
+        raise ValueError("Truncated PSBT key")
+
+    key = data[pos : pos + key_len]
+    pos += key_len
+
+    value_len, pos = _read_varint(data, pos)
+    if pos + value_len > len(data):
+        raise ValueError("Truncated PSBT value")
+    value = data[pos : pos + value_len]
+    pos += value_len
+
+    return key, value, pos
+
+
+def _parse_unsigned_tx(unsigned_tx: bytes) -> None:
+    """Validate the unsigned transaction shape supported by this finalizer."""
+    if len(unsigned_tx) < 10:
+        raise ValueError("Unsigned transaction is too short")
+
+    pos = 4
+    if unsigned_tx[pos] == 0x00 and unsigned_tx[pos + 1] != 0x00:
+        raise ValueError("PSBT unsigned transaction unexpectedly contains witness data")
+
+    input_count, pos = _read_varint(unsigned_tx, pos)
+    if input_count != 1:
+        raise ValueError(f"Expected exactly 1 input, got {input_count}")
+
+    if pos + 36 > len(unsigned_tx):
+        raise ValueError("Unsigned transaction input outpoint is truncated")
+    pos += 36
+
+    script_len, pos = _read_varint(unsigned_tx, pos)
+    if pos + script_len + 4 > len(unsigned_tx):
+        raise ValueError("Unsigned transaction input script or sequence is truncated")
+    pos += script_len + 4
+
+    output_count, pos = _read_varint(unsigned_tx, pos)
+    if output_count != 1:
+        raise ValueError(f"Expected exactly 1 output, got {output_count}")
+
+    if pos + 8 > len(unsigned_tx):
+        raise ValueError("Unsigned transaction output value is truncated")
+    pos += 8
+
+    output_script_len, pos = _read_varint(unsigned_tx, pos)
+    if pos + output_script_len > len(unsigned_tx):
+        raise ValueError("Unsigned transaction output script is truncated")
+    pos += output_script_len
+
+    if pos != len(unsigned_tx) - 4:
+        raise ValueError("Unsigned transaction has trailing data before locktime")
+
+
+def _validate_p2wsh_script(witness_utxo_script: bytes, witness_script: bytes) -> None:
+    """Verify witness_utxo is OP_0 SHA256(witness_script)."""
+    expected = b"\x00\x20" + hashlib.sha256(witness_script).digest()
+    if witness_utxo_script != expected:
+        raise ValueError(
+            "witness_script does not match the P2WSH witness_utxo scriptPubKey"
+        )
+
+
+def _extract_freeze_script_pubkey(witness_script: bytes) -> bytes:
+    """Extract the pubkey from <locktime> OP_CLTV OP_DROP <pubkey> OP_CHECKSIG."""
+    pos = 0
+    if pos >= len(witness_script):
+        raise ValueError("witness_script is empty")
+
+    locktime_len = witness_script[pos]
+    pos += 1
+    if locktime_len < 1 or locktime_len > 5:
+        raise ValueError("witness_script has invalid locktime push")
+    if pos + locktime_len + 2 > len(witness_script):
+        raise ValueError("witness_script locktime push is truncated")
+    pos += locktime_len
+
+    if pos >= len(witness_script):
+        raise ValueError("witness_script missing OP_CHECKLOCKTIMEVERIFY")
+    if witness_script[pos] != 0xB1:
+        raise ValueError("witness_script missing OP_CHECKLOCKTIMEVERIFY")
+    pos += 1
+
+    if pos >= len(witness_script):
+        raise ValueError("witness_script missing OP_DROP")
+    if witness_script[pos] != 0x75:
+        raise ValueError("witness_script missing OP_DROP")
+    pos += 1
+
+    if pos >= len(witness_script):
+        raise ValueError("witness_script missing pubkey push")
+    pubkey_len = witness_script[pos]
+    pos += 1
+    if pubkey_len != 33:
+        raise ValueError("witness_script pubkey must be compressed")
+    if pos + pubkey_len > len(witness_script):
+        raise ValueError("witness_script pubkey is truncated")
+    if pos + pubkey_len + 1 != len(witness_script):
+        raise ValueError("witness_script has unexpected trailing data")
+
+    pubkey = witness_script[pos : pos + pubkey_len]
+    pos += pubkey_len
+    if witness_script[pos] != 0xAC:
+        raise ValueError("witness_script missing OP_CHECKSIG")
+
+    return pubkey
+
+
+def _extract_witness_utxo_script(witness_utxo: bytes) -> bytes:
+    """Extract scriptPubKey from a serialized PSBT witness_utxo value."""
+    if len(witness_utxo) < 9:
+        raise ValueError("witness_utxo is too short")
+    script_len, pos = _read_varint(witness_utxo, 8)
+    script = witness_utxo[pos : pos + script_len]
+    if len(script) != script_len:
+        raise ValueError("witness_utxo scriptPubKey is truncated")
+    return script
+
+
+def parse_signed_bond_psbt(psbt_b64: str) -> dict[str, bytes]:
+    """Extract the fields needed to finalize a signed single-input bond PSBT."""
+    psbt_clean = "".join(psbt_b64.split())
+    try:
+        raw = base64.b64decode(psbt_clean, validate=True)
+    except Exception as e:
+        raise ValueError(f"Invalid base64 PSBT: {e}") from e
+
+    if not raw.startswith(b"psbt\xff"):
+        raise ValueError("Invalid PSBT: missing magic bytes")
+
+    pos = 5
+    unsigned_tx: bytes | None = None
+    global_map_complete = False
+
+    # Global map.
+    while pos < len(raw):
+        key, value, pos = _read_psbt_pair(raw, pos)
+        if key is None:
+            global_map_complete = True
+            break
+        assert value is not None
+        if key[0] == 0x00:  # PSBT_GLOBAL_UNSIGNED_TX
+            unsigned_tx = value
+
+    if not global_map_complete:
+        raise ValueError("PSBT global map is truncated")
+    if unsigned_tx is None:
+        raise ValueError("PSBT missing unsigned transaction")
+
+    _parse_unsigned_tx(unsigned_tx)
+
+    partial_sigs: list[bytes] = []
+    partial_sig_pubkeys: list[bytes] = []
+    witness_script: bytes | None = None
+    witness_utxo_script: bytes | None = None
+    input_map_complete = False
+
+    # Input map for the single input.
+    while pos < len(raw):
+        key, value, pos = _read_psbt_pair(raw, pos)
+        if key is None:
+            input_map_complete = True
+            break
+        assert value is not None
+        key_type = key[0]
+        if key_type == 0x01:  # PSBT_IN_WITNESS_UTXO
+            witness_utxo_script = _extract_witness_utxo_script(value)
+        elif key_type == 0x02:  # PSBT_IN_PARTIAL_SIG
+            pubkey = key[1:]
+            if len(pubkey) != 33:
+                raise ValueError("Partial signature key does not contain a compressed pubkey")
+            partial_sig_pubkeys.append(pubkey)
+            partial_sigs.append(value)
+        elif key_type == 0x05:  # PSBT_IN_WITNESS_SCRIPT
+            witness_script = value
+
+    if not input_map_complete:
+        raise ValueError("PSBT input map is truncated")
+    if not partial_sigs:
+        raise ValueError("PSBT missing partial signature")
+    if len(partial_sigs) > 1:
+        raise ValueError("Expected exactly 1 partial signature")
+    if witness_script is None:
+        raise ValueError("PSBT missing witness_script")
+    if witness_utxo_script is None:
+        raise ValueError("PSBT missing witness_utxo")
+
+    _validate_p2wsh_script(witness_utxo_script, witness_script)
+    script_pubkey = _extract_freeze_script_pubkey(witness_script)
+
+    signature = partial_sigs[0]
+    if partial_sig_pubkeys[0] != script_pubkey:
+        raise ValueError("Partial signature pubkey does not match witness_script pubkey")
+    if not signature or signature[-1] != 0x01:
+        raise ValueError("Partial signature is missing SIGHASH_ALL byte")
+
+    return {
+        "unsigned_tx": unsigned_tx,
+        "signature": signature,
+        "witness_script": witness_script,
+    }
+
+
+def finalize_bond_psbt(psbt_b64: str) -> str:
+    """Return final raw transaction hex from a signed bond PSBT."""
+    data = parse_signed_bond_psbt(psbt_b64)
+    unsigned_tx = data["unsigned_tx"]
+    signature = data["signature"]
+    witness_script = data["witness_script"]
+
+    witness = (
+        _encode_varint(2)
+        + _encode_varint(len(signature))
+        + signature
+        + _encode_varint(len(witness_script))
+        + witness_script
+    )
+
+    # PSBT unsigned txs are non-witness serializations. For the single-input
+    # bond spend, insert marker/flag after nVersion and one witness stack before
+    # nLockTime.
+    signed_tx = unsigned_tx[:4] + b"\x00\x01" + unsigned_tx[4:-4] + witness + unsigned_tx[-4:]
+    return signed_tx.hex()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Finalize a signed fidelity bond PSBT into raw transaction hex.",
+    )
+    parser.add_argument("psbt", nargs="?", help="Base64-encoded signed PSBT")
+    parser.add_argument("--file", "-f", type=Path, help="Read signed PSBT from file")
+    args = parser.parse_args()
+
+    if args.file is not None:
+        psbt_b64 = args.file.read_text().strip()
+    elif args.psbt:
+        psbt_b64 = args.psbt.strip()
+    else:
+        parser.error("Provide a signed PSBT argument or --file")
+
+    try:
+        print(finalize_bond_psbt(psbt_b64))
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_finalize_bond_psbt.py
+++ b/tests/test_finalize_bond_psbt.py
@@ -156,7 +156,10 @@ class TestParseSignedBondPSBT:
             for i in range(0, len(SIGNED_SPECTER_PSBT_B64), 64)
         )
 
-        assert parse_signed_bond_psbt(wrapped)["witness_script"].hex() == WITNESS_SCRIPT_HEX
+        assert (
+            parse_signed_bond_psbt(wrapped)["witness_script"].hex()
+            == WITNESS_SCRIPT_HEX
+        )
 
 
 class TestFinalizeBondPSBT:

--- a/tests/test_finalize_bond_psbt.py
+++ b/tests/test_finalize_bond_psbt.py
@@ -1,0 +1,203 @@
+"""Tests for the standalone signed bond PSBT finalizer."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from finalize_bond_psbt import (  # noqa: E402
+    _encode_varint,
+    _extract_freeze_script_pubkey,
+    _read_psbt_pair,
+    _read_varint,
+    finalize_bond_psbt,
+    parse_signed_bond_psbt,
+)
+
+SIGNED_SPECTER_PSBT_B64 = (
+    "cHNidP8BAFICAAAAATE7hixB8V/y7oXB1Ckyveg+WIPrW0RlxtFNPdv3o6BUAQAAAAD+////"
+    "AdBBDwAAAAAAFgAUr8yGDmmY3JWBeIXYdqhZO4fpB4MAuVVpAAEBK0BCDwAAAAAAIgAg6WSb"
+    "rbiM8Zvs3u3QwM5l56zhJdTDwpQnSzvGG3PlqeEiAgIJ014SVJgJ37nyNaD9IVJ7d042rAku"
+    "z0/0N22Q2dWMBEcwRAIgWYcBBSQzdRvnuXhSFzSa+oczdHEGFS2Vbe3e+YHrNrQCIFe8omA0"
+    "wStZo2SmHImP0gzc/zVrqM0zUSDns6rY04klAQEDBAEAAAABBSoEALlVabF1IQIJ014SVJgJ"
+    "37nyNaD9IVJ7d042rAkuz0/0N22Q2dWMBKwAAA=="
+)
+
+WITNESS_SCRIPT_HEX = (
+    "0400b95569b175210209d35e12549809dfb9f235a0fd21527b774e36ac092ecf4ff4376"
+    "d90d9d58c04ac"
+)
+
+
+def _remove_partial_signature(psbt_b64: str) -> str:
+    raw = base64.b64decode(psbt_b64)
+    pos = 5
+
+    # Copy global map through separator.
+    while True:
+        key, _, next_pos = _read_psbt_pair(raw, pos)
+        pos = next_pos
+        if key is None:
+            break
+
+    output = bytearray(raw[:pos])
+
+    # Copy input map, skipping partial signature pairs.
+    while True:
+        pair_start = pos
+        key, _, next_pos = _read_psbt_pair(raw, pos)
+        pos = next_pos
+        if key is None:
+            output.append(0)
+            break
+        if key[0] != 0x02:
+            output.extend(raw[pair_start:next_pos])
+
+    output.extend(raw[pos:])
+    return base64.b64encode(output).decode()
+
+
+def _replace_partial_signature_pubkey(psbt_b64: str, pubkey: bytes) -> str:
+    raw = base64.b64decode(psbt_b64)
+    pos = 5
+
+    while True:
+        key, _, next_pos = _read_psbt_pair(raw, pos)
+        pos = next_pos
+        if key is None:
+            break
+
+    output = bytearray(raw[:pos])
+
+    while True:
+        pair_start = pos
+        key, value, next_pos = _read_psbt_pair(raw, pos)
+        pos = next_pos
+        if key is None:
+            output.append(0)
+            break
+        if key[0] == 0x02:
+            assert value is not None
+            new_key = b"\x02" + pubkey
+            output.extend(_encode_varint(len(new_key)) + new_key)
+            output.extend(_encode_varint(len(value)) + value)
+        else:
+            output.extend(raw[pair_start:next_pos])
+
+    output.extend(raw[pos:])
+    return base64.b64encode(output).decode()
+
+
+def _remove_first_separator(psbt_b64: str) -> str:
+    raw = base64.b64decode(psbt_b64)
+    pos = 5
+
+    while True:
+        key, _, next_pos = _read_psbt_pair(raw, pos)
+        pos = next_pos
+        if key is None:
+            return base64.b64encode(raw[: pos - 1]).decode()
+
+
+class TestParseSignedBondPSBT:
+    def test_extracts_signed_bond_fields(self) -> None:
+        result = parse_signed_bond_psbt(SIGNED_SPECTER_PSBT_B64)
+
+        assert result["witness_script"].hex() == WITNESS_SCRIPT_HEX
+        assert result["signature"][-1] == 0x01
+        assert result["unsigned_tx"].hex().startswith("02000000")
+
+    def test_unsigned_psbt_raises(self) -> None:
+        with pytest.raises(ValueError, match="partial signature"):
+            parse_signed_bond_psbt(_remove_partial_signature(SIGNED_SPECTER_PSBT_B64))
+
+    def test_witness_script_mismatch_raises(self) -> None:
+        raw = bytearray(base64.b64decode(SIGNED_SPECTER_PSBT_B64))
+        needle = hashlib.sha256(bytes.fromhex(WITNESS_SCRIPT_HEX)).digest()
+        offset = bytes(raw).index(needle)
+        raw[offset] ^= 0x01
+
+        with pytest.raises(ValueError, match="does not match"):
+            parse_signed_bond_psbt(base64.b64encode(raw).decode())
+
+    def test_partial_signature_pubkey_mismatch_raises(self) -> None:
+        wrong_pubkey = bytes.fromhex("03" + "11" * 32)
+        psbt = _replace_partial_signature_pubkey(SIGNED_SPECTER_PSBT_B64, wrong_pubkey)
+
+        with pytest.raises(ValueError, match="pubkey does not match"):
+            parse_signed_bond_psbt(psbt)
+
+    def test_truncated_psbt_raises_value_error(self) -> None:
+        raw = base64.b64decode(SIGNED_SPECTER_PSBT_B64)
+        truncated = base64.b64encode(raw[:-7]).decode()
+
+        with pytest.raises(ValueError, match="truncated|Truncated|Unexpected end"):
+            parse_signed_bond_psbt(truncated)
+
+    def test_missing_global_separator_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="global map is truncated"):
+            parse_signed_bond_psbt(_remove_first_separator(SIGNED_SPECTER_PSBT_B64))
+
+    def test_truncated_witness_script_raises_value_error(self) -> None:
+        truncated_script = bytes.fromhex(WITNESS_SCRIPT_HEX)[:7]
+
+        with pytest.raises(ValueError, match="truncated|missing"):
+            _extract_freeze_script_pubkey(truncated_script)
+
+    def test_line_wrapped_psbt_is_accepted(self) -> None:
+        wrapped = "\n".join(
+            SIGNED_SPECTER_PSBT_B64[i : i + 64]
+            for i in range(0, len(SIGNED_SPECTER_PSBT_B64), 64)
+        )
+
+        assert parse_signed_bond_psbt(wrapped)["witness_script"].hex() == WITNESS_SCRIPT_HEX
+
+
+class TestFinalizeBondPSBT:
+    def test_finalize_outputs_witness_transaction(self) -> None:
+        signed_hex = finalize_bond_psbt(SIGNED_SPECTER_PSBT_B64)
+        signed = bytes.fromhex(signed_hex)
+
+        assert signed[4] == 0x00
+        assert signed[5] == 0x01
+
+        offset = 6
+        input_count, offset = _read_varint(signed, offset)
+        assert input_count == 1
+        offset += 32 + 4
+        script_len, offset = _read_varint(signed, offset)
+        offset += script_len + 4
+
+        output_count, offset = _read_varint(signed, offset)
+        assert output_count == 1
+        offset += 8
+        output_script_len, offset = _read_varint(signed, offset)
+        offset += output_script_len
+
+        witness_items, offset = _read_varint(signed, offset)
+        assert witness_items == 2
+
+        sig_len, offset = _read_varint(signed, offset)
+        signature = signed[offset : offset + sig_len]
+        offset += sig_len
+        assert signature[-1] == 0x01
+
+        script_len, offset = _read_varint(signed, offset)
+        witness_script = signed[offset : offset + script_len]
+        assert witness_script.hex() == WITNESS_SCRIPT_HEX
+
+    def test_finalized_tx_has_expected_hex(self) -> None:
+        assert finalize_bond_psbt(SIGNED_SPECTER_PSBT_B64) == (
+            "02000000000101313b862c41f15ff2ee85c1d42932bde83e5883eb5b4465c6d14d3d"
+            "dbf7a3a0540100000000feffffff01d0410f0000000000160014afcc860e6998dc95"
+            "817885d876a8593b87e90783024730440220598701052433751be7b9785217349afa"
+            "8733747106152d956deddef981eb36b4022057bca26034c12b59a364a61c898fd20"
+            "cdcff356ba8cd335120e7b3aad8d38925012a0400b95569b175210209d35e125498"
+            "09dfb9f235a0fd21527b774e36ac092ecf4ff4376d90d9d58c04ac00b95569"
+        )


### PR DESCRIPTION
## Summary

Document Specter DIY as a supported hardware-wallet signing path for fidelity bond redemption through QR-based PSBT exchange.

This clarifies that Specter DIY can sign the CLTV bond spend PSBT by scanning the unsigned PSBT as a QR code and returning a signed PSBT, without exposing the mnemonic to JoinMarket NG tooling.

## Changes

- Add Specter DIY to the fidelity bond hardware-wallet compatibility notes
- Document the Specter DIY QR PSBT signing flow
- Update the dry-run example to save the unsigned PSBT and render it as a QR code
- Clarify the distinction between:
  - Ledger/Jade signing through upstream Bitcoin Core HWI
  - Specter DIY signing through QR PSBT exchange
  - mnemonic signing as the fallback path

## HWI note

Specter DIY is not listed as a supported device in upstream Bitcoin Core HWI. Specter DIY documentation also recommends QR codes or SD card instead of USB/HWI-style communication.

This PR therefore does not claim Specter DIY HWI support. It documents the working QR PSBT flow as the positive supported path.

References:

- HWI supported devices: https://hwi.readthedocs.io/en/latest/devices/index.html
- Specter DIY FAQ: https://docs.specter.solutions/diy/faq/
- Specter Desktop FAQ: https://docs.specter.solutions/desktop/faq/

## Testing

Docs-only change.

- Reviewed the updated signing flow against private Signet Specter DIY test notes
- Verified Markdown diff for whitespace issues with `git diff --check`
