### PR TITLE
[jmcore] reject pathological relative cjfee in offer parsing

### DIFF
--- a/jmcore/src/jmcore/directory_client.py
+++ b/jmcore/src/jmcore/directory_client.py
@@ -135,6 +135,23 @@ def parse_fidelity_bond_proof(
         return None
 
 
+def normalize_relative_cjfee(cjfee_str: str) -> str:
+    """Validate and fixed-point format a peer-supplied relative cjfee.
+
+    Relative fees are small non-negative fractions. Reject pathological Decimals
+    before ``format(value, "f")``, which would otherwise expand a tiny string
+    like ``"1E-9999999999"`` into gigabytes and OOM the orderbook parser.
+    """
+    value = Decimal(cjfee_str)
+    if not value.is_finite():
+        raise ValueError(f"Non-finite cjfee: {cjfee_str}")
+    sign, digits, exp = value.as_tuple()
+    # exp is an int for finite Decimals (the str sentinels only occur for NaN/Inf).
+    if sign or len(digits) > 32 or not isinstance(exp, int) or not (-32 <= exp <= 32):
+        raise ValueError(f"Unreasonable cjfee: {cjfee_str}")
+    return format(value, "f")
+
+
 class DirectoryClient:
     """
     Client for connecting to JoinMarket directory servers.
@@ -1381,10 +1398,7 @@ class DirectoryClient:
                 if offer_type in ["sw0absoffer", "swabsoffer"]:
                     cjfee = str(int(cjfee_str))
                 else:
-                    # Use fixed-point format to avoid scientific notation
-                    # (e.g., Decimal("0.000000001") -> "1E-9" with str(),
-                    # but "0.000000001" with format(..., "f"))
-                    cjfee = format(Decimal(cjfee_str), "f")
+                    cjfee = normalize_relative_cjfee(cjfee_str)
 
                 offer = Offer(
                     counterparty=from_nick,

--- a/jmcore/tests/test_offer_cjfee_dos.py
+++ b/jmcore/tests/test_offer_cjfee_dos.py
@@ -1,0 +1,39 @@
+"""Relative cjfee normalization must reject pathological peer input.
+
+A public offer's cjfee is attacker-controlled. ``format(Decimal(x), "f")`` on a
+tiny string with a huge exponent expands to gigabytes, so a single offer could
+OOM every peer parsing the orderbook.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from jmcore.directory_client import normalize_relative_cjfee
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("0.0001", "0.0001"),
+        ("1E-9", "0.000000001"),
+        ("0", "0"),
+        ("0.00015", "0.00015"),
+    ],
+)
+def test_legitimate_fees_normalized(raw, expected):
+    assert normalize_relative_cjfee(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ["1E-9999999999", "1E999999999", "1E-100000", "NaN", "Inf", "-0.5", "9" * 64],
+)
+def test_pathological_fees_rejected_fast(hostile):
+    start = time.monotonic()
+    with pytest.raises(ValueError):
+        normalize_relative_cjfee(hostile)
+    # Rejected by inspecting the Decimal, never by expanding it.
+    assert time.monotonic() - start < 1.0


### PR DESCRIPTION
A public offer's relative cjfee is attacker-controlled and is fixed-point formatted with no validation in `_parse_offer_from_message` (`jmcore/src/jmcore/directory_client.py`):

```python
cjfee = format(Decimal(cjfee_str), "f")
```

