### PR TITLE
[jmwallet] apply first-sync auto-freeze guard on all sync paths

### DIFF
--- a/jmwallet/src/jmwallet/wallet/sync.py
+++ b/jmwallet/src/jmwallet/wallet/sync.py
@@ -125,6 +125,25 @@ class WalletSyncMixin:
                 prior_funded_addresses.add(utxo.address)
         return prior_known_outpoints, prior_funded_addresses
 
+    def _freeze_reused_after_sync(
+        self,
+        prior_used_addresses: set[str],
+        prior_known_outpoints: set[str],
+        prior_funded_addresses: set[str],
+    ) -> None:
+        # On the first sync after init utxo_cache was empty when the snapshot
+        # was taken, so treat the current scan's addresses as funded to avoid
+        # freezing pre-existing coins on used addresses (issue #529).
+        if getattr(self, "_just_initialized", False):
+            if not prior_known_outpoints:
+                prior_funded_addresses = prior_funded_addresses | {
+                    utxo.address for utxos in self.utxo_cache.values() for utxo in utxos
+                }
+            self._just_initialized = False
+        self._auto_freeze_reused_address_utxos(
+            prior_used_addresses, prior_known_outpoints, prior_funded_addresses
+        )
+
     def _record_history_address(self, address: str, origin: str | None = None) -> None:
         """Mark ``address`` as having on-chain history (current or spent).
 
@@ -557,7 +576,7 @@ class WalletSyncMixin:
         if self.backend.supports_descriptor_scan:
             result = await self._sync_all_with_descriptors(fidelity_bond_addresses)
             if result is not None:
-                self._auto_freeze_reused_address_utxos(
+                self._freeze_reused_after_sync(
                     prior_used_addresses, prior_known_outpoints, prior_funded_addresses
                 )
                 self._apply_frozen_state()
@@ -609,7 +628,7 @@ class WalletSyncMixin:
                 await self.sync_fidelity_bonds(bond_locktimes)
 
         logger.info(f"Sync complete: {sum(len(u) for u in result.values())} total UTXOs")
-        self._auto_freeze_reused_address_utxos(
+        self._freeze_reused_after_sync(
             prior_used_addresses, prior_known_outpoints, prior_funded_addresses
         )
         self._apply_frozen_state()
@@ -1548,25 +1567,8 @@ class WalletSyncMixin:
             f"{format_amount(total_value)} total"
         )
 
-        # On the first sync after process initialization, the utxo_cache was
-        # empty at snapshot time (prior_known_outpoints is empty) but
-        # addresses_with_history is already populated from the persisted metadata
-        # store.  Without adjustment, every UTXO on a "used" address would
-        # look like a "freshly arrived coin at an empty used address" and be
-        # auto-frozen.  Supplement prior_funded_addresses with all addresses
-        # present in the current scan so those UTXOs are treated as pre-existing.
-        # _just_initialized is True only on the first sync after __init__.
-        effective_funded = prior_funded_addresses
-        just_initialized = getattr(self, "_just_initialized", False)
-        if just_initialized and not prior_known_outpoints:
-            effective_funded = prior_funded_addresses | {
-                utxo.address for utxos in self.utxo_cache.values() for utxo in utxos
-            }
-        if just_initialized:
-            self._just_initialized = False  # type: ignore[assignment]
-
-        self._auto_freeze_reused_address_utxos(
-            prior_used_addresses, prior_known_outpoints, effective_funded
+        self._freeze_reused_after_sync(
+            prior_used_addresses, prior_known_outpoints, prior_funded_addresses
         )
         self._apply_frozen_state()
         return result

--- a/jmwallet/tests/test_address_reuse_freeze.py
+++ b/jmwallet/tests/test_address_reuse_freeze.py
@@ -297,3 +297,41 @@ async def test_first_sync_after_restart_keeps_existing_coins_spendable(
     assert utxo.frozen is False
     assert not ws.metadata_store.is_frozen(utxo.outpoint)
     assert ws._just_initialized is False
+
+
+async def test_reuse_is_still_frozen_on_sync_after_restart_guard(
+    tmp_path: Path,
+) -> None:
+    """The first-sync guard is one-shot: later syncs still freeze forced reuse.
+
+    The restart guard only suppresses false positives on the very first sync
+    after init. Once consumed, a dust payment that lands on a spent-empty used
+    address must still be auto-frozen, otherwise the forced-address-reuse
+    defense would be permanently disabled for the whole process lifetime.
+    """
+    ws = _make_wallet(tmp_path, max_sats_freeze_reuse=-1)
+    # Restart state: REUSED_ADDRESS is known-used but currently empty.
+    ws.addresses_with_history = {REUSED_ADDRESS}
+
+    scan: dict[int, list[UTXOInfo]] = {0: []}
+
+    async def fake_descriptor_sync(_bonds: object = None) -> dict[int, list[UTXOInfo]]:
+        ws.utxo_cache = {0: list(scan[0])}
+        return ws.utxo_cache
+
+    ws.backend.is_wallet_setup = AsyncMock(return_value=True)
+    ws.backend.list_descriptors = AsyncMock(return_value=[])
+    ws.setup_descriptor_wallet = AsyncMock(return_value=True)
+    ws._sync_all_with_descriptors = fake_descriptor_sync
+
+    # First sync after restart consumes the guard (no coins present yet).
+    await ws.sync_all()
+    assert ws._just_initialized is False
+
+    # A forced-reuse dust payment now arrives on the spent-empty used address.
+    reuse = _utxo(txid="e5" * 32, address=REUSED_ADDRESS, value=600)
+    scan[0] = [reuse]
+    await ws.sync_all()
+
+    assert reuse.frozen is True
+    assert ws.metadata_store.is_frozen(reuse.outpoint)

--- a/jmwallet/tests/test_address_reuse_freeze.py
+++ b/jmwallet/tests/test_address_reuse_freeze.py
@@ -13,6 +13,7 @@ joinmarket-clientserver's ``POLICY.max_sats_freeze_reuse`` behavior:
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -264,3 +265,35 @@ def test_default_threshold_is_freeze_all(tmp_path: Path) -> None:
     ws = WalletService(mnemonic=MNEMONIC, backend=backend, network="regtest")
     # Matches legacy default: -1 freezes all reuse.
     assert ws.max_sats_freeze_reuse == -1
+
+
+async def test_first_sync_after_restart_keeps_existing_coins_spendable(
+    tmp_path: Path,
+) -> None:
+    """sync_all on the first sync after init must not freeze existing coins.
+
+    On restart utxo_cache is empty when the pre-sync snapshot is taken while
+    addresses_with_history is restored from the metadata store, so without the
+    first-sync guard every coin on a used address looks like fresh reuse on an
+    empty address and is wrongly frozen.
+    """
+    ws = _make_wallet(tmp_path, max_sats_freeze_reuse=-1)
+    # Restart state: the address is known-used and its coin is still present.
+    ws.addresses_with_history = {REUSED_ADDRESS}
+    utxo = _utxo(txid="d4" * 32, address=REUSED_ADDRESS, value=10_000)
+
+    async def fake_descriptor_sync(_bonds=None):
+        ws.utxo_cache = {0: [utxo]}
+        return ws.utxo_cache
+
+    ws.backend.is_wallet_setup = AsyncMock(return_value=True)
+    ws.backend.list_descriptors = AsyncMock(return_value=[])
+    ws.setup_descriptor_wallet = AsyncMock(return_value=True)
+    ws._sync_all_with_descriptors = fake_descriptor_sync
+
+    assert ws._just_initialized is True
+    await ws.sync_all()
+
+    assert utxo.frozen is False
+    assert not ws.metadata_store.is_frozen(utxo.outpoint)
+    assert ws._just_initialized is False


### PR DESCRIPTION
The forced-address-reuse auto-freeze (#529) has a first-sync guard that prevents it from freezing pre-existing coins when the wallet has just been initialized. That guard was only applied on one of the three sync paths, so the path the daemon and JAM web UI actually use on wallet unlock/restart (`sync_all` -> `_sync_all_with_descriptors`) ran the auto-freeze unguarded.