### PR TITLE
Maker: `onion_host` in config.toml is ignored (missing MakerSettings field)

### DIFF
--- a/jmcore/src/jmcore/data/config.toml.template
+++ b/jmcore/src/jmcore/data/config.toml.template
@@ -387,6 +387,7 @@
 # offer_reannounce_delay_max = 600
 
 # Onion service settings
+# onion_host = ""  # Static hidden service address (e.g., 'mymaker...onion'). When not set, Tor control auto-generates one.
 # onion_serving_host = "127.0.0.1"
 # onion_serving_port = 5222
 # tor_target_host = "127.0.0.1"

--- a/jmcore/src/jmcore/settings.py
+++ b/jmcore/src/jmcore/settings.py
@@ -703,6 +703,10 @@ class MakerSettings(BaseModel):
         description="Interval for periodic wallet rescans",
     )
     # Hidden service settings
+    onion_host: str | None = Field(
+        default=None,
+        description="Static hidden service address (e.g., 'mymaker...onion'). When not set, Tor control auto-generates one.",
+    )
     onion_serving_host: str = Field(
         default="127.0.0.1",
         description="Bind address for incoming connections",

--- a/jmcore/tests/test_settings.py
+++ b/jmcore/tests/test_settings.py
@@ -296,6 +296,26 @@ cj_fee_absolute = 1000
         assert settings.maker.offer_type == "sw0absoffer"
         assert settings.maker.cj_fee_absolute == 1000
 
+    def test_toml_maker_onion_host(
+        self, temp_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``onion_host`` must be readable from the [maker] TOML section (#535)."""
+        config_path = temp_data_dir / "config.toml"
+        config_path.write_text("""
+[maker]
+onion_host = "mymakerabcdef.onion"
+""")
+
+        settings = JoinMarketSettings()
+
+        assert settings.maker.onion_host == "mymakerabcdef.onion"
+
+    def test_maker_onion_host_defaults_to_none(self) -> None:
+        """Without configuration ``onion_host`` defaults to None."""
+        settings = JoinMarketSettings()
+
+        assert settings.maker.onion_host is None
+
     def test_toml_neutrino_settings(
         self, temp_data_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/maker/src/maker/cli.py
+++ b/maker/src/maker/cli.py
@@ -347,6 +347,7 @@ def build_maker_config(
         background_full_rescan=settings.wallet.background_full_rescan,
         scan_lookback_blocks=settings.wallet.scan_lookback_blocks,
         tor_control=tor_control_cfg,
+        onion_host=settings.maker.onion_host,
         onion_serving_host=effective_onion_host,
         onion_serving_port=effective_onion_port,
         tor_target_host=effective_target_host,

--- a/maker/tests/test_config.py
+++ b/maker/tests/test_config.py
@@ -353,6 +353,38 @@ class TestBuildMakerConfig:
         )
         assert config.max_sats_freeze_reuse == -1
 
+    def test_onion_host_forwarded(self) -> None:
+        """``maker.onion_host`` from settings must reach the MakerConfig (#535).
+
+        Otherwise the documented ``onion_host`` config key is silently ignored
+        and the maker never advertises the configured static .onion address.
+        """
+        from jmcore.settings import JoinMarketSettings
+
+        from maker.cli import build_maker_config
+
+        settings = JoinMarketSettings()
+        settings.maker.onion_host = "mymakerabcdef.onion"
+        config = build_maker_config(
+            settings=settings,
+            mnemonic=TEST_MNEMONIC,
+            passphrase="",
+        )
+        assert config.onion_host == "mymakerabcdef.onion"
+
+    def test_onion_host_defaults_to_none(self) -> None:
+        """Without configuration ``onion_host`` stays None (auto-generated)."""
+        from jmcore.settings import JoinMarketSettings
+
+        from maker.cli import build_maker_config
+
+        config = build_maker_config(
+            settings=JoinMarketSettings(),
+            mnemonic=TEST_MNEMONIC,
+            passphrase="",
+        )
+        assert config.onion_host is None
+
     def test_dual_offers_creates_two_configs(self) -> None:
         """Test that --dual-offers creates both relative and absolute offer configs."""
         from jmcore.settings import JoinMarketSettings


### PR DESCRIPTION
Summary
-------
The `onion_host` configuration field is defined in MakerConfig:

 https://github.com/joinmarket-ng/joinmarket-ng/blob/ce4409c7eb04b7a52ba54a1a2a22a83076c6760b/maker/src/maker/config.py#L178-L183
 
but is not loaded from the project's settings system. As a result, setting `onion_host` in `~/.joinmarket-ng/config.toml` has no effect; the maker never advertises or uses the provided static .onion address.

Reproduction
----------
1. Add the following to `~/.joinmarket-ng/config.toml`:

```
[maker]
onion_host = "mymakerabcdef.onion"
```

2. Start the maker: `jm-maker start --mnemonic-file ~/.joinmarket-ng/wallets/default.mnemonic`.
3. Observe in logs and directory announcements that the maker advertises `NOT-SERVING-ONION` or an auto-generated ephemeral onion instead of the configured address.

Observed behaviour
----------------
- `onion_host` from the config file is ignored.

Root cause
---------
- `MakerConfig` (maker/src/maker/config.py) defines `onion_host`.
- However, the unified settings model (`MakerSettings` in jmcore/src/jmcore/settings.py) does not include an `onion_host` field. The settings loader (pydantic-settings) only reads keys present in `MakerSettings`, so `onion_host` in the TOML is never mapped into runtime settings.

Expected behaviour
-----------------
- Users can set a static hidden service address via config.toml and the maker should advertise that address instead of an ephemeral onion address if tor_control auto-generates one.

Proposed fix
-----------
Add `onion_host: str | None = Field(default=None, description="Hidden service address (e.g., 'mymaker...onion')")` to `MakerSettings` in `jmcore/src/jmcore/settings.py` alongside the existing `onion_serving_host` and `onion_serving_port` fields. This will allow the TOML loader and environment variables to populate the value and restore the documented behaviour.