### PR TITLE
[taker] authenticate maker !ioauth against its declared UTXOs

### DIFF
--- a/taker/src/taker/coinjoin_session.py
+++ b/taker/src/taker/coinjoin_session.py
@@ -627,7 +627,7 @@ class CoinJoinSession:
 
                     # Parse: <utxo_list> <auth_pub> <cj_addr> <change_addr> <btc_sig>
                     ioauth_parts = decrypted.split()
-                    if len(ioauth_parts) < 4:
+                    if len(ioauth_parts) < 5:
                         logger.warning(
                             f"Invalid !ioauth format from {nick}: expected 5 parts, "
                             f"got {len(ioauth_parts)}"
@@ -641,32 +641,18 @@ class CoinJoinSession:
                     cj_addr = ioauth_parts[2]
                     change_addr = ioauth_parts[3]
 
-                    # Verify btc_sig if present - proves maker owns the UTXO
-                    # NOTE: BTC sig verification is OPTIONAL per JoinMarket protocol
-                    # It provides additional security by proving maker controls the UTXO
-                    # but not all makers may provide it
-                    if len(ioauth_parts) >= 5:
-                        btc_sig = ioauth_parts[4]
-                        # The signature is over the maker's NaCl pubkey
-                        from jmcore.crypto import ecdsa_verify
+                    # The maker must prove control of its auth key by signing its
+                    # NaCl pubkey with it. An unauthenticated session lets a
+                    # malicious directory substitute the maker's encryption key and
+                    # MITM the channel, so a failing btc_sig is fatal.
+                    btc_sig = ioauth_parts[4]
+                    from jmcore.crypto import ecdsa_verify
 
-                        maker_nacl_pk = session.pubkey  # Maker's NaCl pubkey from !pubkey
-                        auth_pub_bytes = bytes.fromhex(auth_pub)
-                        logger.debug(
-                            f"Verifying BTC sig from {nick}: "
-                            f"message={maker_nacl_pk[:32]}..., "
-                            f"sig={btc_sig[:32]}..., "
-                            f"pubkey={auth_pub[:16]}..."
-                        )
-                        if not ecdsa_verify(maker_nacl_pk, btc_sig, auth_pub_bytes):
-                            logger.warning(
-                                f"BTC signature verification failed from {nick} - "
-                                f"continuing anyway (optional security feature)"
-                            )
-                            # NOTE: We don't delete the session here - BTC sig is optional
-                            # The transaction verification will still protect against fraud
-                        else:
-                            logger.info(f"BTC signature verified for {nick}")
+                    if not ecdsa_verify(session.pubkey, btc_sig, bytes.fromhex(auth_pub)):
+                        logger.warning(f"btc_sig verification failed from {nick}, dropping")
+                        failed_makers.append(nick)
+                        del self.maker_sessions[nick]
+                        continue
 
                     # Parse utxo_list using protocol helper
                     # (handles both legacy and extended format)
@@ -765,6 +751,15 @@ class CoinJoinSession:
                             f"Dropping maker {nick}: one or more UTXOs failed "
                             "Neutrino verification (likely already spent)"
                         )
+                        failed_makers.append(nick)
+                        del self.maker_sessions[nick]
+                        continue
+
+                    # Tie the authenticated session to on-chain ownership: the auth
+                    # pubkey must own one of the maker's declared UTXOs.
+                    auth_spk = pubkey_to_p2wpkh_script(bytes.fromhex(auth_pub)).hex()
+                    if not any(u.get("scriptpubkey", "") == auth_spk for u in session.utxos):
+                        logger.warning(f"auth_pub from {nick} matches no declared UTXO, dropping")
                         failed_makers.append(nick)
                         del self.maker_sessions[nick]
                         continue

--- a/taker/src/taker/coinjoin_session.py
+++ b/taker/src/taker/coinjoin_session.py
@@ -21,7 +21,7 @@ import asyncio
 import time
 from typing import TYPE_CHECKING, Any
 
