### PR TITLE
[jmcore] [taker] authenticate relayed maker responses by signed sender nick

### DIFF
--- a/jmcore/src/jmcore/crypto.py
+++ b/jmcore/src/jmcore/crypto.py
@@ -14,7 +14,7 @@ from coincurve import PrivateKey, PublicKey
 from coincurve import verify_signature as coincurve_verify
 from mnemonic import Mnemonic
 
-from jmcore.protocol import JM_VERSION
+from jmcore.protocol import JM_VERSION, get_nick_version
 
 NICK_HASH_LENGTH = 10
 NICK_MAX_ENCODED = 14
@@ -296,6 +296,42 @@ def verify_signature(public_key_hex: str, message: bytes, signature: bytes) -> b
         return coincurve_verify(signature, message, public_key_bytes)
     except Exception:
         return False
+
+
+def nick_from_pubkey_hex(pubkey_hex: str, version: int = JM_VERSION) -> str:
+    """Derive the JoinMarket nick a compressed pubkey maps to (J{version}{hash})."""
+    pubkey_bytes = bytes.fromhex(pubkey_hex)
+    nick_pkh_raw = hashlib.sha256(binascii.hexlify(pubkey_bytes)).digest()[:NICK_HASH_LENGTH]
+    nick_pkh = base58_encode(nick_pkh_raw)
+    nick_pkh += "O" * (NICK_MAX_ENCODED - len(nick_pkh))
+    return f"J{version}{nick_pkh}"
+
+
+def verify_signed_privmsg(
+    from_nick: str, rest: str, hostid: str = "onion-network"
+) -> tuple[bool, str, str]:
+    """Authenticate a relayed private message.
+
+    ``rest`` is ``"<command> <data...> <pubkey_hex> <sig_b64>"``. Returns
+    ``(ok, command, data)``; ``ok`` is True only when the appended pubkey hashes
+    to ``from_nick`` and the signature over ``data + hostid`` verifies. This binds
+    the message to its claimed sender so callers must never attribute by substring.
+    """
+    tokens = rest.split(" ")
+    if len(tokens) < 3:
+        return False, "", ""
+    command = tokens[0]
+    pubkey_hex = tokens[-2]
+    sig_b64 = tokens[-1]
+    data = " ".join(tokens[1:-2])
+    try:
+        if nick_from_pubkey_hex(pubkey_hex, get_nick_version(from_nick)) != from_nick:
+            return False, command, data
+        if not ecdsa_verify(data + hostid, sig_b64, bytes.fromhex(pubkey_hex)):
+            return False, command, data
+    except Exception:
+        return False, command, data
+    return True, command, data
 
 
 def strip_signature_padding(signature: bytes) -> bytes:

--- a/taker/src/taker/multi_directory.py
+++ b/taker/src/taker/multi_directory.py
@@ -14,13 +14,13 @@ import random
 from dataclasses import dataclass
 from typing import Any
 
-from jmcore.crypto import NickIdentity
+from jmcore.crypto import NickIdentity, verify_signed_privmsg
 from jmcore.deduplication import ResponseDeduplicator
 from jmcore.directory_client import DirectoryClient
 from jmcore.directory_pool import DirectoryClientPool
 from jmcore.models import Offer
-from jmcore.network import OnionPeer
-from jmcore.protocol import NOT_SERVING_ONION_HOSTNAME
+from jmcore.network import ONION_HOSTID, OnionPeer
+from jmcore.protocol import NOT_SERVING_ONION_HOSTNAME, parse_jm_message
 from loguru import logger
 
 
@@ -754,68 +754,56 @@ class MultiDirectoryClient(DirectoryClientPool):
             if not line:
                 return
 
