### PR TITLE
[maker] fix PoDLE !hp2 Sybil DoS

### DIFF
--- a/maker/src/maker/bot.py
+++ b/maker/src/maker/bot.py
@@ -146,11 +146,8 @@ class MakerBot(BackgroundTasksMixin, ProtocolHandlersMixin, DirectConnectionMixi
         # This prevents processing duplicates and avoids false rate limit violations
         self._message_deduplicator = MessageDeduplicator(window_seconds=30.0)
 
-        # Semaphore to limit concurrent ephemeral hp2 broadcasts.
-        # Each broadcast opens Tor connections to all directories, so we cap
-        # concurrency to prevent a Sybil DoS (many nicks each sending one !hp2
-        # relay request). Max 2 allows one own broadcast + one relay to overlap.
-        self._hp2_broadcast_semaphore = asyncio.Semaphore(2)
+        self._hp2_own_broadcast_semaphore = asyncio.Semaphore(1)
+        self._hp2_relay_broadcast_semaphore = asyncio.Semaphore(1)
 
         # Track failed directory reconnection attempts
         # Key: node_id (host:port), Value: number of reconnection attempts

--- a/maker/src/maker/protocol_handlers.py
+++ b/maker/src/maker/protocol_handlers.py
@@ -62,7 +62,8 @@ class ProtocolHandlersMixin:
     _orderbook_rate_limiter: OrderbookRateLimiter
     _direct_connection_rate_limiter: DirectConnectionRateLimiter
     _own_wallet_nicks: set[str]
-    _hp2_broadcast_semaphore: asyncio.Semaphore
+    _hp2_own_broadcast_semaphore: asyncio.Semaphore
+    _hp2_relay_broadcast_semaphore: asyncio.Semaphore
 
     async def _handle_message(
         self: MakerBotProtocol, message: dict[str, Any], source: str = "unknown"
@@ -646,7 +647,7 @@ class ProtocolHandlersMixin:
             add_commitment(commitment)
 
             # Broadcast via ephemeral identity (fire-and-forget)
-            asyncio.create_task(self._broadcast_commitment_ephemeral(commitment))
+            asyncio.create_task(self._broadcast_commitment_ephemeral(commitment, is_relay=True))
 
         except Exception as e:
             logger.error(f"Failed to handle !hp2 relay request: {e}")
@@ -685,14 +686,16 @@ class ProtocolHandlersMixin:
             add_commitment(commitment)
 
             # Broadcast via ephemeral identity (fire-and-forget)
-            asyncio.create_task(self._broadcast_commitment_ephemeral(commitment))
+            asyncio.create_task(self._broadcast_commitment_ephemeral(commitment, is_relay=False))
 
             logger.debug(f"Scheduled ephemeral commitment broadcast: {commitment[:16]}...")
 
         except Exception as e:
             logger.error(f"Failed to broadcast commitment: {e}")
 
-    async def _broadcast_commitment_ephemeral(self, commitment: str) -> None:
+    async def _broadcast_commitment_ephemeral(
+        self, commitment: str, *, is_relay: bool = False
+    ) -> None:
         """Open ephemeral directory connections and broadcast a commitment.
 
         Creates short-lived connections to all configured directory servers
@@ -700,29 +703,27 @@ class ProtocolHandlersMixin:
         credentials, broadcasts the commitment as a public !hp2 message, then
         tears down the connections.
 
-        Guarded by ``_hp2_broadcast_semaphore`` (max 2 concurrent) to prevent
-        a Sybil DoS where many nicks each send one relay request, causing us
-        to open excessive Tor circuits. Requests that exceed the concurrency
-        limit are silently dropped -- the commitment is already blacklisted
-        locally by the caller.
+        Concurrency is bounded by two dedicated semaphores so that a Sybil
+        flood of relayed peer requests cannot starve the maker's own
+        post-ioauth broadcasts. Own broadcasts (``is_relay=False``) queue
+        for their slot to guarantee propagation; relayed broadcasts
+        (``is_relay=True``) are dropped on contention -- the commitment is
+        already blacklisted locally by the caller.
 
         This is a background task -- errors are logged, not raised.
         """
-        acquired = self._hp2_broadcast_semaphore.locked() is False
-        if not acquired:
-            # All slots may be taken; try non-blocking acquire
+        if is_relay:
+            semaphore = self._hp2_relay_broadcast_semaphore
             try:
-                # Semaphore.acquire() with wait=False isn't available, so use
-                # a zero-timeout wait to avoid blocking.
-                await asyncio.wait_for(self._hp2_broadcast_semaphore.acquire(), timeout=0)
-                acquired = True
+                await asyncio.wait_for(semaphore.acquire(), timeout=0)
             except TimeoutError:
                 logger.debug(
-                    f"Dropping ephemeral hp2 broadcast (concurrency limit): {commitment[:16]}..."
+                    f"Dropping relayed hp2 broadcast (concurrency limit): {commitment[:16]}..."
                 )
                 return
         else:
-            await self._hp2_broadcast_semaphore.acquire()
+            semaphore = self._hp2_own_broadcast_semaphore
+            await semaphore.acquire()
 
         hp2_msg = f"hp2 {commitment}"
         ephemeral_clients: list[DirectoryClient] = []
@@ -775,7 +776,7 @@ class ProtocolHandlersMixin:
             logger.error(f"Ephemeral commitment broadcast failed: {e}")
 
         finally:
-            self._hp2_broadcast_semaphore.release()
+            semaphore.release()
             for client in ephemeral_clients:
                 try:
                     await client.close()

--- a/maker/src/maker/protocols.py
+++ b/maker/src/maker/protocols.py
@@ -61,7 +61,8 @@ class MakerBotProtocol(Protocol):
     _directory_reconnect_attempts: dict[str, int]
     _all_directories_disconnected: bool
     _own_wallet_nicks: set[str]
-    _hp2_broadcast_semaphore: asyncio.Semaphore
+    _hp2_own_broadcast_semaphore: asyncio.Semaphore
+    _hp2_relay_broadcast_semaphore: asyncio.Semaphore
 
     # -- Cross-mixin methods --
 

--- a/maker/tests/test_commitment_broadcast.py
+++ b/maker/tests/test_commitment_broadcast.py
@@ -8,7 +8,8 @@ correlation with the maker's long-lived identity:
 - _broadcast_commitment_ephemeral: fresh connections, pubmsg, close
 - _handle_hp2_privmsg: relay requests from other makers
 - _handle_hp2_pubmsg: public commitment blacklisting
-- _hp2_broadcast_semaphore: concurrency limiting for DoS protection
+- _hp2_own_broadcast_semaphore / _hp2_relay_broadcast_semaphore:
+  separated concurrency pools so relay floods cannot starve own broadcasts
 """
 
 from __future__ import annotations
@@ -79,7 +80,7 @@ class TestBroadcastCommitment:
         # Let the create_task fire
         await asyncio.sleep(0)
 
-        mock_ephemeral.assert_called_once_with(COMMITMENT)
+        mock_ephemeral.assert_called_once_with(COMMITMENT, is_relay=False)
 
     async def test_does_not_use_existing_directory_connections(
         self, maker_bot: MakerBot, mock_directory_client: MagicMock
@@ -249,7 +250,7 @@ class TestHandleHp2Privmsg:
 
         await asyncio.sleep(0)
 
-        mock_ephemeral.assert_called_once_with(COMMITMENT)
+        mock_ephemeral.assert_called_once_with(COMMITMENT, is_relay=True)
 
     async def test_ignores_invalid_format(self, maker_bot: MakerBot) -> None:
         with (
@@ -299,53 +300,81 @@ class TestHandleHp2Pubmsg:
 
 
 @pytest.mark.asyncio
-class TestHp2BroadcastSemaphore:
-    """Tests for the concurrency semaphore protecting ephemeral broadcasts."""
+class TestHp2BroadcastSemaphores:
+    """Tests for the dedicated concurrency pools protecting ephemeral broadcasts."""
 
-    async def test_semaphore_initialized_with_max_2(self, maker_bot: MakerBot) -> None:
-        # Semaphore(2) allows 2 concurrent broadcasts
-        assert not maker_bot._hp2_broadcast_semaphore.locked()
+    async def test_semaphores_initialized_unlocked(self, maker_bot: MakerBot) -> None:
+        assert not maker_bot._hp2_own_broadcast_semaphore.locked()
+        assert not maker_bot._hp2_relay_broadcast_semaphore.locked()
 
-    async def test_concurrent_broadcasts_limited(self, maker_bot: MakerBot) -> None:
-        """When 2 broadcasts are in-flight, a 3rd should be dropped."""
-        # Hold both semaphore slots
-        await maker_bot._hp2_broadcast_semaphore.acquire()
-        await maker_bot._hp2_broadcast_semaphore.acquire()
+    async def test_relay_pool_drops_relays_on_contention(self, maker_bot: MakerBot) -> None:
+        """When the relay pool is busy, additional relayed broadcasts are dropped."""
+        await maker_bot._hp2_relay_broadcast_semaphore.acquire()
 
-        # Now the semaphore is exhausted; ephemeral broadcast should be dropped
         mock_client = MagicMock()
         mock_client.connect = AsyncMock()
         mock_client.send_public_message = AsyncMock()
         mock_client.close = AsyncMock()
 
         with patch("maker.protocol_handlers.DirectoryClient", return_value=mock_client):
-            await maker_bot._broadcast_commitment_ephemeral(COMMITMENT)
+            await maker_bot._broadcast_commitment_ephemeral(COMMITMENT, is_relay=True)
 
-        # Should not have connected or broadcast anything
         mock_client.connect.assert_not_called()
 
-        # Release for cleanup
-        maker_bot._hp2_broadcast_semaphore.release()
-        maker_bot._hp2_broadcast_semaphore.release()
+        maker_bot._hp2_relay_broadcast_semaphore.release()
 
-    async def test_semaphore_released_after_broadcast(self, maker_bot: MakerBot) -> None:
+    async def test_relay_saturation_does_not_starve_own_broadcast(
+        self, maker_bot: MakerBot
+    ) -> None:
+        """Security invariant: a Sybil flood of relayed broadcasts must not block
+        the maker's own post-ioauth commitment broadcast. The two pools are
+        independent, so saturating the relay pool leaves the own pool free."""
+        await maker_bot._hp2_relay_broadcast_semaphore.acquire()
+
         mock_client = MagicMock()
         mock_client.connect = AsyncMock()
         mock_client.send_public_message = AsyncMock()
         mock_client.close = AsyncMock()
 
         with patch("maker.protocol_handlers.DirectoryClient", return_value=mock_client):
-            await maker_bot._broadcast_commitment_ephemeral(COMMITMENT)
+            await maker_bot._broadcast_commitment_ephemeral(COMMITMENT, is_relay=False)
 
-        # Semaphore should be released (not locked)
-        assert not maker_bot._hp2_broadcast_semaphore.locked()
+        # Own broadcast must have reached all configured directories.
+        assert mock_client.connect.call_count == 2
+        assert mock_client.send_public_message.call_count == 2
+        mock_client.send_public_message.assert_has_calls(
+            [call(f"hp2 {COMMITMENT}"), call(f"hp2 {COMMITMENT}")]
+        )
 
-    async def test_semaphore_released_on_failure(self, maker_bot: MakerBot) -> None:
+        maker_bot._hp2_relay_broadcast_semaphore.release()
+
+    async def test_own_pool_released_after_broadcast(self, maker_bot: MakerBot) -> None:
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.send_public_message = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        with patch("maker.protocol_handlers.DirectoryClient", return_value=mock_client):
+            await maker_bot._broadcast_commitment_ephemeral(COMMITMENT, is_relay=False)
+
+        assert not maker_bot._hp2_own_broadcast_semaphore.locked()
+
+    async def test_relay_pool_released_after_broadcast(self, maker_bot: MakerBot) -> None:
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.send_public_message = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        with patch("maker.protocol_handlers.DirectoryClient", return_value=mock_client):
+            await maker_bot._broadcast_commitment_ephemeral(COMMITMENT, is_relay=True)
+
+        assert not maker_bot._hp2_relay_broadcast_semaphore.locked()
+
+    async def test_own_pool_released_on_failure(self, maker_bot: MakerBot) -> None:
         with patch("maker.protocol_handlers.DirectoryClient") as mock_cls:
             mock_cls.return_value.connect = AsyncMock(side_effect=ConnectionError("fail"))
             mock_cls.return_value.close = AsyncMock()
 
-            await maker_bot._broadcast_commitment_ephemeral(COMMITMENT)
+            await maker_bot._broadcast_commitment_ephemeral(COMMITMENT, is_relay=False)
 
-        # Semaphore should still be released
-        assert not maker_bot._hp2_broadcast_semaphore.locked()
+        assert not maker_bot._hp2_own_broadcast_semaphore.locked()


### PR DESCRIPTION
1. The attacker spams a bunch of commitment blacklist requests at a maker.
2. Each relay takes a ticket. Both tickets get held.
3. While the tickets are busy with the attacker's junk relays, the maker finishes its own coinjoin.
4. The maker tries to shout the real burned commitment, no tickets available and the shout is silently dropped.
5. Other makers never hear "this commitment is burned."
6. The taker takes the same commitment and reuses it against every other maker. 

This pull request fixes the above described attack.

Now if the attacker spams relay requests, only the relay ticket fills up. The own-shout ticket is sitting there untouched, waits for a coinjoin to finish.