### PR TITLE
feat(docker): flexible runtime user

### DIFF
--- a/directory_server/Dockerfile
+++ b/directory_server/Dockerfile
@@ -52,7 +52,7 @@ COPY directory_server/requirements.txt /build/directory_server/requirements.txt
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ -n "$SOURCE_DATE_EPOCH" ]; then export SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH; fi && \
-    pip install --user --build-constraint /build/constraints.txt \
+    pip install --prefix=/app --build-constraint /build/constraints.txt \
         -r /build/jmcore/requirements.txt \
         -r /build/directory_server/requirements.txt
 
@@ -65,13 +65,13 @@ COPY directory_server/pyproject.toml /build/directory_server/
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ -n "$SOURCE_DATE_EPOCH" ]; then export SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH; fi && \
-    pip install --user --build-constraint /build/constraints.txt \
+    pip install --prefix=/app --build-constraint /build/constraints.txt \
         /build/jmcore \
         /build/directory_server
 
 # Normalize installed Python environment mtimes for reproducible COPY layer digests
 RUN if [ -n "$SOURCE_DATE_EPOCH" ]; then \
-        find /root/.local -exec touch -d @${SOURCE_DATE_EPOCH} {} +; \
+        find /app -exec touch -d @${SOURCE_DATE_EPOCH} {} +; \
     fi
 
 # =============================================================================
@@ -102,14 +102,18 @@ RUN useradd -m -u 1000 jm && \
         sed -i "s/^jm:!:[0-9]*:/jm:!:${DAYS_SINCE_EPOCH}:/" /etc/shadow; \
     fi
 
-# Copy Python packages from builder and set ownership
-COPY --from=builder --chown=jm:jm /root/.local /home/jm/.local
+# Copy Python packages from builder and set permissions
+COPY --from=builder /app /app
+RUN chmod -R a+rX /app
 
 # Switch to non-root user
 USER jm
 
 # Make sure scripts are in PATH
-ENV PATH=/home/jm/.local/bin:$PATH
+ENV PATH=/app/bin:$PATH
+
+# Make sure packages are in Python PATH
+ENV PYTHONPATH=/app/lib/python${PYTHON_VERSION%.*}/site-packages
 
 EXPOSE 5222 8080
 
@@ -158,7 +162,7 @@ COPY directory_server/requirements.txt /build/directory_server/requirements.txt
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ -n "$SOURCE_DATE_EPOCH" ]; then export SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH; fi && \
-    pip install --user --build-constraint /build/constraints.txt \
+    pip install --prefix=/app --build-constraint /build/constraints.txt \
         -r /build/jmcore/requirements.txt \
         -r /build/directory_server/requirements.txt
 
@@ -171,13 +175,13 @@ COPY directory_server/pyproject.toml /build/directory_server/
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ -n "$SOURCE_DATE_EPOCH" ]; then export SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH; fi && \
-    pip install --user --build-constraint /build/constraints.txt \
+    pip install --prefix=/app --build-constraint /build/constraints.txt \
         /build/jmcore \
         /build/directory_server
 
 # Normalize installed Python environment mtimes for reproducible COPY layer digests
 RUN if [ -n "$SOURCE_DATE_EPOCH" ]; then \
-        find /root/.local -exec touch -d @${SOURCE_DATE_EPOCH} {} +; \
+        find /app -exec touch -d @${SOURCE_DATE_EPOCH} {} +; \
     fi
 
 FROM python:${PYTHON_VERSION}@${PYTHON_FULL_DIGEST} AS debug
@@ -205,14 +209,18 @@ RUN useradd -m -u 1000 jm && \
         sed -i "s/^jm:!:[0-9]*:/jm:!:${DAYS_SINCE_EPOCH}:/" /etc/shadow; \
     fi
 
-# Copy Python packages from debug builder and set ownership
-COPY --from=debug-builder --chown=jm:jm /root/.local /home/jm/.local
+# Copy Python packages from debug builder and set permissions
+COPY --from=debug-builder /app /app
+RUN chmod -R a+rX /app
 
 # Switch to non-root user
 USER jm
 
 # Make sure scripts are in PATH