-from jmcore.bitcoin import get_txid, parse_transaction
+from jmcore.bitcoin import get_txid, parse_transaction, pubkey_to_p2wpkh_script
 from jmcore.encryption import CryptoSession
 from jmcore.protocol import FEATURE_NEUTRINO_COMPAT, parse_utxo_list
 from jmwallet.history import (
@@ -684,6 +684,7 @@ class CoinJoinSession:
                     for utxo_meta in utxo_metadata_list:
                         txid = utxo_meta.txid
                         vout = utxo_meta.vout
+                        scriptpubkey = ""
 
                         # Verify UTXO and get value/address
                         try:
@@ -701,6 +702,7 @@ class CoinJoinSession:
                                 if result.valid:
                                     value = result.value
                                     address = ""  # Not available from verification
+                                    scriptpubkey = utxo_meta.scriptpubkey or ""
                                     logger.debug(
                                         f"Neutrino-verified UTXO {txid}:{vout} = {value} sats"
                                     )
@@ -717,6 +719,7 @@ class CoinJoinSession:
                                 if utxo_info:
                                     value = utxo_info.value
                                     address = utxo_info.address
+                                    scriptpubkey = utxo_info.scriptpubkey or ""
                                 else:
                                     # Fallback: get raw transaction and parse it
                                     tx_info = await self.backend.get_transaction(txid)
@@ -724,6 +727,7 @@ class CoinJoinSession:
                                         parsed_tx = parse_transaction(tx_info.raw)
                                         if parsed_tx and len(parsed_tx.outputs) > vout:
                                             value = parsed_tx.outputs[vout].value
+                                            scriptpubkey = parsed_tx.outputs[vout].script.hex()
                                             try:
                                                 address = parsed_tx.outputs[vout].address(
                                                     self.config.network
@@ -751,6 +755,7 @@ class CoinJoinSession:
                                 "vout": vout,
                                 "value": value,
                                 "address": address,
+                                "scriptpubkey": scriptpubkey,
                             }
                         )
                         logger.debug(f"Added UTXO from {nick}: {txid}:{vout} = {value} sats")
@@ -1403,6 +1408,16 @@ class CoinJoinSession:
                             txid, vout = input_map[idx]
                             utxo = maker_utxo_map[(txid, vout)]
                             value = utxo["value"]
+
+                            # Bind the maker-supplied pubkey to this UTXO's own
+                            # scriptPubKey. Without this a signature by any key
+                            # verifies for a UTXO the maker does not control,
+                            # yielding a consensus-invalid coinjoin.
+                            utxo_spk = utxo.get("scriptpubkey", "")
+                            if not utxo_spk or bytes.fromhex(utxo_spk) != pubkey_to_p2wpkh_script(
+                                pubkey
+                            ):
+                                continue
 
                             # Create scriptCode for verification
                             script_code = create_p2wpkh_script_code(pubkey)

--- a/taker/src/taker/coinjoin_session.py
+++ b/taker/src/taker/coinjoin_session.py
@@ -756,9 +756,14 @@ class CoinJoinSession:
                         continue
 
                     # Tie the authenticated session to on-chain ownership: the auth
-                    # pubkey must own one of the maker's declared UTXOs.
+                    # pubkey must own one of the maker's declared UTXOs. Compare
+                    # case-insensitively: for neutrino peers the scriptPubKey is
+                    # peer-supplied hex whose case is not normalized (matching the
+                    # case-insensitive signing-phase check via bytes.fromhex).
                     auth_spk = pubkey_to_p2wpkh_script(bytes.fromhex(auth_pub)).hex()
-                    if not any(u.get("scriptpubkey", "") == auth_spk for u in session.utxos):
+                    if not any(
+                        u.get("scriptpubkey", "").lower() == auth_spk for u in session.utxos
+                    ):
                         logger.warning(f"auth_pub from {nick} matches no declared UTXO, dropping")
                         failed_makers.append(nick)
                         del self.maker_sessions[nick]