`format(Decimal("1E-9999999999"), "f")` expands a tiny string into a number with billions of digits. Offers are public, unsigned `PUBMSG`s broadcast to every peer, so a single crafted offer forces a multi-GB allocation and **OOM-kills every taker and orderbook_watcher** parsing the orderbook. (Python's 4300-digit `int()` guard does not cover `Decimal` formatting.) Measured: `1E-50000000` produces a 50 MB string in ~0.08 s; it scales linearly.

This was also rediscovered independently by an Atheris fuzz harness over the offer-parsing path.

## Fuzzing logs

```
INFO: Using built-in libfuzzer
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 2933980607
INFO:        1 files found in corpus/offer
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: seed corpus: files: 1 min: 6b max: 6b total: 6b rss: 73Mb
#2	INITED exec/s: 0 rss: 73Mb
#296	NEW    cov: 22 ft: 22 corp: 2/5b lim: 6 exec/s: 0 rss: 73Mb L: 4/4 MS: 4 ShuffleBytes-CrossOver-CrossOver-InsertByte-
#311	REDUCE cov: 22 ft: 22 corp: 2/4b lim: 6 exec/s: 0 rss: 73Mb L: 3/3 MS: 5 EraseBytes-EraseBytes-InsertByte-ChangeByte-InsertByte-
#51026	REDUCE cov: 23 ft: 23 corp: 3/8b lim: 509 exec/s: 0 rss: 73Mb L: 4/4 MS: 5 EraseBytes-CrossOver-ShuffleBytes-InsertByte-InsertByte-
#262144	pulse  cov: 23 ft: 23 corp: 3/8b lim: 2600 exec/s: 131072 rss: 73Mb
#524288	pulse  cov: 23 ft: 23 corp: 3/8b lim: 4096 exec/s: 131072 rss: 73Mb
#754456	NEW    cov: 23 ft: 26 corp: 4/114b lim: 4096 exec/s: 125742 rss: 73Mb L: 106/106 MS: 4 ChangeBit-InsertRepeatedBytes-EraseBytes-InsertByte-
#754512	REDUCE cov: 23 ft: 26 corp: 4/105b lim: 4096 exec/s: 125752 rss: 73Mb L: 97/97 MS: 1 EraseBytes-
#754638	REDUCE cov: 23 ft: 26 corp: 4/102b lim: 4096 exec/s: 125773 rss: 73Mb L: 94/94 MS: 1 EraseBytes-
#754649	REDUCE cov: 23 ft: 26 corp: 4/90b lim: 4096 exec/s: 125774 rss: 73Mb L: 82/82 MS: 1 EraseBytes-
#755460	REDUCE cov: 23 ft: 26 corp: 4/87b lim: 4096 exec/s: 125910 rss: 73Mb L: 79/79 MS: 1 EraseBytes-
#756111	REDUCE cov: 23 ft: 26 corp: 4/77b lim: 4096 exec/s: 126018 rss: 73Mb L: 69/69 MS: 1 EraseBytes-

 === Uncaught Python exception: ===
MemoryError: <EMPTY MESSAGE>
Traceback (most recent call last):
  File "/home/test/fuzz/harnesses/fuzz_offer.py", line 22, in TestOneInput
    cjfee = format(Decimal(cjfee_str), "f")  # <-- DoS candidate
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
MemoryError: <EMPTY MESSAGE>

==596716== ERROR: libFuzzer: fuzz target exited
SUMMARY: libFuzzer: fuzz target exited
MS: 1 ChangeBinInt-; base unit: dfb784e7f1789e9b79ec791844a78a016ac9f90e
0x3d,0x32,...,0x45,0x32,0x32,0x32,0x32,0x32,0x32,0x32,0x32,0x32,0x32,0x32,...
=22222222222222.22222222222222222222222222222222E22222222222222222.1+
artifact_prefix='findings/offer_'; Test unit written to findings/offer_crash-17cb02d6621d75b7ec6dffafc4f4f3af31cb5d28
Base64: PTIyMjIyMjIyMjIyMjIyLjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyRTIyMjIyMjIyMjIyMjIyMjIyLjEr
```

Decoding the crashing artifact through the harness's `FuzzedDataProvider` yields the
offer field that triggers it:

```
offer_type = swreloffer
cjfee_str  = '22222222222222.22222222222222222222222222222222E222222222222'
```

`format(Decimal("…E222222222222"), "f")` attempts to materialize a ~222-billion-digit
string → `MemoryError`. With this PR, the same input is rejected before expansion:

```
>>> normalize_relative_cjfee("22222222222222.22222222222222222222222222222222E222222222222")
ValueError: Unreasonable cjfee: 22222222222222.…E222222222222
```