-ENV PATH=/home/jm/.local/bin:$PATH
+ENV PATH=/app/bin:$PATH
+
+# Make sure packages are in Python PATH
+ENV PYTHONPATH=/app/lib/python${PYTHON_VERSION%.*}/site-packages
 
 EXPOSE 5222 8080
 

--- a/maker/Dockerfile
+++ b/maker/Dockerfile
@@ -59,7 +59,7 @@ COPY maker/requirements.txt /build/maker/requirements.txt
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ -n "$SOURCE_DATE_EPOCH" ]; then export SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH; fi && \
-    pip install --user \
+    pip install --prefix=/app \
         -r /build/jmcore/requirements.txt \
         -r /build/jmwallet/requirements.txt \
         -r /build/maker/requirements.txt
@@ -77,14 +77,14 @@ COPY maker/pyproject.toml /build/maker/
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ -n "$SOURCE_DATE_EPOCH" ]; then export SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH; fi && \
-    pip install --user --build-constraint /build/constraints.txt \
+    pip install --prefix=/app --build-constraint /build/constraints.txt \
         /build/jmcore \
         /build/jmwallet \
         /build/maker
 
 # Normalize installed Python environment mtimes for reproducible COPY layer digests
 RUN if [ -n "$SOURCE_DATE_EPOCH" ]; then \
-        find /root/.local -exec touch -d @${SOURCE_DATE_EPOCH} {} +; \
+        find /app -exec touch -d @${SOURCE_DATE_EPOCH} {} +; \
     fi
 
 # =============================================================================
@@ -115,14 +115,18 @@ RUN useradd -m -u 1000 jm && \
         sed -i "s/^jm:!:[0-9]*:/jm:!:${DAYS_SINCE_EPOCH}:/" /etc/shadow; \
     fi
 
-# Copy Python packages from builder and set ownership
-COPY --from=builder --chown=jm:jm /root/.local /home/jm/.local
+# Copy Python packages from builder and set permissions
+COPY --from=builder /app /app
+RUN chmod -R a+rX /app
 
 # Switch to non-root user
 USER jm
 
 # Make sure scripts are in PATH
-ENV PATH=/home/jm/.local/bin:$PATH
+ENV PATH=/app/bin:$PATH
+
+# Make sure packages are in Python PATH
+ENV PYTHONPATH=/app/lib/python${PYTHON_VERSION%.*}/site-packages
 
 # Create data directory for JoinMarket files
 # This includes commitment blacklist, history, and other persistent data

--- a/orderbook_watcher/Dockerfile
+++ b/orderbook_watcher/Dockerfile
@@ -51,7 +51,7 @@ COPY orderbook_watcher/requirements.txt /build/orderbook_watcher/
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ -n "$SOURCE_DATE_EPOCH" ]; then export SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH; fi && \
-    pip install --user \
+    pip install --prefix=/app \
         -r /build/jmcore/requirements.txt \
         -r /build/jmwallet/requirements.txt \
         -r /build/orderbook_watcher/requirements.txt
@@ -68,7 +68,7 @@ COPY jmwallet/pyproject.toml /build/jmwallet/
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ -n "$SOURCE_DATE_EPOCH" ]; then export SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH; fi && \
-    pip install --user --build-constraint /build/constraints.txt \
+    pip install --prefix=/app --build-constraint /build/constraints.txt \
         /build/jmcore \
         /build/jmwallet
 
@@ -88,7 +88,7 @@ RUN find /build/orderbook_watcher/src /build/orderbook_watcher/static -type f -e
 
 # Normalize installed Python environment mtimes for reproducible COPY layer digests
 RUN if [ -n "$SOURCE_DATE_EPOCH" ]; then \
-        find /root/.local -exec touch -d @${SOURCE_DATE_EPOCH} {} +; \
+        find /app -exec touch -d @${SOURCE_DATE_EPOCH} {} +; \
     fi
 
 # =============================================================================