-            # Check for !error messages from any of our expected nicks
-            if "!error" in line:
-                for nick in list(remaining_nicks):
-                    if nick in line:
-                        # Deduplicate error responses too
-                        if not deduplicator.add_response(nick, "error", line, source):
-                            logger.debug(f"Duplicate !error from {nick} via {source}")
-                            break
-                        # Extract error message after !error
-                        parts = line.split("!error", 1)
-                        error_msg = parts[1].strip() if len(parts) > 1 else "Unknown error"
-                        responses[nick] = {"error": True, "data": error_msg}
-                        remaining_nicks.discard(nick)
-                        logger.warning(f"Received !error from {nick}: {error_msg}")
-                        break
+            # Attribute strictly to the authenticated sender. Substring matching
+            # let any peer claim another maker's nick by embedding it in payload.
+            parsed = parse_jm_message(line)
+            if parsed is None:
+                return
+            from_nick = parsed[0]
+            if from_nick not in expected_nicks:
                 return
 
-            # Parse the message to find sender and command
-            if expected_command not in line:
+            ok, command, _data = verify_signed_privmsg(from_nick, parsed[2], ONION_HOSTID)
+            if not ok:
+                logger.warning(f"Dropping unverified message from {from_nick} via {source}")
                 return
 
-            # Match against expected nicks (not just remaining)
-            for nick in expected_nicks:
-                if nick in line:
-                    # For accumulating responses (like !sig), skip deduplication
-                    # since we expect multiple messages from the same maker
-                    if not accumulate_responses:
-                        # Check for duplicate response from another directory
-                        if not deduplicator.add_response(nick, expected_command, line, source):
-                            logger.debug(f"Duplicate {expected_command} from {nick} via {source}")
-                            break
+            # Preserve the downstream payload contract (data plus pubkey/sig suffix).
+            payload = parsed[2].split(" ", 1)[1].strip() if " " in parsed[2] else ""
 
-                    # Extract data after the command
-                    parts = line.split(expected_command, 1)
-                    if len(parts) > 1:
-                        data = parts[1].strip()
-                        if accumulate_responses:
-                            # Accumulate multiple !sig messages, but deduplicate by content
-                            # to avoid counting the same sig relayed via multiple directories.
-                            nick_seen = seen_sig_data.setdefault(nick, set())
-                            if data in nick_seen:
-                                logger.debug(
-                                    f"Duplicate {expected_command} content from {nick} "
-                                    f"via {source} -- dropped"
-                                )
-                                break
-                            nick_seen.add(data)
-                            if nick not in responses:
-                                responses[nick] = {"data": []}
-                                remaining_nicks.discard(nick)
-                            responses[nick]["data"].append(data)
-                            logger.debug(
-                                f"Received {expected_command} "
-                                f"#{len(responses[nick]['data'])} "
-                                f"from {nick} via {source}"
-                            )
-                        else:
-                            # Single response (original behavior)
-                            responses[nick] = {"data": data}
-                            remaining_nicks.discard(nick)
-                            logger.debug(f"Received {expected_command} from {nick} via {source}")
-                    break
+            if command == "error":
+                if not deduplicator.add_response(from_nick, "error", line, source):
+                    return
+                responses[from_nick] = {"error": True, "data": _data or "Unknown error"}
+                remaining_nicks.discard(from_nick)
+                logger.warning(f"Received error from {from_nick}: {_data}")
+                return
+
+            if command != expected_command.lstrip("!"):
+                return
+
+            if not accumulate_responses:
+                if not deduplicator.add_response(from_nick, expected_command, line, source):
+                    logger.debug(f"Duplicate {expected_command} from {from_nick} via {source}")
+                    return
+                responses[from_nick] = {"data": payload}
+                remaining_nicks.discard(from_nick)
+                logger.debug(f"Received {expected_command} from {from_nick} via {source}")
+            else:
+                # Accumulate !sig messages, deduplicating identical content relayed
+                # by multiple directories.
+                nick_seen = seen_sig_data.setdefault(from_nick, set())
+                if payload in nick_seen:
+                    return
+                nick_seen.add(payload)
+                if from_nick not in responses:
+                    responses[from_nick] = {"data": []}
+                    remaining_nicks.discard(from_nick)
+                responses[from_nick]["data"].append(payload)
+                logger.debug(
+                    f"Received {expected_command} #{len(responses[from_nick]['data'])} "
+                    f"from {from_nick} via {source}"
+                )
 
         while not is_complete():
             elapsed = asyncio.get_event_loop().time() - start_time

