### PR TITLE
feat(jmwalletd): add backend field to getinfo endpoint response

### DIFF
--- a/jmwalletd/src/jmwalletd/models.py
+++ b/jmwalletd/src/jmwalletd/models.py
@@ -115,6 +115,7 @@ class GetInfoResponse(BaseModel):
     """Response for GET /api/v1/getinfo."""
 
     version: str
+    backend: str
 
 
 class SessionResponse(BaseModel):

--- a/jmwalletd/src/jmwalletd/routers/wallet.py
+++ b/jmwalletd/src/jmwalletd/routers/wallet.py
@@ -115,10 +115,10 @@ async def _background_wallet_sync(state: DaemonState, walletname: str) -> None:
 # ---------------------------------------------------------------------------
 @router.get("/getinfo", operation_id="version")
 async def get_info() -> GetInfoResponse:
-    """Return backend version information."""
+    """Return backend information."""
     from jmcore.version import __version__
 
-    return GetInfoResponse(version=__version__)
+    return GetInfoResponse(version=__version__, backend="joinmarket-ng")
 
 
 # ---------------------------------------------------------------------------

--- a/jmwalletd/tests/test_models.py
+++ b/jmwalletd/tests/test_models.py
@@ -352,8 +352,9 @@ class TestSessionResponse:
 
 class TestMiscModels:
     def test_getinfo(self) -> None:
-        resp = GetInfoResponse(version="0.17.0")
+        resp = GetInfoResponse(version="0.17.0", backend="joinmarket-ng")
         assert resp.version == "0.17.0"
+        assert resp.backend == "joinmarket-ng"
 
     def test_list_wallets(self) -> None:
         resp = ListWalletsResponse(wallets=["a.jmdat", "b.jmdat"])

--- a/jmwalletd/tests/test_wallet_router.py
+++ b/jmwalletd/tests/test_wallet_router.py
@@ -33,11 +33,12 @@ def authed_client(
 
 
 class TestGetInfo:
-    def test_returns_version(self, client: TestClient) -> None:
+    def test_returns_version_and_backend(self, client: TestClient) -> None:
         resp = client.get("/api/v1/getinfo")
         assert resp.status_code == 200
         data = resp.json()
         assert "version" in data
+        assert data["backend"] == "joinmarket-ng"
 
 
 class TestGetSession:

--- a/tests/e2e/test_jmwalletd_api.py
+++ b/tests/e2e/test_jmwalletd_api.py
@@ -185,6 +185,7 @@ async def test_getinfo(client: httpx.AsyncClient) -> None:
     assert r.status_code == 200
     body = r.json()
     assert "version" in body
+    assert body["backend"] == "joinmarket-ng"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary
This PR adds a `backend` field to the `/api/v1/getinfo` endpoint, returning the value `"joinmarket-ng"`.
This metadata allows the Jam WebUI frontend or other clients to distinguish this implementation from the legacy client-server backend.