@@ -119,14 +119,18 @@ RUN useradd -m -u 1000 jm && \
         sed -i "s/^jm:!:[0-9]*:/jm:!:${DAYS_SINCE_EPOCH}:/" /etc/shadow; \
     fi
 
-# Copy Python packages from builder and set ownership
-COPY --from=builder --chown=jm:jm /root/.local /home/jm/.local
+# Copy Python packages from builder and set permissions
+COPY --from=builder /app /app
+RUN chmod -R a+rX /app
 
 # Switch to non-root user
 USER jm
 
 # Make sure scripts are in PATH
-ENV PATH=/home/jm/.local/bin:$PATH
+ENV PATH=/app/bin:$PATH
+
+# Make sure packages are in Python PATH
+ENV PYTHONPATH=/app/lib/python${PYTHON_VERSION%.*}/site-packages
 
 # Copy application source and static files from builder (with normalized permissions)
 COPY --from=builder --chown=jm:jm /build/orderbook_watcher/src /app/orderbook_watcher/src

--- a/taker/Dockerfile
+++ b/taker/Dockerfile
@@ -57,7 +57,7 @@ COPY maker/requirements.txt /build/maker/requirements.txt
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ -n "$SOURCE_DATE_EPOCH" ]; then export SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH; fi && \
-    pip install --user \
+    pip install --prefix=/app \
         -r /build/jmcore/requirements.txt \
         -r /build/jmwallet/requirements.txt \
         -r /build/taker/requirements.txt \
@@ -80,7 +80,7 @@ COPY tumbler/pyproject.toml /build/tumbler/
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ -n "$SOURCE_DATE_EPOCH" ]; then export SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH; fi && \
-    pip install --user --build-constraint /build/constraints.txt \
+    pip install --prefix=/app --build-constraint /build/constraints.txt \
         /build/jmcore \
         /build/jmwallet \
         /build/taker \
@@ -89,7 +89,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # Normalize installed Python environment mtimes for reproducible COPY layer digests
 RUN if [ -n "$SOURCE_DATE_EPOCH" ]; then \
-        find /root/.local -exec touch -d @${SOURCE_DATE_EPOCH} {} +; \
+        find /app -exec touch -d @${SOURCE_DATE_EPOCH} {} +; \
     fi
 
 # =============================================================================
@@ -120,14 +120,18 @@ RUN useradd -m -u 1000 jm && \
         sed -i "s/^jm:!:[0-9]*:/jm:!:${DAYS_SINCE_EPOCH}:/" /etc/shadow; \
     fi
 
-# Copy Python packages from builder and set ownership
-COPY --from=builder --chown=jm:jm /root/.local /home/jm/.local
+# Copy Python packages from builder and set permissions
+COPY --from=builder /app /app
+RUN chmod -R a+rX /app
 
 # Switch to non-root user
 USER jm
 
 # Make sure scripts are in PATH
-ENV PATH=/home/jm/.local/bin:$PATH
+ENV PATH=/app/bin:$PATH
+
+# Make sure packages are in Python PATH
+ENV PYTHONPATH=/app/lib/python${PYTHON_VERSION%.*}/site-packages
 
 # Create data directory for JoinMarket files
 # This includes commitment blacklist, history, and other persistent data


### PR DESCRIPTION
# Make images runtime-user flexible by moving packages to /app

Install Python packages to `/app` via `--prefix=/app` instead of `--user` (`~/.local`), making them root-owned and world-readable. This allows the container to run as any UID at runtime (e.g. user: "1046:1046" in Compose) without requiring a matching user baked into the image.

## Changes:

- Builder: `pip install --prefix=/app` instead of `--user`
- Production: `COPY --from=builder /app /app with chmod -R a+rX`
- `PATH` updated to `/app/bin`
- `PYTHONPATH` set to `/app/lib/python${PYTHON_VERSION%.*}/site-packages` (shell expansion strips patch version to match Python's directory naming)

The jm user and data volume path (`/home/jm/.joinmarket-ng`) are unchanged.