### PR TITLE
fix(jmwalletd): apply LOGGING__LEVEL configuration to log sinks

### DIFF
--- a/jmwalletd/src/jmwalletd/app.py
+++ b/jmwalletd/src/jmwalletd/app.py
@@ -21,6 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from loguru import logger
 
+from jmcore.settings import get_settings
 from jmwalletd.deps import get_daemon_state, set_daemon_state
 from jmwalletd.errors import (
     InsufficientScope,
@@ -101,7 +102,7 @@ def create_app(*, data_dir: Path | None = None) -> FastAPI:
     # ------------------------------------------------------------------
     # In-memory log ring buffer so jam's Logs page can fetch recent output.
     # ------------------------------------------------------------------
-    install_log_sink()
+    install_log_sink(level=get_settings().logging.level)
 
     # ------------------------------------------------------------------
     # Cache-busting response headers (matching reference).

--- a/jmwalletd/src/jmwalletd/log_buffer.py
+++ b/jmwalletd/src/jmwalletd/log_buffer.py
@@ -14,6 +14,7 @@ spam from blowing past reasonable memory even within the line limit.
 from __future__ import annotations
 
 import contextlib
+import sys
 import threading
 from collections import deque
 
@@ -64,6 +65,7 @@ class LogRingBuffer:
 
 _buffer: LogRingBuffer | None = None
 _sink_id: int | None = None
+_stderr_sink_id: int | None = 0
 
 
 def get_log_buffer() -> LogRingBuffer:
@@ -75,12 +77,20 @@ def get_log_buffer() -> LogRingBuffer:
 
 
 def install_log_sink(level: str = "DEBUG") -> None:
-    """Attach the ring buffer as a loguru sink.
+    """Attach the ring buffer as a loguru sink and reconfigure stderr logging.
 
-    Safe to call multiple times; the existing sink is removed first so the
+    Safe to call multiple times; existing sinks are removed first so the
     level can be updated at runtime without duplicating records.
     """
-    global _sink_id
+    global _sink_id, _stderr_sink_id
+    level_str = level.upper()
+
+    if _stderr_sink_id is not None:
+        with contextlib.suppress(ValueError):
+            logger.remove(_stderr_sink_id)
+        _stderr_sink_id = None
+    _stderr_sink_id = logger.add(sys.stderr, level=level_str)
+
     buffer = get_log_buffer()
     if _sink_id is not None:
         with contextlib.suppress(ValueError):
@@ -93,7 +103,7 @@ def install_log_sink(level: str = "DEBUG") -> None:
         format=(
             "{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} - {message}"
         ),
-        level=level.upper(),
+        level=level_str,
         colorize=False,
         enqueue=False,
     )

--- a/jmwalletd/src/jmwalletd/log_buffer.py
+++ b/jmwalletd/src/jmwalletd/log_buffer.py
@@ -13,7 +13,6 @@ spam from blowing past reasonable memory even within the line limit.
 
 from __future__ import annotations
 
-import contextlib
 import sys
 import threading
 from collections import deque
@@ -64,8 +63,6 @@ class LogRingBuffer:
 
 
 _buffer: LogRingBuffer | None = None
-_sink_id: int | None = None
-_stderr_sink_id: int | None = 0
 
 
 def get_log_buffer() -> LogRingBuffer:
@@ -79,31 +76,23 @@ def get_log_buffer() -> LogRingBuffer:
 def install_log_sink(level: str = "DEBUG") -> None:
     """Attach the ring buffer as a loguru sink and reconfigure stderr logging.
 
-    Safe to call multiple times; existing sinks are removed first so the
-    level can be updated at runtime without duplicating records.
+    This replaces the process-wide handler set so stale console sinks cannot
+    bypass the configured level. Safe to call multiple times.
     """
-    global _sink_id, _stderr_sink_id
     level_str = level.upper()
-
-    if _stderr_sink_id is not None:
-        with contextlib.suppress(ValueError):
-            logger.remove(_stderr_sink_id)
-        _stderr_sink_id = None
-    _stderr_sink_id = logger.add(sys.stderr, level=level_str)
-
     buffer = get_log_buffer()
-    if _sink_id is not None:
-        with contextlib.suppress(ValueError):
-            # Already removed elsewhere (e.g. logger.remove()).
-            logger.remove(_sink_id)
-        _sink_id = None
-
-    _sink_id = logger.add(
-        buffer.append,
-        format=(
-            "{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} - {message}"
-        ),
-        level=level_str,
-        colorize=False,
-        enqueue=False,
+    logger.configure(
+        handlers=[
+            {"sink": sys.stderr, "level": level_str},
+            {
+                "sink": buffer.append,
+                "format": (
+                    "{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | "
+                    "{name}:{function}:{line} - {message}"
+                ),
+                "level": level_str,
+                "colorize": False,
+                "enqueue": False,
+            },
+        ]
     )

--- a/jmwalletd/tests/test_logs_router.py
+++ b/jmwalletd/tests/test_logs_router.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 from fastapi.testclient import TestClient
 from loguru import logger
 
+import jmwalletd.app as app_module
 from jmwalletd.log_buffer import get_log_buffer, install_log_sink
 
 
@@ -45,6 +51,51 @@ class TestGetLogs:
         response = client.get("/api/v1/logs", headers=_auth_headers(token))
         assert response.status_code == 200
         assert "probe-marker-12345" in response.text
+
+
+def test_create_app_uses_configured_log_level(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    installed_levels: list[str] = []
+    settings = SimpleNamespace(logging=SimpleNamespace(level="ERROR"))
+    monkeypatch.setattr(app_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        app_module,
+        "install_log_sink",
+        lambda *, level: installed_levels.append(level),
+    )
+
+    app_module.create_app(data_dir=tmp_path)
+
+    assert installed_levels == ["ERROR"]
+
+
+def test_install_log_sink_replaces_preconfigured_console_sink() -> None:
+    script = """
+from loguru import logger
+
+from jmcore.cli_common import setup_logging
+from jmwalletd.log_buffer import get_log_buffer, install_log_sink
+
+setup_logging("DEBUG")
+install_log_sink("WARNING")
+get_log_buffer().clear()
+logger.debug("filtered-debug-marker")
+logger.warning("visible-warning-marker")
+print(get_log_buffer().text(), end="")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "filtered-debug-marker" not in result.stderr
+    assert result.stderr.count("visible-warning-marker") == 1
+    assert "filtered-debug-marker" not in result.stdout
+    assert result.stdout.count("visible-warning-marker") == 1
 
 
 class TestLogRingBuffer:


### PR DESCRIPTION
- Pass `get_settings().logging.level` when initializing the log sink in `jmwalletd/app.py`.
- Update `install_log_sink()` in `jmwalletd/log_buffer.py` to set both the in-memory buffer and the sys.stderr logger to the configured level.
- Verified with unit and docker container tests across all log levels (DEBUG, INFO, WARNING, ERROR, and unset).

Closes #569 