--- a/taker/tests/test_taker_protocol.py
+++ b/taker/tests/test_taker_protocol.py
@@ -1852,7 +1852,9 @@ class TestPhaseAuthMakerAuthentication:
     """
 
     @staticmethod
-    async def _drive_phase_auth(*, auth_owns_utxo: bool, valid_btc_sig: bool):
+    async def _drive_phase_auth(
+        *, auth_owns_utxo: bool, valid_btc_sig: bool, spk_upper: bool = False
+    ):
         from coincurve import PrivateKey
         from jmcore.bitcoin import pubkey_to_p2wpkh_script
         from jmcore.crypto import ecdsa_sign
@@ -1881,6 +1883,10 @@ class TestPhaseAuthMakerAuthentication:
         # The UTXO's real scriptPubKey is owned by auth_key, or by an unrelated key.
         owner_pub = auth_pub if auth_owns_utxo else PrivateKey().public_key.format(compressed=True)
         stored_spk = pubkey_to_p2wpkh_script(owner_pub).hex()
+        if spk_upper:
+            # Neutrino peers supply the scriptPubKey hex verbatim; its case is
+            # not normalized, so the auth binding must be case-insensitive.
+            stored_spk = stored_spk.upper()
 
         # btc_sig over the maker's NaCl pubkey, by auth_key (valid) or a wrong key.
         signer = auth_key if valid_btc_sig else PrivateKey()
@@ -1959,3 +1965,17 @@ class TestPhaseAuthMakerAuthentication:
         )
         assert result.success is False
         assert nick not in session_state.maker_sessions
+
+    @pytest.mark.asyncio
+    async def test_accepts_authenticated_maker_with_uppercase_scriptpubkey(self):
+        """The auth binding must be case-insensitive.
+
+        Neutrino peers supply the UTXO scriptPubKey as unnormalized hex, so an
+        uppercase (but otherwise correct) scriptPubKey must still authenticate.
+        """
+        result, session_state, nick = await self._drive_phase_auth(
+            auth_owns_utxo=True, valid_btc_sig=True, spk_upper=True
+        )
+        assert result.success is True
+        assert nick in session_state.maker_sessions
+        assert session_state.maker_sessions[nick].responded_auth is True

--- a/taker/tests/test_taker_protocol.py
+++ b/taker/tests/test_taker_protocol.py
@@ -1842,3 +1842,120 @@ async def test_do_coinjoin_refreshes_maker_nick_exclusion(
         if mock_select.called:
             # If selection was attempted, the nick must already be excluded.
             assert "J5LateStartMaker" in taker.orderbook_manager.own_wallet_nicks
+
+
+class TestPhaseAuthMakerAuthentication:
+    """_phase_auth must authenticate the maker's !ioauth: a valid btc_sig over its
+    NaCl pubkey by an auth key that owns one of its declared UTXOs. Otherwise a
+    malicious directory could substitute the maker's encryption key and MITM the
+    channel, or a maker could authenticate with a UTXO it does not control.
+    """
+
+    @staticmethod
+    async def _drive_phase_auth(*, auth_owns_utxo: bool, valid_btc_sig: bool):
+        from coincurve import PrivateKey
+        from jmcore.bitcoin import pubkey_to_p2wpkh_script
+        from jmcore.crypto import ecdsa_sign
+        from jmwallet.backends.base import UTXO
+
+        from taker.coinjoin_session import CoinJoinSession
+
+        offer = Offer(
+            counterparty="J5maker",
+            oid=0,
+            ordertype=OfferType.SW0_RELATIVE,
+            minsize=100_000,
+            maxsize=10_000_000,
+            txfee=0,
+            cjfee="0.001",
+            fidelity_bond_value=0,
+        )
+
+        taker_crypto, maker_crypto = make_crypto_pair()
+        maker_nacl_pk_hex = maker_crypto.get_pubkey_hex()
+
+        auth_key = PrivateKey()
+        auth_pub = auth_key.public_key.format(compressed=True)
+        txid, vout, value = "b" * 64, 0, 1_500_000
+
+        # The UTXO's real scriptPubKey is owned by auth_key, or by an unrelated key.
+        owner_pub = auth_pub if auth_owns_utxo else PrivateKey().public_key.format(compressed=True)
+        stored_spk = pubkey_to_p2wpkh_script(owner_pub).hex()
+
+        # btc_sig over the maker's NaCl pubkey, by auth_key (valid) or a wrong key.
+        signer = auth_key if valid_btc_sig else PrivateKey()
+        btc_sig = ecdsa_sign(maker_nacl_pk_hex, signer.secret)
+
+        ioauth = f"{txid}:{vout} {auth_pub.hex()} bcrt1qcj bcrt1qchange {btc_sig}"
+        encrypted = maker_crypto.encrypt(ioauth)
+
+        nick = "J5maker"
+        session = MakerSession(nick=nick, offer=offer, pubkey=maker_nacl_pk_hex)
+        object.__setattr__(session, "crypto", taker_crypto)
+
+        with patch.object(Taker, "__init__", lambda self, *a, **k: None):
+            taker = Taker.__new__(Taker)
+            taker._session = CoinJoinSession()
+            taker._session.attach(taker)
+            taker.wallet = MagicMock()
+            taker.backend = AsyncMock()
+            taker.backend.requires_neutrino_metadata = MagicMock(return_value=False)
+            taker.backend.get_utxo = AsyncMock(
+                return_value=UTXO(
+                    txid=txid,
+                    vout=vout,
+                    value=value,
+                    address="bcrt1qtest",
+                    confirmations=3,
+                    scriptpubkey=stored_spk,
+                )
+            )
+            taker.config = MagicMock()
+            taker.config.minimum_makers = 1
+            taker.config.maker_timeout_sec = 5
+
+            dc = MagicMock()
+            dc.send_privmsg = AsyncMock()
+            dc.upgrade_channel_prefer_direct = MagicMock(side_effect=lambda n, ch: ch)
+            dc.wait_for_responses = AsyncMock(return_value={nick: {"data": encrypted}})
+            taker.directory_client = dc
+
+            commitment = MagicMock()
+            commitment.has_neutrino_metadata.return_value = False
+            commitment.to_revelation.return_value = {
+                "utxo": f"{txid}:{vout}",
+                "P": "00",
+                "P2": "00",
+                "sig": "00",
+                "e": "00",
+            }
+            taker._session.podle_commitment = commitment
+            taker._session.maker_sessions = {nick: session}
+
+            result = await taker._session._phase_auth()
+            return result, taker._session, nick
+
+    @pytest.mark.asyncio
+    async def test_accepts_authenticated_maker(self):
+        result, session_state, nick = await self._drive_phase_auth(
+            auth_owns_utxo=True, valid_btc_sig=True
+        )
+        assert result.success is True
+        assert nick in session_state.maker_sessions
+        assert session_state.maker_sessions[nick].responded_auth is True
+
+    @pytest.mark.asyncio
+    async def test_rejects_maker_with_invalid_btc_sig(self):
+        result, session_state, nick = await self._drive_phase_auth(
+            auth_owns_utxo=True, valid_btc_sig=False
+        )
+        assert result.success is False
+        assert nick not in session_state.maker_sessions
+
+    @pytest.mark.asyncio
+    async def test_rejects_maker_whose_auth_pub_owns_no_declared_utxo(self):
+        result, session_state, nick = await self._drive_phase_auth(
+            auth_owns_utxo=False, valid_btc_sig=True
+        )
+        assert result.success is False
+        assert nick not in session_state.maker_sessions

--- a/taker/tests/test_taker_signing.py
+++ b/taker/tests/test_taker_signing.py
@@ -4,11 +4,13 @@ Tests for taker transaction signing functionality.
 
 from __future__ import annotations
 
+import base64
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from jmcore.bitcoin import pubkey_to_p2wpkh_script
 from jmwallet.wallet.bip32 import HDKey, mnemonic_to_seed
 from jmwallet.wallet.models import UTXOInfo
 from jmwallet.wallet.signing import (
@@ -810,6 +812,106 @@ class TestPhaseCollectSignaturesCompleteness:
             "doesn't respond. The old minimum_makers check would have "
             "incorrectly allowed this."
         )
+
+    def _maker1_sig_response(self, tx_bytes: bytes, privkey: Any) -> str:
+        """Build a valid base64 !sig payload for maker1's input signed by ``privkey``."""
+        from jmwallet.wallet.signing import (
+            create_p2wpkh_script_code,
+            sign_p2wpkh_input,
+        )
+
+        tx = deserialize_transaction(tx_bytes)
+        index_map = {(ti.txid_le[::-1].hex(), ti.vout): idx for idx, ti in enumerate(tx.inputs)}
+        idx = index_map[("b" * 64, 0)]
+        pub = privkey.public_key.format(compressed=True)
+        sig = sign_p2wpkh_input(tx, idx, create_p2wpkh_script_code(pub), 1_500_000, privkey)
+        payload = bytes([len(sig)]) + sig + bytes([len(pub)]) + pub
+        return base64.b64encode(payload).decode()
+
+    def _collect_with_maker1(
+        self, two_maker_tx_data: CoinJoinTxData, maker1_scriptpubkey: str, privkey: Any
+    ) -> Any:
+        """Drive a round where only maker1 responds (with a real signature).
+
+        maker2 stays silent, so the round always fails; whether maker1's signature
+        is accepted is isolated in maker1's own session state.
+        """
+        from jmcore.models import Offer, OfferType
+
+        offer = Offer(
+            counterparty="maker1",
+            oid=0,
+            ordertype=OfferType.SW0_RELATIVE,
+            minsize=100_000,
+            maxsize=10_000_000,
+            txfee=0,
+            cjfee="0.001",
+            fidelity_bond_value=0,
+        )
+        maker_sessions = {
+            "maker1": self._make_maker_session(
+                "maker1",
+                offer,
+                [
+                    {
+                        "txid": "b" * 64,
+                        "vout": 0,
+                        "value": 1_500_000,
+                        "scriptpubkey": maker1_scriptpubkey,
+                    }
+                ],
+            ),
+            "maker2": self._make_maker_session(
+                "maker2", offer, [{"txid": "c" * 64, "vout": 0, "value": 1_200_000}]
+            ),
+        }
+        taker = self._build_taker_with_tx(two_maker_tx_data, maker_sessions=maker_sessions)
+        sig_b64 = self._maker1_sig_response(taker._session.unsigned_tx, privkey)
+        maker_sessions["maker1"].crypto.decrypt = MagicMock(return_value=sig_b64)
+        taker.directory_client.wait_for_responses = AsyncMock(
+            return_value={"maker1": {"data": [sig_b64]}}
+        )
+        return taker
+
+    @pytest.mark.asyncio
+    async def test_accepts_maker_signature_bound_to_its_utxo(
+        self, two_maker_tx_data: CoinJoinTxData
+    ) -> None:
+        """A valid signature whose pubkey owns the UTXO scriptPubKey is accepted."""
+        from coincurve import PrivateKey
+
+        maker1_key = PrivateKey()
+        spk = pubkey_to_p2wpkh_script(maker1_key.public_key.format(compressed=True)).hex()
+        taker = self._collect_with_maker1(two_maker_tx_data, spk, maker1_key)
+
+        result = await taker._session._phase_collect_signatures()
+
+        assert result is False  # maker2 stayed silent
+        assert taker._session.maker_sessions["maker1"].responded_sig is True
+
+    @pytest.mark.asyncio
+    async def test_rejects_maker_signature_not_bound_to_its_utxo(
+        self, two_maker_tx_data: CoinJoinTxData
+    ) -> None:
+        """A valid signature whose pubkey does not own the UTXO must be rejected.
+
+        Regression test: the taker previously derived the verification scriptCode
+        from the maker-supplied pubkey without checking that the pubkey controls
+        the UTXO, so a maker could pass verification with a key it does not own,
+        producing a consensus-invalid coinjoin.
+        """
+        from coincurve import PrivateKey
+
+        maker1_key = PrivateKey()
+        other_key = PrivateKey()
+        # The UTXO is owned by other_key, but maker1 signs with maker1_key.
+        spk = pubkey_to_p2wpkh_script(other_key.public_key.format(compressed=True)).hex()
+        taker = self._collect_with_maker1(two_maker_tx_data, spk, maker1_key)
+
+        result = await taker._session._phase_collect_signatures()
+
+        assert result is False
+        assert "maker1" not in taker._session.maker_sessions
 
 
 # Re-export fixtures for use in conftest


### PR DESCRIPTION
Built on top of #554

Introduced by 19221f29. It added the `btc_sig` check as optional (non-fatal) without binding `auth_pub` to a UTXO; f251a5e8 later moved it into `coinjoin_session.py`.

Legacy joinmarket is not affected. Its `auth_counterparty` rejects an invalid `btc_sig` and `_verify_ioauth_inputs` requires `auth_pub` to match a confirmed declared UTXO (pubkey_has_script).

Fuzzing logs :

```
btc_sig verify:      cs = FATAL (auth_counterparty -> drop)   ng = non-fatal (kept)
auth_pub <-> UTXO:   cs = bound (_verify_ioauth_inputs)       ng = not checked

regression test without fix:
   test_rejects_maker_with_invalid_btc_sig ................. FAILED (maker accepted)
   test_rejects_maker_whose_auth_pub_owns_no_declared_utxo . FAILED (maker accepted)
regression test with fix:  3 passed
full taker suite:          307 passed
```