--- a/taker/tests/test_response_authentication.py
+++ b/taker/tests/test_response_authentication.py
@@ -1,0 +1,100 @@
+"""Authentication of relayed maker responses in wait_for_responses.
+
+A malicious peer must not be able to have its response attributed to another
+maker by embedding that maker's nick in its payload, nor to impersonate a maker
+without its signing key.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _taker_test_helpers import make_directory_client
+from jmcore.crypto import NickIdentity
+from jmcore.network import ONION_HOSTID
+
+
+def signed_line(identity: NickIdentity, recipient: str, command: str, data: str) -> str:
+    """Build a directory-relayed, signed JM privmsg line."""
+    return f"{identity.nick}!{recipient}!{command} {identity.sign_message(data, ONION_HOSTID)}"
+
+
+async def run(client, expected_nicks, command, lines, counts=None):
+    for line in lines:
+        await client._direct_message_queue.put({"line": line, "source": "dir1"})
+    client.clients = {}
+    return await client.wait_for_responses(
+        expected_nicks=expected_nicks,
+        expected_command=command,
+        timeout=1.0,
+        expected_counts=counts,
+    )
+
+
+@pytest.mark.asyncio
+async def test_legit_signed_response_accepted():
+    client = make_directory_client()
+    maker = NickIdentity(5)
+    line = signed_line(maker, client.nick_identity.nick, "pubkey", "MAKER_NACL features=ping")
+    responses = await run(client, [maker.nick], "!pubkey", [line])
+    assert maker.nick in responses
+    assert responses[maker.nick]["data"].split()[0] == "MAKER_NACL"
+
+
+@pytest.mark.asyncio
+async def test_embedded_victim_nick_not_attributed_to_victim():
+    client = make_directory_client()
+    victim = NickIdentity(5)
+    attacker = NickIdentity(5)
+    # Attacker sends its own validly-signed !pubkey but embeds the victim nick.
+    data = f"ATTACKER_NACL {victim.nick}"
+    line = signed_line(attacker, client.nick_identity.nick, "pubkey", data)
+    responses = await run(client, [victim.nick, attacker.nick], "!pubkey", [line])
+    assert responses[attacker.nick]["data"].split()[0] == "ATTACKER_NACL"
+    # The honest maker's session must remain unset, never keyed to the attacker.
+    assert victim.nick not in responses
+
+
+@pytest.mark.asyncio
+async def test_forged_from_nick_rejected():
+    client = make_directory_client()
+    victim = NickIdentity(5)
+    attacker = NickIdentity(5)
+    # Attacker claims the victim's nick in the envelope but signs with its own key.
+    signed = attacker.sign_message("ATTACKER_NACL", ONION_HOSTID)
+    line = f"{victim.nick}!{client.nick_identity.nick}!pubkey {signed}"
+    responses = await run(client, [victim.nick], "!pubkey", [line])
+    assert victim.nick not in responses
+
+
+@pytest.mark.asyncio
+async def test_spoofed_error_does_not_abort_victim():
+    client = make_directory_client()
+    victim = NickIdentity(5)
+    attacker = NickIdentity(5)
+    # Valid message from attacker whose payload contains "!error" and victim nick.
+    data = f"x !error blacklist {victim.nick}"
+    line = signed_line(attacker, client.nick_identity.nick, "pubkey", data)
+    responses = await run(client, [victim.nick, attacker.nick], "!pubkey", [line])
+    assert not responses.get(victim.nick, {}).get("error")
+    assert victim.nick not in responses
+
+
+@pytest.mark.asyncio
+async def test_tampered_payload_dropped():
+    client = make_directory_client()
+    maker = NickIdentity(5)
+    signed = maker.sign_message("MAKER_NACL", ONION_HOSTID)
+    tampered = "pubkey TAMPERED " + signed.split(" ", 1)[1]
+    line = f"{maker.nick}!{client.nick_identity.nick}!{tampered}"
+    responses = await run(client, [maker.nick], "!pubkey", [line])
+    assert maker.nick not in responses
+
+
+@pytest.mark.asyncio
+async def test_genuine_error_from_maker_recorded():
+    client = make_directory_client()
+    maker = NickIdentity(5)
+    line = signed_line(maker, client.nick_identity.nick, "error", "commitment-blacklisted")
+    responses = await run(client, [maker.nick], "!pubkey", [line])
+    assert responses[maker.nick]["error"] is True
+    assert "commitment-blacklisted" in responses[maker.nick]["data"]

--- a/taker/tests/test_taker_protocol.py
+++ b/taker/tests/test_taker_protocol.py
@@ -21,8 +21,10 @@ from _taker_test_helpers import (
     make_taker_config,
     make_utxo,
 )
+from jmcore.crypto import NickIdentity
 from jmcore.encryption import CryptoSession
 from jmcore.models import Offer, OfferType
+from jmcore.network import ONION_HOSTID
 from jmwallet.wallet.models import UTXOInfo
 
 from taker.multi_directory import ChannelBinding
@@ -605,12 +607,15 @@ class TestMultiDirectoryClientDirectConnections:
 
         client = make_directory_client()
 
-        maker_nick = "J5TestMaker"
+        maker = NickIdentity(5)
+        maker_nick = maker.nick
         sig_data = "deadbeefdeadbeef"
-        # Craft two raw message lines that look like they came from different
-        # directory servers but carry identical !sig payload.
-        msg_dir1 = {"line": f"{maker_nick} !sig {sig_data}", "source": "dir1"}
-        msg_dir2 = {"line": f"{maker_nick} !sig {sig_data}", "source": "dir2"}
+        # Two signed lines relayed by different directory servers but carrying
+        # the identical, validly-signed !sig payload from the same maker.
+        signed = maker.sign_message(sig_data, ONION_HOSTID)
+        line = f"{maker_nick}!{client.nick_identity.nick}!sig {signed}"
+        msg_dir1 = {"line": line, "source": "dir1"}
+        msg_dir2 = {"line": line, "source": "dir2"}
 
         # Pre-load both messages into the direct queue so wait_for_responses
         # drains them without actually opening network connections.
@@ -629,7 +634,7 @@ class TestMultiDirectoryClientDirectConnections:
 
         assert maker_nick in responses
         assert len(responses[maker_nick]["data"]) == 1
-        assert responses[maker_nick]["data"][0] == sig_data
+        assert responses[maker_nick]["data"][0].split()[0] == sig_data
 
 
 # --- Tests for Sweep Mode CJ Amount Preservation ---


### PR DESCRIPTION
The taker matches maker responses to nicks using **substring containment** over the raw relayed line and the per-message nick signature is **never verified on receipt**. In `wait_for_responses` / `process_message`
(`taker/src/taker/multi_directory.py`):

```python
if "!error" in line: ...
if expected_command not in line: ...
for nick in expected_nicks:
    if nick in line:   # attacker-controlled payload
```

Every JM private message is sent as `from_nick!to_nick!<cmd> <data> <pubkey_hex> <sig_b64>` and signed by
`NickIdentity.sign_message` but nothing in the taker/maker/directory receive path verifies that signature or binds the pubkey to `from_nick` (the only inbound check, the `!ioauth` btc_sig at `coinjoin_session.py:661`, is explicitly non-fatal).