### PR TITLE
feat(directory): authenticate nick ownership

### DIFF
--- a/directory_server/docker-compose.yml
+++ b/directory_server/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - DIRECTORY_SERVER__HOST=0.0.0.0
       - DIRECTORY_SERVER__PORT=5222
       - DIRECTORY_SERVER__MAX_PEERS=10000
+      - DIRECTORY_SERVER__NICK_AUTH_DIRECTORY_ID
       - LOGGING__LEVEL=INFO
     networks:
       - joinmarket_directory_internal

--- a/directory_server/src/directory_server/handshake_handler.py
+++ b/directory_server/src/directory_server/handshake_handler.py
@@ -7,8 +7,10 @@ Implements Single Responsibility Principle: only handles handshakes.
 import json
 
 from jmcore.models import NetworkType, PeerInfo, PeerStatus
+from jmcore.nick_auth import NickAuthMode
 from jmcore.protocol import (
     FEATURE_NEUTRINO_COMPAT,
+    FEATURE_NICK_AUTH,
     FEATURE_PEERLIST_FEATURES,
     FEATURE_PING,
     JM_VERSION,
@@ -27,12 +29,29 @@ class HandshakeError(Exception):
 
 class HandshakeHandler:
     def __init__(
-        self, network: NetworkType, server_nick: str, motd: str, neutrino_compat: bool = False
+        self,
+        network: NetworkType,
+        server_nick: str,
+        motd: str,
+        neutrino_compat: bool = False,
+        nick_auth_mode: NickAuthMode = NickAuthMode.DISABLED,
+        nick_auth_directory_id: str | None = None,
     ):
         self.network = network
         self.server_nick = server_nick
         self.motd = motd
         self.neutrino_compat = neutrino_compat
+        self.nick_auth_mode = nick_auth_mode
+        self.nick_auth_directory_id = nick_auth_directory_id
+
+    @property
+    def advertises_nick_auth(self) -> bool:
+        return self.nick_auth_mode is not NickAuthMode.DISABLED and bool(
+            self.nick_auth_directory_id
+        )
+
+    def negotiates_nick_auth(self, peer: PeerInfo) -> bool:
+        return self.advertises_nick_auth and peer.features.get(FEATURE_NICK_AUTH) is True
 
     def process_handshake(self, handshake_data: str, peer_location: str) -> tuple[PeerInfo, dict]:
         try:
@@ -91,21 +110,31 @@ class HandshakeHandler:
             server_features: set[str] = {FEATURE_PEERLIST_FEATURES, FEATURE_PING}
             if self.neutrino_compat:
                 server_features.add(FEATURE_NEUTRINO_COMPAT)
+            if self.advertises_nick_auth:
+                server_features.add(FEATURE_NICK_AUTH)
             feature_set = FeatureSet(features=server_features)
+
+            accepted = not (
+                self.nick_auth_mode is NickAuthMode.REQUIRE_VERIFIED
+                and not self.negotiates_nick_auth(peer_info)
+            )
 
             response = create_handshake_response(
                 nick=self.server_nick,
                 network=self.network.value,
-                accepted=True,
-                motd=self.motd,
+                accepted=accepted,
+                motd=self.motd if accepted else "Rejected: verified nick authentication required",
                 features=feature_set,
             )
 
-            logger.info(
-                f"Handshake accepted: {nick} from {peer_network.value} "
-                f"at {peer_info.location_string} "
-                f"(v{negotiated_version}, neutrino={peer_neutrino_compat})"
-            )
+            if accepted:
+                logger.info(
+                    f"Handshake accepted: {nick} from {peer_network.value} "
+                    f"at {peer_info.location_string} "
+                    f"(v{negotiated_version}, neutrino={peer_neutrino_compat})"
+                )
+            else:
+                logger.info(f"Handshake rejected by nick authentication policy: {nick}")
 
             return (peer_info, response)
 

--- a/directory_server/src/directory_server/heartbeat.py
+++ b/directory_server/src/directory_server/heartbeat.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
@@ -37,8 +38,8 @@ from loguru import logger
 from directory_server.peer_registry import PeerRegistry
 
 # Type aliases
-SendCallback = Callable[[str, bytes], Awaitable[None]]
-EvictCallback = Callable[[str, str], Awaitable[None]]
+SendCallback = Callable[..., Awaitable[None]]
+EvictCallback = Callable[..., Awaitable[None]]
 
 
 @dataclass
@@ -80,7 +81,7 @@ class HeartbeatManager:
         self.server_nick = server_nick
 
         # Peers waiting for a PONG reply
-        self._pong_pending: set[str] = set()
+        self._pong_pending: set[tuple[str, str]] = set()
         self._task: asyncio.Task[None] | None = None
 
     # -- public API --
@@ -108,17 +109,23 @@ class HeartbeatManager:
         self._pong_pending.clear()
         logger.info("Heartbeat stopped")
 
-    def handle_pong(self, peer_key: str) -> None:
+    def handle_pong(self, peer_key: str, connection_id: str | None = None) -> None:
         """Called by the message router when a PONG is received.
 
         Clears ``pong_pending`` so the peer is not evicted.
         """
-        if peer_key in self._pong_pending:
-            self._pong_pending.discard(peer_key)
+        connection_id = connection_id or self.peer_registry.get_connection_id(peer_key)
+        owner = (peer_key, connection_id) if connection_id is not None else None
+        if owner is not None and owner in self._pong_pending:
+            self._pong_pending.discard(owner)
             logger.trace(f"Heartbeat: PONG received from {peer_key}")
 
+    def forget_owner(self, peer_key: str, connection_id: str) -> None:
+        """Remove heartbeat state belonging to an exact connection generation."""
+        self._pong_pending.discard((peer_key, connection_id))
+
     @property
-    def pong_pending(self) -> frozenset[str]:
+    def pong_pending(self) -> frozenset[tuple[str, str]]:
         """Read-only view of peers with pending pongs (for testing)."""
         return frozenset(self._pong_pending)
 
@@ -145,66 +152,74 @@ class HeartbeatManager:
 
         # Phase 1: hard-evict peers that exceeded the absolute timeout
         hard_evict_peers = self.peer_registry.get_peers_idle_since(hard_cutoff)
-        for peer_key, peer_info in hard_evict_peers:
+        hard_evicted: set[tuple[str, str]] = set()
+        for peer_key, peer_info, connection_id in hard_evict_peers:
             logger.info(
                 f"Heartbeat: hard-evicting {peer_info.nick} ({peer_key}) "
                 f"-- idle since {peer_info.last_seen}"
             )
-            self._pong_pending.discard(peer_key)
-            await self.evict_callback(peer_key, "idle timeout")
+            owner = (peer_key, connection_id)
+            hard_evicted.add(owner)
+            self._pong_pending.discard(owner)
+            await self._call_evict(peer_key, "idle timeout", connection_id)
 
         # Phase 2: probe idle peers (idle > idle_threshold but < hard_evict)
         idle_peers = self.peer_registry.get_peers_idle_since(idle_cutoff)
-        pinged_keys: list[str] = []
+        pinged_owners: list[tuple[str, str]] = []
 
-        for peer_key, peer_info in idle_peers:
+        for peer_key, peer_info, connection_id in idle_peers:
             # Skip peers already hard-evicted above
-            if self.peer_registry.get_by_key(peer_key) is None:
+            owner = (peer_key, connection_id)
+            if owner in hard_evicted or not self.peer_registry.is_current_owner(
+                peer_key, connection_id
+            ):
                 continue
 
-            if self.peer_registry.supports_ping(peer_key):
+            if self.peer_registry.supports_ping(peer_key, connection_id):
                 # Send PING to ping-capable peers
-                await self._send_ping(peer_key)
-                self._pong_pending.add(peer_key)
-                pinged_keys.append(peer_key)
-            elif self.peer_registry.is_maker(peer_key):
+                self._pong_pending.add(owner)
+                if await self._send_ping(peer_key, connection_id):
+                    pinged_owners.append(owner)
+            elif self.peer_registry.is_maker(peer_key, connection_id):
                 # Send unicast !orderbook to non-ping makers to elicit a response
-                await self._send_orderbook_probe(peer_key, peer_info.nick)
+                await self._send_orderbook_probe(peer_key, peer_info.nick, connection_id)
             # else: non-ping takers/watchers -- no probe, will be hard-evicted later
 
-        if not pinged_keys:
+        if not pinged_owners:
             return
 
-        logger.debug(f"Heartbeat: pinged {len(pinged_keys)} idle peers, waiting for PONGs")
+        logger.debug(f"Heartbeat: pinged {len(pinged_owners)} idle peers, waiting for PONGs")
 
         # Phase 3: wait for PONGs
         await asyncio.sleep(self.config.pong_wait_sec)
 
         # Phase 4: evict peers that did not respond
-        timed_out = [k for k in pinged_keys if k in self._pong_pending]
-        for peer_key in timed_out:
+        timed_out = [owner for owner in pinged_owners if owner in self._pong_pending]
+        for peer_key, connection_id in timed_out:
             peer = self.peer_registry.get_by_key(peer_key)
             nick = peer.nick if peer else peer_key
             logger.info(f"Heartbeat: evicting {nick} ({peer_key}) -- no PONG response")
-            self._pong_pending.discard(peer_key)
-            await self.evict_callback(peer_key, "pong timeout")
+            self._pong_pending.discard((peer_key, connection_id))
+            await self._call_evict(peer_key, "pong timeout", connection_id)
 
         if timed_out:
             logger.info(f"Heartbeat: evicted {len(timed_out)} unresponsive peers")
 
-    async def _send_ping(self, peer_key: str) -> None:
+    async def _send_ping(self, peer_key: str, connection_id: str) -> bool:
         """Send a PING message to a peer."""
         ping_envelope = MessageEnvelope(message_type=MessageType.PING, payload="")
         try:
-            await self.send_callback(peer_key, ping_envelope.to_bytes())
+            await self._call_send(peer_key, ping_envelope.to_bytes(), connection_id)
             logger.trace(f"Heartbeat: sent PING to {peer_key}")
+            return True
         except Exception as e:
             logger.debug(f"Heartbeat: failed to send PING to {peer_key}: {e}")
             # Send failure likely means peer is already gone; evict immediately
-            self._pong_pending.discard(peer_key)
-            await self.evict_callback(peer_key, f"send failed: {e}")
+            self._pong_pending.discard((peer_key, connection_id))
+            await self._call_evict(peer_key, f"send failed: {e}", connection_id)
+            return False
 
-    async def _send_orderbook_probe(self, peer_key: str, nick: str) -> None:
+    async def _send_orderbook_probe(self, peer_key: str, nick: str, connection_id: str) -> None:
         """Send a unicast !orderbook to a non-ping maker to probe liveness.
 
         The maker will respond with its offers, which updates last_seen on the
@@ -229,7 +244,35 @@ class HeartbeatManager:
             payload=payload,
         )
         try:
-            await self.send_callback(peer_key, probe_envelope.to_bytes())
+            await self._call_send(peer_key, probe_envelope.to_bytes(), connection_id)
             logger.trace(f"Heartbeat: sent !orderbook probe to {nick} ({peer_key})")
         except Exception as e:
             logger.debug(f"Heartbeat: failed to send !orderbook probe to {peer_key}: {e}")
+
+    async def _call_send(self, peer_key: str, data: bytes, connection_id: str) -> None:
+        if not self.peer_registry.is_current_owner(peer_key, connection_id):
+            return
+        if self._accepts_args(self.send_callback, 3):
+            await self.send_callback(peer_key, data, connection_id)
+        else:
+            await self.send_callback(peer_key, data)
+
+    async def _call_evict(self, peer_key: str, reason: str, connection_id: str) -> None:
+        if self._accepts_args(self.evict_callback, 3):
+            await self.evict_callback(peer_key, reason, connection_id)
+        else:
+            await self.evict_callback(peer_key, reason)
+
+    @staticmethod
+    def _accepts_args(callback: Callable[..., object], count: int) -> bool:
+        try:
+            parameters = inspect.signature(callback).parameters.values()
+        except (TypeError, ValueError):
+            return True
+        positional = [
+            parameter
+            for parameter in parameters
+            if parameter.kind
+            in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        ]
+        return len(positional) >= count

--- a/directory_server/src/directory_server/heartbeat.py
+++ b/directory_server/src/directory_server/heartbeat.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import inspect
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
@@ -38,8 +37,8 @@ from loguru import logger
 from directory_server.peer_registry import PeerRegistry
 
 # Type aliases
-SendCallback = Callable[..., Awaitable[None]]
-EvictCallback = Callable[..., Awaitable[None]]
+SendCallback = Callable[[str, bytes, str], Awaitable[None]]
+EvictCallback = Callable[[str, str, str], Awaitable[None]]
 
 
 @dataclass
@@ -60,8 +59,8 @@ class HeartbeatManager:
 
     Args:
         peer_registry: Registry to query peer state and last_seen.
-        send_callback: Async callable ``(peer_key, data_bytes) -> None``.
-        evict_callback: Async callable ``(peer_key, reason) -> None``
+        send_callback: Async callable ``(peer_key, data_bytes, connection_id) -> None``.
+        evict_callback: Async callable ``(peer_key, reason, connection_id) -> None``
             that disconnects and unregisters a peer.
         config: Timing configuration.
     """
@@ -252,27 +251,7 @@ class HeartbeatManager:
     async def _call_send(self, peer_key: str, data: bytes, connection_id: str) -> None:
         if not self.peer_registry.is_current_owner(peer_key, connection_id):
             return
-        if self._accepts_args(self.send_callback, 3):
-            await self.send_callback(peer_key, data, connection_id)
-        else:
-            await self.send_callback(peer_key, data)
+        await self.send_callback(peer_key, data, connection_id)
 
     async def _call_evict(self, peer_key: str, reason: str, connection_id: str) -> None:
-        if self._accepts_args(self.evict_callback, 3):
-            await self.evict_callback(peer_key, reason, connection_id)
-        else:
-            await self.evict_callback(peer_key, reason)
-
-    @staticmethod
-    def _accepts_args(callback: Callable[..., object], count: int) -> bool:
-        try:
-            parameters = inspect.signature(callback).parameters.values()
-        except (TypeError, ValueError):
-            return True
-        positional = [
-            parameter
-            for parameter in parameters
-            if parameter.kind
-            in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
-        ]
-        return len(positional) >= count
+        await self.evict_callback(peer_key, reason, connection_id)

--- a/directory_server/src/directory_server/message_router.py
+++ b/directory_server/src/directory_server/message_router.py
@@ -6,17 +6,19 @@ Implements Single Responsibility Principle: only handles message routing.
 
 import asyncio
 import contextlib
+import inspect
 from collections.abc import Awaitable, Callable, Iterator
 
-from jmcore.models import MessageEnvelope, NetworkType, PeerInfo
+from jmcore.models import MessageEnvelope, NetworkType, PeerInfo, PeerStatus
 from jmcore.protocol import FeatureSet, MessageType, create_peerlist_entry, parse_jm_message
 from loguru import logger
 
 from directory_server.peer_registry import PeerRegistry
 
-SendCallback = Callable[[str, bytes], Awaitable[None]]
-FailedSendCallback = Callable[[str], Awaitable[None]]
-PongCallback = Callable[[str], None]
+SendCallback = Callable[..., Awaitable[None]]
+FailedSendCallback = Callable[..., Awaitable[None]]
+PongCallback = Callable[..., None]
+BroadcastTarget = tuple[str, str | None] | tuple[str, str | None, str]
 
 # Default batch size for concurrent broadcasts to limit memory usage
 # This can be overridden via Settings.broadcast_batch_size
@@ -38,25 +40,50 @@ class MessageRouter:
         self.on_send_failed = on_send_failed
         self.on_pong = on_pong
         # Track peers that failed during current operation to avoid repeated attempts
-        self._failed_peers: set[str] = set()
-        # Track offers per peer (peer_key -> set of order IDs)
-        self._peer_offers: dict[str, set[str]] = {}
+        self._failed_peers: set[tuple[str, str]] = set()
+        # Offers belong to a connection generation, not just a reusable peer key.
+        self._peer_offers: dict[tuple[str, str], set[str]] = {}
 
-    async def route_message(self, envelope: MessageEnvelope, from_key: str) -> None:
+    async def route_message(
+        self,
+        envelope: MessageEnvelope,
+        from_key: str,
+        connection_id: str | None = None,
+    ) -> None:
+        connection_id = connection_id or self.peer_registry.get_connection_id(from_key)
+        peer = self.peer_registry.get_by_key(from_key)
+        if (
+            connection_id is None
+            or peer is None
+            or peer.status != PeerStatus.HANDSHAKED
+            or not self.peer_registry.is_current_owner(from_key, connection_id)
+        ):
+            logger.warning(f"Dropping message from stale or unhandshaked peer: {from_key}")
+            return
         if envelope.message_type == MessageType.PUBMSG:
-            await self._handle_public_message(envelope, from_key)
+            await self._handle_public_message(envelope, from_key, connection_id)
         elif envelope.message_type == MessageType.PRIVMSG:
-            await self._handle_private_message(envelope, from_key)
+            await self._handle_private_message(envelope, from_key, connection_id)
         elif envelope.message_type == MessageType.GETPEERLIST:
-            await self._handle_peerlist_request(from_key)
+            await self._handle_peerlist_request(from_key, connection_id)
         elif envelope.message_type == MessageType.PING:
-            await self._handle_ping(from_key)
+            await self._handle_ping(from_key, connection_id)
         elif envelope.message_type == MessageType.PONG:
-            self._handle_pong(from_key)
+            self._handle_pong(from_key, connection_id)
         else:
             logger.debug(f"Unhandled message type: {envelope.message_type}")
 
-    async def _handle_public_message(self, envelope: MessageEnvelope, from_key: str) -> None:
+    async def _handle_public_message(
+        self,
+        envelope: MessageEnvelope,
+        from_key: str,
+        connection_id: str | None = None,
+    ) -> None:
+        connection_id = connection_id or self.peer_registry.get_connection_id(from_key)
+        if connection_id is None or not self.peer_registry.is_current_owner(
+            from_key, connection_id
+        ):
+            return
         parsed = parse_jm_message(envelope.payload)
         if not parsed:
             logger.warning("Invalid public message format")
@@ -98,12 +125,13 @@ class MessageRouter:
                 # Extract order ID (second field in offer messages)
                 try:
                     order_id = message_parts[1]
-                    if from_key not in self._peer_offers:
-                        self._peer_offers[from_key] = set()
-                    self._peer_offers[from_key].add(order_id)
+                    offer_owner = (from_key, connection_id)
+                    if offer_owner not in self._peer_offers:
+                        self._peer_offers[offer_owner] = set()
+                    self._peer_offers[offer_owner].add(order_id)
                     logger.trace(
                         f"Tracked offer {order_id} from {from_nick} "
-                        f"(total offers: {len(self._peer_offers[from_key])})"
+                        f"(total offers: {len(self._peer_offers[offer_owner])})"
                     )
                 except (ValueError, IndexError):
                     pass
@@ -112,41 +140,68 @@ class MessageRouter:
         envelope_bytes = envelope.to_bytes()
 
         # Use generator to avoid building full target list in memory
-        def target_generator() -> Iterator[tuple[str, str | None]]:
-            for peer in self.peer_registry.iter_connected(from_peer.network):
-                peer_key = (
-                    peer.nick
-                    if peer.location_string == "NOT-SERVING-ONION"
-                    else peer.location_string
-                )
+        def target_generator() -> Iterator[BroadcastTarget]:
+            for peer_key, peer, target_connection_id in self.peer_registry.iter_connected_owners(
+                from_peer.network
+            ):
                 if peer_key != from_key:
-                    yield (peer_key, peer.nick)
+                    yield (peer_key, peer.nick, target_connection_id)
 
         # Execute sends in batches to limit memory usage
         sent_count = await self._batched_broadcast_iter(target_generator(), envelope_bytes)
 
         logger.trace(f"Broadcasted public message from {from_nick} to {sent_count} peers")
 
-    async def _safe_send(self, peer_key: str, data: bytes, nick: str | None = None) -> None:
+    async def _safe_send(
+        self,
+        peer_key: str,
+        data: bytes,
+        nick: str | None = None,
+        expected_connection_id: str | None = None,
+    ) -> None:
         """Send with exception handling to prevent one failed send from affecting others."""
+        expected_connection_id = expected_connection_id or self.peer_registry.get_connection_id(
+            peer_key
+        )
+        if expected_connection_id is None:
+            legacy_failure = (peer_key, "")
+            if legacy_failure in self._failed_peers:
+                return
+            try:
+                await self.send_callback(peer_key, data)
+            except Exception as e:
+                logger.warning(f"Failed to send to {nick or peer_key}: {e}")
+                self._failed_peers.add(legacy_failure)
+                if self.on_send_failed:
+                    with contextlib.suppress(Exception):
+                        await self.on_send_failed(peer_key)
+            return
+        failed_owner = (peer_key, expected_connection_id)
         # Skip if this peer already failed in current operation
-        if peer_key in self._failed_peers:
+        if failed_owner in self._failed_peers:
+            return
+        peer = self.peer_registry.get_by_key(peer_key)
+        if (
+            peer is None
+            or peer.status != PeerStatus.HANDSHAKED
+            or not self.peer_registry.is_current_owner(peer_key, expected_connection_id)
+        ):
             return
 
         try:
-            await self.send_callback(peer_key, data)
+            await self._call_send(peer_key, data, expected_connection_id)
         except Exception as e:
             logger.warning(f"Failed to send to {nick or peer_key}: {e}")
             # Mark peer as failed to prevent repeated attempts
-            self._failed_peers.add(peer_key)
+            self._failed_peers.add(failed_owner)
             # Notify server to clean up this peer
             if self.on_send_failed:
                 try:
-                    await self.on_send_failed(peer_key)
+                    await self._call_failed(peer_key, expected_connection_id)
                 except Exception as cleanup_err:
                     logger.trace(f"Error in on_send_failed callback: {cleanup_err}")
 
-    async def _batched_broadcast(self, targets: list[tuple[str, str | None]], data: bytes) -> int:
+    async def _batched_broadcast(self, targets: list[BroadcastTarget], data: bytes) -> int:
         """
         Broadcast data to targets in batches to limit memory usage.
 
@@ -157,9 +212,7 @@ class MessageRouter:
         """
         return await self._batched_broadcast_iter(iter(targets), data)
 
-    async def _batched_broadcast_iter(
-        self, targets: Iterator[tuple[str, str | None]], data: bytes
-    ) -> int:
+    async def _batched_broadcast_iter(self, targets: Iterator[BroadcastTarget], data: bytes) -> int:
         """
         Broadcast data to targets from an iterator in batches.
 
@@ -173,30 +226,45 @@ class MessageRouter:
         self._failed_peers.clear()
 
         total_sent = 0
-        batch: list[tuple[str, str | None]] = []
+        batch: list[tuple[str, str | None, str]] = []
 
         for target in targets:
-            peer_key, nick = target
-            # Skip peers that have already failed in this broadcast
-            if peer_key in self._failed_peers:
+            peer_key, nick = target[:2]
+            connection_id = (
+                target[2] if len(target) == 3 else self.peer_registry.get_connection_id(peer_key)
+            )
+            if connection_id is None:
                 continue
-            batch.append(target)
+            # Skip peers that have already failed in this broadcast
+            if (peer_key, connection_id) in self._failed_peers:
+                continue
+            batch.append((peer_key, nick, connection_id))
 
             if len(batch) >= self.broadcast_batch_size:
-                tasks = [self._safe_send(pk, data, n) for pk, n in batch]
+                tasks = [self._safe_send(pk, data, n, cid) for pk, n, cid in batch]
                 await asyncio.gather(*tasks)
                 total_sent += len(batch)
                 batch = []
 
         # Process remaining items
         if batch:
-            tasks = [self._safe_send(pk, data, n) for pk, n in batch]
+            tasks = [self._safe_send(pk, data, n, cid) for pk, n, cid in batch]
             await asyncio.gather(*tasks)
             total_sent += len(batch)
 
         return total_sent
 
-    async def _handle_private_message(self, envelope: MessageEnvelope, from_key: str) -> None:
+    async def _handle_private_message(
+        self,
+        envelope: MessageEnvelope,
+        from_key: str,
+        connection_id: str | None = None,
+    ) -> None:
+        connection_id = connection_id or self.peer_registry.get_connection_id(from_key)
+        if connection_id is None or not self.peer_registry.is_current_owner(
+            from_key, connection_id
+        ):
+            return
         parsed = parse_jm_message(envelope.payload)
         if not parsed:
             logger.warning("Invalid private message format")
@@ -220,7 +288,7 @@ class MessageRouter:
             )
 
         to_peer = self.peer_registry.get_by_nick(to_nick)
-        if not to_peer:
+        if not to_peer or to_peer.status != PeerStatus.HANDSHAKED:
             logger.warning(f"Target peer not found: {to_nick}")
             # Log all registered peers for debugging
             all_peers = list(self.peer_registry._peers.keys())
@@ -239,54 +307,70 @@ class MessageRouter:
             )
             return
 
+        to_peer_key = (
+            to_peer.nick
+            if to_peer.location_string == "NOT-SERVING-ONION"
+            else to_peer.location_string
+        )
+        to_connection_id = self.peer_registry.get_connection_id(to_peer_key)
+        if to_connection_id is None:
+            return
         try:
-            to_peer_key = (
-                to_peer.nick
-                if to_peer.location_string == "NOT-SERVING-ONION"
-                else to_peer.location_string
-            )
             logger.info(f"Sending to peer_key: {to_peer_key}")
-            await self.send_callback(to_peer_key, envelope.to_bytes())
+            await self._call_send(to_peer_key, envelope.to_bytes(), to_connection_id)
             logger.info(f"Successfully routed private message: {from_nick} -> {to_nick}")
 
-            await self._send_peer_location(to_peer_key, from_peer)
+            await self._send_peer_location(to_peer_key, from_peer, to_connection_id)
         except Exception as e:
             logger.warning(f"Failed to route private message to {to_nick}: {e}")
             # Notify server to clean up this peer's mapping
             if self.on_send_failed:
-                to_peer_key = (
-                    to_peer.nick
-                    if to_peer.location_string == "NOT-SERVING-ONION"
-                    else to_peer.location_string
-                )
                 with contextlib.suppress(Exception):
-                    await self.on_send_failed(to_peer_key)
+                    await self._call_failed(to_peer_key, to_connection_id)
 
-    async def _handle_peerlist_request(self, from_key: str) -> None:
+    async def _handle_peerlist_request(
+        self, from_key: str, connection_id: str | None = None
+    ) -> None:
+        connection_id = connection_id or self.peer_registry.get_connection_id(from_key)
+        if connection_id is None or not self.peer_registry.is_current_owner(
+            from_key, connection_id
+        ):
+            return
         peer = self.peer_registry.get_by_key(from_key)
         if not peer:
             return
 
         # Check if requesting peer supports peerlist_features
         include_features = peer.features.get("peerlist_features", False)
-        await self.send_peerlist(from_key, peer.network, include_features=include_features)
+        await self.send_peerlist(
+            from_key,
+            peer.network,
+            include_features=include_features,
+            expected_connection_id=connection_id,
+        )
 
-    async def _handle_ping(self, from_key: str) -> None:
+    async def _handle_ping(self, from_key: str, connection_id: str | None = None) -> None:
+        connection_id = connection_id or self.peer_registry.get_connection_id(from_key)
+        if connection_id is None or not self.peer_registry.is_current_owner(
+            from_key, connection_id
+        ):
+            return
         pong_envelope = MessageEnvelope(message_type=MessageType.PONG, payload="")
         try:
-            await self.send_callback(from_key, pong_envelope.to_bytes())
+            await self._call_send(from_key, pong_envelope.to_bytes(), connection_id)
             logger.trace(f"Sent PONG to {from_key}")
         except Exception as e:
             logger.trace(f"Failed to send PONG: {e}")
 
-    def _handle_pong(self, from_key: str) -> None:
+    def _handle_pong(self, from_key: str, connection_id: str | None = None) -> None:
         """Handle a PONG response from a peer.
 
         Delegates to the heartbeat module via callback to clear pong_pending.
         """
         logger.trace(f"Received PONG from {from_key}")
-        if self.on_pong:
-            self.on_pong(from_key)
+        connection_id = connection_id or self.peer_registry.get_connection_id(from_key)
+        if self.on_pong and connection_id is not None:
+            self._call_pong(from_key, connection_id)
 
     async def send_peerlist(
         self,
@@ -294,6 +378,7 @@ class MessageRouter:
         network: NetworkType,
         include_features: bool = False,
         chunk_size: int = 20,
+        expected_connection_id: str | None = None,
     ) -> None:
         """
         Send peerlist to a peer in chunks.
@@ -313,6 +398,9 @@ class MessageRouter:
             f"send_peerlist called for {to_key}, network={network}, "
             f"include_features={include_features}"
         )
+        expected_connection_id = expected_connection_id or self.peer_registry.get_connection_id(
+            to_key
+        )
 
         # Build list of entries
         entries: list[str] = []
@@ -330,7 +418,7 @@ class MessageRouter:
         if not entries:
             envelope = MessageEnvelope(message_type=MessageType.PEERLIST, payload="")
             try:
-                await self.send_callback(to_key, envelope.to_bytes())
+                await self._call_send(to_key, envelope.to_bytes(), expected_connection_id)
                 logger.debug(f"Sent empty peerlist to {to_key}")
             except Exception as e:
                 logger.warning(f"Failed to send peerlist to {to_key}: {e}")
@@ -344,7 +432,7 @@ class MessageRouter:
             envelope = MessageEnvelope(message_type=MessageType.PEERLIST, payload=peerlist_msg)
 
             try:
-                await self.send_callback(to_key, envelope.to_bytes())
+                await self._call_send(to_key, envelope.to_bytes(), expected_connection_id)
                 chunks_sent += 1
                 # Small delay between chunks to avoid overwhelming the connection
                 if i + chunk_size < len(entries):
@@ -358,7 +446,12 @@ class MessageRouter:
             f"include_features={include_features})"
         )
 
-    async def _send_peer_location(self, to_location: str, peer_info: PeerInfo) -> None:
+    async def _send_peer_location(
+        self,
+        to_location: str,
+        peer_info: PeerInfo,
+        expected_connection_id: str | None = None,
+    ) -> None:
         if peer_info.onion_address == "NOT-SERVING-ONION":
             return
 
@@ -375,13 +468,25 @@ class MessageRouter:
         envelope = MessageEnvelope(message_type=MessageType.PEERLIST, payload=entry)
 
         try:
-            await self.send_callback(to_location, envelope.to_bytes())
+            await self._call_send(to_location, envelope.to_bytes(), expected_connection_id)
         except Exception as e:
             logger.trace(f"Failed to send peer location: {e}")
 
-    async def broadcast_peer_disconnect(self, peer_location: str, network: NetworkType) -> None:
-        peer = self.peer_registry.get_by_location(peer_location)
+    async def broadcast_peer_disconnect(
+        self,
+        peer_location: str,
+        network: NetworkType,
+        expected_connection_id: str | None = None,
+    ) -> None:
+        peer = self.peer_registry.get_by_location(peer_location) or self.peer_registry.get_by_key(
+            peer_location
+        )
         if not peer or not peer.nick:
+            return
+        peer_key = (
+            peer.nick if peer.location_string == "NOT-SERVING-ONION" else peer.location_string
+        )
+        if not self.peer_registry.is_current_owner(peer_key, expected_connection_id):
             return
 
         entry = create_peerlist_entry(peer.nick, peer.location_string, disconnected=True)
@@ -391,26 +496,57 @@ class MessageRouter:
         envelope_bytes = envelope.to_bytes()
 
         # Use generator to avoid building full target list in memory
-        def target_generator() -> Iterator[tuple[str, str | None]]:
-            for p in self.peer_registry.iter_connected(network):
-                if p.location_string == peer_location:
+        def target_generator() -> Iterator[BroadcastTarget]:
+            for target_key, p, target_connection_id in self.peer_registry.iter_connected_owners(
+                network
+            ):
+                if target_key == peer_key:
                     continue
-                peer_key = p.nick if p.location_string == "NOT-SERVING-ONION" else p.location_string
-                yield (peer_key, p.nick)
+                yield (target_key, p.nick, target_connection_id)
 
         # Execute sends in batches to limit memory usage
         sent_count = await self._batched_broadcast_iter(target_generator(), envelope_bytes)
 
         logger.info(f"Broadcasted disconnect for {peer.nick} to {sent_count} peers")
 
+    async def broadcast_displaced_peer_disconnect(
+        self,
+        peer: PeerInfo,
+        connection_id: str,
+    ) -> None:
+        """Invalidate state announced by an owner that was atomically displaced."""
+        if peer.status != PeerStatus.HANDSHAKED:
+            return
+        entry = create_peerlist_entry(peer.nick, peer.location_string, disconnected=True)
+        envelope_bytes = MessageEnvelope(
+            message_type=MessageType.PEERLIST,
+            payload=entry,
+        ).to_bytes()
+
+        def target_generator() -> Iterator[BroadcastTarget]:
+            for (
+                target_key,
+                target,
+                target_connection_id,
+            ) in self.peer_registry.iter_connected_owners(peer.network):
+                if target_connection_id != connection_id and target.nick != peer.nick:
+                    yield (target_key, target.nick, target_connection_id)
+
+        await self._batched_broadcast_iter(target_generator(), envelope_bytes)
+
     def get_offer_stats(self) -> dict:
         """Get statistics about tracked offers."""
-        total_offers = sum(len(offers) for offers in self._peer_offers.values())
-        peers_with_offers = len([k for k, v in self._peer_offers.items() if v])
+        current_offers = {
+            owner: offers
+            for owner, offers in self._peer_offers.items()
+            if self.peer_registry.is_current_owner(*owner)
+        }
+        total_offers = sum(len(offers) for offers in current_offers.values())
+        peers_with_offers = len([k for k, v in current_offers.items() if v])
 
         # Find peers with more than 2 offers
         peers_many_offers = []
-        for peer_key, offers in self._peer_offers.items():
+        for (peer_key, _connection_id), offers in current_offers.items():
             if len(offers) > 2:
                 peer_info = self.peer_registry.get_by_key(peer_key)
                 nick = peer_info.nick if peer_info else peer_key
@@ -425,6 +561,52 @@ class MessageRouter:
             "peers_many_offers": peers_many_offers[:10],  # Top 10
         }
 
-    def remove_peer_offers(self, peer_key: str) -> None:
+    def remove_peer_offers(self, peer_key: str, expected_connection_id: str | None = None) -> None:
         """Remove offer tracking for a disconnected peer."""
-        self._peer_offers.pop(peer_key, None)
+        if expected_connection_id is None:
+            for owner in [owner for owner in self._peer_offers if owner[0] == peer_key]:
+                self._peer_offers.pop(owner, None)
+            return
+        self._peer_offers.pop((peer_key, expected_connection_id), None)
+
+    async def _call_send(
+        self, peer_key: str, data: bytes, expected_connection_id: str | None
+    ) -> None:
+        if expected_connection_id is not None and not self.peer_registry.is_current_owner(
+            peer_key, expected_connection_id
+        ):
+            return
+        if self._accepts_args(self.send_callback, 3):
+            await self.send_callback(peer_key, data, expected_connection_id)
+        else:
+            await self.send_callback(peer_key, data)
+
+    async def _call_failed(self, peer_key: str, expected_connection_id: str) -> None:
+        if self.on_send_failed is None:
+            return
+        if self._accepts_args(self.on_send_failed, 2):
+            await self.on_send_failed(peer_key, expected_connection_id)
+        else:
+            await self.on_send_failed(peer_key)
+
+    def _call_pong(self, peer_key: str, expected_connection_id: str) -> None:
+        if self.on_pong is None:
+            return
+        if self._accepts_args(self.on_pong, 2):
+            self.on_pong(peer_key, expected_connection_id)
+        else:
+            self.on_pong(peer_key)
+
+    @staticmethod
+    def _accepts_args(callback: Callable[..., object], count: int) -> bool:
+        try:
+            parameters = inspect.signature(callback).parameters.values()
+        except (TypeError, ValueError):
+            return True
+        positional = [
+            parameter
+            for parameter in parameters
+            if parameter.kind
+            in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        ]
+        return len(positional) >= count

--- a/directory_server/src/directory_server/message_router.py
+++ b/directory_server/src/directory_server/message_router.py
@@ -290,11 +290,7 @@ class MessageRouter:
         to_peer = self.peer_registry.get_by_nick(to_nick)
         if not to_peer or to_peer.status != PeerStatus.HANDSHAKED:
             logger.warning(f"Target peer not found: {to_nick}")
-            # Log all registered peers for debugging
-            all_peers = list(self.peer_registry._peers.keys())
-            logger.info(f"Registered peer keys: {all_peers}")
-            nick_map = dict(self.peer_registry._nick_to_key)
-            logger.info(f"Nick to key map: {nick_map}")
+            logger.info(f"Registered peer nicks: {list(self.peer_registry._peers)}")
             return
 
         from_peer = self.peer_registry.get_by_key(from_key)
@@ -307,11 +303,7 @@ class MessageRouter:
             )
             return
 
-        to_peer_key = (
-            to_peer.nick
-            if to_peer.location_string == "NOT-SERVING-ONION"
-            else to_peer.location_string
-        )
+        to_peer_key = to_peer.nick
         to_connection_id = self.peer_registry.get_connection_id(to_peer_key)
         if to_connection_id is None:
             return
@@ -448,7 +440,7 @@ class MessageRouter:
 
     async def _send_peer_location(
         self,
-        to_location: str,
+        to_key: str,
         peer_info: PeerInfo,
         expected_connection_id: str | None = None,
     ) -> None:
@@ -468,24 +460,19 @@ class MessageRouter:
         envelope = MessageEnvelope(message_type=MessageType.PEERLIST, payload=entry)
 
         try:
-            await self._call_send(to_location, envelope.to_bytes(), expected_connection_id)
+            await self._call_send(to_key, envelope.to_bytes(), expected_connection_id)
         except Exception as e:
             logger.trace(f"Failed to send peer location: {e}")
 
     async def broadcast_peer_disconnect(
         self,
-        peer_location: str,
+        peer_key: str,
         network: NetworkType,
         expected_connection_id: str | None = None,
     ) -> None:
-        peer = self.peer_registry.get_by_location(peer_location) or self.peer_registry.get_by_key(
-            peer_location
-        )
+        peer = self.peer_registry.get_by_key(peer_key)
         if not peer or not peer.nick:
             return
-        peer_key = (
-            peer.nick if peer.location_string == "NOT-SERVING-ONION" else peer.location_string
-        )
         if not self.peer_registry.is_current_owner(peer_key, expected_connection_id):
             return
 

--- a/directory_server/src/directory_server/message_router.py
+++ b/directory_server/src/directory_server/message_router.py
@@ -6,7 +6,6 @@ Implements Single Responsibility Principle: only handles message routing.
 
 import asyncio
 import contextlib
-import inspect
 from collections.abc import Awaitable, Callable, Iterator
 
 from jmcore.models import MessageEnvelope, NetworkType, PeerInfo, PeerStatus
@@ -15,9 +14,9 @@ from loguru import logger
 
 from directory_server.peer_registry import PeerRegistry
 
-SendCallback = Callable[..., Awaitable[None]]
-FailedSendCallback = Callable[..., Awaitable[None]]
-PongCallback = Callable[..., None]
+SendCallback = Callable[[str, bytes, str | None], Awaitable[None]]
+FailedSendCallback = Callable[[str, str], Awaitable[None]]
+PongCallback = Callable[[str, str], None]
 BroadcastTarget = tuple[str, str | None] | tuple[str, str | None, str]
 
 # Default batch size for concurrent broadcasts to limit memory usage
@@ -39,8 +38,6 @@ class MessageRouter:
         self.broadcast_batch_size = broadcast_batch_size
         self.on_send_failed = on_send_failed
         self.on_pong = on_pong
-        # Track peers that failed during current operation to avoid repeated attempts
-        self._failed_peers: set[tuple[str, str]] = set()
         # Offers belong to a connection generation, not just a reusable peer key.
         self._peer_offers: dict[tuple[str, str], set[str]] = {}
 
@@ -158,27 +155,18 @@ class MessageRouter:
         data: bytes,
         nick: str | None = None,
         expected_connection_id: str | None = None,
+        failed: set[tuple[str, str]] | None = None,
     ) -> None:
         """Send with exception handling to prevent one failed send from affecting others."""
+        failed = failed if failed is not None else set()
         expected_connection_id = expected_connection_id or self.peer_registry.get_connection_id(
             peer_key
         )
         if expected_connection_id is None:
-            legacy_failure = (peer_key, "")
-            if legacy_failure in self._failed_peers:
-                return
-            try:
-                await self.send_callback(peer_key, data)
-            except Exception as e:
-                logger.warning(f"Failed to send to {nick or peer_key}: {e}")
-                self._failed_peers.add(legacy_failure)
-                if self.on_send_failed:
-                    with contextlib.suppress(Exception):
-                        await self.on_send_failed(peer_key)
             return
         failed_owner = (peer_key, expected_connection_id)
         # Skip if this peer already failed in current operation
-        if failed_owner in self._failed_peers:
+        if failed_owner in failed:
             return
         peer = self.peer_registry.get_by_key(peer_key)
         if (
@@ -193,7 +181,7 @@ class MessageRouter:
         except Exception as e:
             logger.warning(f"Failed to send to {nick or peer_key}: {e}")
             # Mark peer as failed to prevent repeated attempts
-            self._failed_peers.add(failed_owner)
+            failed.add(failed_owner)
             # Notify server to clean up this peer
             if self.on_send_failed:
                 try:
@@ -221,9 +209,9 @@ class MessageRouter:
 
         Returns the number of targets processed.
         """
-        # Clear failed peers set at start of broadcast to allow fresh attempts
-        # while still preventing repeated attempts within this broadcast
-        self._failed_peers.clear()
+        # A disconnect broadcast re-enters this method through on_send_failed, and
+        # broadcasts also run concurrently. Keep failures local to this call.
+        failed: set[tuple[str, str]] = set()
 
         total_sent = 0
         batch: list[tuple[str, str | None, str]] = []
@@ -236,19 +224,19 @@ class MessageRouter:
             if connection_id is None:
                 continue
             # Skip peers that have already failed in this broadcast
-            if (peer_key, connection_id) in self._failed_peers:
+            if (peer_key, connection_id) in failed:
                 continue
             batch.append((peer_key, nick, connection_id))
 
             if len(batch) >= self.broadcast_batch_size:
-                tasks = [self._safe_send(pk, data, n, cid) for pk, n, cid in batch]
+                tasks = [self._safe_send(pk, data, n, cid, failed) for pk, n, cid in batch]
                 await asyncio.gather(*tasks)
                 total_sent += len(batch)
                 batch = []
 
         # Process remaining items
         if batch:
-            tasks = [self._safe_send(pk, data, n, cid) for pk, n, cid in batch]
+            tasks = [self._safe_send(pk, data, n, cid, failed) for pk, n, cid in batch]
             await asyncio.gather(*tasks)
             total_sent += len(batch)
 
@@ -563,37 +551,14 @@ class MessageRouter:
             peer_key, expected_connection_id
         ):
             return
-        if self._accepts_args(self.send_callback, 3):
-            await self.send_callback(peer_key, data, expected_connection_id)
-        else:
-            await self.send_callback(peer_key, data)
+        await self.send_callback(peer_key, data, expected_connection_id)
 
     async def _call_failed(self, peer_key: str, expected_connection_id: str) -> None:
         if self.on_send_failed is None:
             return
-        if self._accepts_args(self.on_send_failed, 2):
-            await self.on_send_failed(peer_key, expected_connection_id)
-        else:
-            await self.on_send_failed(peer_key)
+        await self.on_send_failed(peer_key, expected_connection_id)
 
     def _call_pong(self, peer_key: str, expected_connection_id: str) -> None:
         if self.on_pong is None:
             return
-        if self._accepts_args(self.on_pong, 2):
-            self.on_pong(peer_key, expected_connection_id)
-        else:
-            self.on_pong(peer_key)
-
-    @staticmethod
-    def _accepts_args(callback: Callable[..., object], count: int) -> bool:
-        try:
-            parameters = inspect.signature(callback).parameters.values()
-        except (TypeError, ValueError):
-            return True
-        positional = [
-            parameter
-            for parameter in parameters
-            if parameter.kind
-            in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
-        ]
-        return len(positional) >= count
+        self.on_pong(peer_key, expected_connection_id)

--- a/directory_server/src/directory_server/peer_registry.py
+++ b/directory_server/src/directory_server/peer_registry.py
@@ -5,7 +5,9 @@ Implements Single Responsibility Principle: only manages peer state.
 """
 
 from collections.abc import Iterator
+from dataclasses import dataclass
 from datetime import UTC, datetime
+from uuid import uuid4
 
 from jmcore.models import NetworkType, PeerInfo, PeerStatus
 from jmcore.protocol import FeatureSet
@@ -16,36 +18,140 @@ class PeerNotFoundError(Exception):
     pass
 
 
+class PeerOwnershipConflictError(Exception):
+    """Raised when a live peer already owns a nick or routing key."""
+
+
+@dataclass(frozen=True)
+class PeerOwner:
+    connection_id: str
+    verified_pubkey: bytes | str | None = None
+
+    @property
+    def verified(self) -> bool:
+        return self.verified_pubkey is not None
+
+
+@dataclass(frozen=True)
+class DisplacedPeer:
+    peer_key: str
+    peer: PeerInfo
+    connection_id: str
+
+
+@dataclass(frozen=True)
+class RegistrationResult:
+    peer_key: str
+    connection_id: str
+    displaced: tuple[DisplacedPeer, ...] = ()
+
+
 class PeerRegistry:
     def __init__(self, max_peers: int = 1000):
         self.max_peers = max_peers
         self._peers: dict[str, PeerInfo] = {}
         self._nick_to_key: dict[str, str] = {}
+        self._owners: dict[str, PeerOwner] = {}
 
-    def register(self, peer: PeerInfo) -> None:
-        if len(self._peers) >= self.max_peers:
-            raise ValueError(f"Maximum peers reached: {self.max_peers}")
+    def register(
+        self,
+        peer: PeerInfo,
+        connection_id: str | None = None,
+        *,
+        verified_pubkey: bytes | str | None = None,
+    ) -> RegistrationResult:
+        """Atomically reserve a peer's nick and routing key for one connection.
 
+        Legacy registrations use first-live-writer ownership. A verified registration may
+        replace legacy owners, while replacing a verified owner requires the same full pubkey.
+        """
+        connection_id = connection_id or uuid4().hex
         location = peer.location_string
         key = peer.nick if location == "NOT-SERVING-ONION" else location
+        conflicting_keys = {
+            candidate for candidate in (key, self._nick_to_key.get(peer.nick)) if candidate
+        }
+
+        displaced: list[DisplacedPeer] = []
+        for conflicting_key in conflicting_keys:
+            existing_peer = self._peers.get(conflicting_key)
+            existing_owner = self._owners.get(conflicting_key)
+            if existing_peer is None or existing_owner is None:
+                continue
+            # Nick authentication proves ownership of a nick, not of an onion
+            # endpoint claimed in the handshake. Never let a verified nick
+            # evict a different peer by copying its routing location.
+            if conflicting_key == key and existing_peer.nick != peer.nick:
+                raise PeerOwnershipConflictError(
+                    f"Peer location already registered: {peer.location_string}"
+                )
+            if verified_pubkey is None:
+                raise PeerOwnershipConflictError(
+                    f"Peer nick or location already registered: {peer.nick}"
+                )
+            if existing_owner.verified and existing_owner.verified_pubkey != verified_pubkey:
+                raise PeerOwnershipConflictError(f"Verified nick already registered: {peer.nick}")
+            displaced.append(
+                DisplacedPeer(
+                    peer_key=conflicting_key,
+                    peer=existing_peer,
+                    connection_id=existing_owner.connection_id,
+                )
+            )
+
+        if len(self._peers) - len(displaced) >= self.max_peers:
+            raise ValueError(f"Maximum peers reached: {self.max_peers}")
+
+        for old in displaced:
+            self._remove(old.peer_key)
 
         self._peers[key] = peer
+        self._owners[key] = PeerOwner(
+            connection_id=connection_id,
+            verified_pubkey=verified_pubkey,
+        )
         if peer.nick:
             self._nick_to_key[peer.nick] = key
 
         peer.last_seen = datetime.now(UTC)
         logger.info(f"Registered peer: {peer.nick} at {location}")
+        return RegistrationResult(
+            peer_key=key,
+            connection_id=connection_id,
+            displaced=tuple(displaced),
+        )
 
-    def unregister(self, key: str) -> None:
-        if key not in self._peers:
-            return
+    def unregister(self, key: str, expected_connection_id: str | None = None) -> bool:
+        if not self.is_current_owner(key, expected_connection_id):
+            return False
 
-        peer = self._peers[key]
-        if peer.nick in self._nick_to_key:
-            del self._nick_to_key[peer.nick]
-
-        del self._peers[key]
+        peer = self._remove(key)
+        if peer is None:
+            return False
         logger.info(f"Unregistered peer: {peer.nick} at {peer.location_string}")
+        return True
+
+    def _remove(self, key: str) -> PeerInfo | None:
+        peer = self._peers.pop(key, None)
+        if peer is None:
+            return None
+        if self._nick_to_key.get(peer.nick) == key:
+            del self._nick_to_key[peer.nick]
+        self._owners.pop(key, None)
+        return peer
+
+    def is_current_owner(self, key: str, expected_connection_id: str | None) -> bool:
+        owner = self._owners.get(key)
+        if owner is None:
+            return False
+        return expected_connection_id is None or owner.connection_id == expected_connection_id
+
+    def get_owner(self, key: str) -> PeerOwner | None:
+        return self._owners.get(key)
+
+    def get_connection_id(self, key: str) -> str | None:
+        owner = self.get_owner(key)
+        return owner.connection_id if owner else None
 
     def get_by_key(self, key: str) -> PeerInfo | None:
         return self._peers.get(key)
@@ -59,21 +165,38 @@ class PeerRegistry:
             return self._peers.get(key)
         return None
 
-    def update_status(self, key: str, status: PeerStatus) -> None:
+    def get_key_by_nick(self, nick: str) -> str | None:
+        """Return the routing key currently reserved for ``nick``."""
+        return self._nick_to_key.get(nick)
+
+    def update_status(
+        self,
+        key: str,
+        status: PeerStatus,
+        expected_connection_id: str | None = None,
+    ) -> bool:
+        if not self.is_current_owner(key, expected_connection_id):
+            return False
         peer = self.get_by_key(key)
         if peer:
             peer.status = status
             if status in (PeerStatus.CONNECTED, PeerStatus.HANDSHAKED):
                 peer.last_seen = datetime.now(UTC)
+            return True
+        return False
 
-    def update_last_seen(self, key: str) -> None:
+    def update_last_seen(self, key: str, expected_connection_id: str | None = None) -> bool:
         """Update the last_seen timestamp for a peer.
 
         Called on every received message to track peer liveness for heartbeat.
         """
+        if not self.is_current_owner(key, expected_connection_id):
+            return False
         peer = self.get_by_key(key)
         if peer:
             peer.last_seen = datetime.now(UTC)
+            return True
+        return False
 
     def _iter_connected(self, network: NetworkType | None = None) -> Iterator[PeerInfo]:
         """Iterator over connected peers.
@@ -91,6 +214,20 @@ class PeerRegistry:
     def iter_connected(self, network: NetworkType | None = None) -> Iterator[PeerInfo]:
         """Public memory-efficient iterator over connected peers."""
         return self._iter_connected(network)
+
+    def iter_connected_owners(
+        self, network: NetworkType | None = None
+    ) -> Iterator[tuple[str, PeerInfo, str]]:
+        """Iterate over handshaked peers with their current ownership generation."""
+        for key, peer in list(self._peers.items()):
+            owner = self._owners.get(key)
+            if (
+                owner is not None
+                and peer.status == PeerStatus.HANDSHAKED
+                and not peer.is_directory
+                and (network is None or peer.network == network)
+            ):
+                yield key, peer, owner.connection_id
 
     def get_all_connected(self, network: NetworkType | None = None) -> list[PeerInfo]:
         return list(self._iter_connected(network))
@@ -129,6 +266,7 @@ class PeerRegistry:
     def clear(self) -> None:
         self._peers.clear()
         self._nick_to_key.clear()
+        self._owners.clear()
 
     def get_passive_peers(self, network: NetworkType | None = None) -> list[PeerInfo]:
         """
@@ -191,31 +329,37 @@ class PeerRegistry:
         """
         return [p for p in self._iter_connected(network) if p.neutrino_compat]
 
-    def get_peers_idle_since(self, cutoff: datetime) -> list[tuple[str, PeerInfo]]:
+    def get_peers_idle_since(self, cutoff: datetime) -> list[tuple[str, PeerInfo, str]]:
         """Get connected peers whose last_seen is older than cutoff.
 
-        Returns list of (peer_key, peer_info) tuples.
+        Returns list of (peer_key, peer_info, connection_id) tuples.
         """
-        result: list[tuple[str, PeerInfo]] = []
+        result: list[tuple[str, PeerInfo, str]] = []
         for key, peer in list(self._peers.items()):
+            owner = self._owners.get(key)
             if (
-                peer.status == PeerStatus.HANDSHAKED
+                owner is not None
+                and peer.status == PeerStatus.HANDSHAKED
                 and not peer.is_directory
                 and peer.last_seen is not None
                 and peer.last_seen < cutoff
             ):
-                result.append((key, peer))
+                result.append((key, peer, owner.connection_id))
         return result
 
-    def supports_ping(self, key: str) -> bool:
+    def supports_ping(self, key: str, expected_connection_id: str | None = None) -> bool:
         """Check if a peer supports PING/PONG heartbeat."""
+        if not self.is_current_owner(key, expected_connection_id):
+            return False
         peer = self.get_by_key(key)
         if peer is None:
             return False
         return peer.features.get("ping", False) is True
 
-    def is_maker(self, key: str) -> bool:
+    def is_maker(self, key: str, expected_connection_id: str | None = None) -> bool:
         """Check if a peer is a maker (serves an onion address)."""
+        if not self.is_current_owner(key, expected_connection_id):
+            return False
         peer = self.get_by_key(key)
         if peer is None:
             return False

--- a/directory_server/src/directory_server/peer_registry.py
+++ b/directory_server/src/directory_server/peer_registry.py
@@ -19,7 +19,7 @@ class PeerNotFoundError(Exception):
 
 
 class PeerOwnershipConflictError(Exception):
-    """Raised when a live peer already owns a nick or routing key."""
+    """Raised when a live peer already owns a nick."""
 
 
 @dataclass(frozen=True)
@@ -50,7 +50,6 @@ class PeerRegistry:
     def __init__(self, max_peers: int = 1000):
         self.max_peers = max_peers
         self._peers: dict[str, PeerInfo] = {}
-        self._nick_to_key: dict[str, str] = {}
         self._owners: dict[str, PeerOwner] = {}
 
     def register(
@@ -60,40 +59,27 @@ class PeerRegistry:
         *,
         verified_pubkey: bytes | str | None = None,
     ) -> RegistrationResult:
-        """Atomically reserve a peer's nick and routing key for one connection.
+        """Atomically reserve a peer's nick for one connection.
 
         Legacy registrations use first-live-writer ownership. A verified registration may
         replace legacy owners, while replacing a verified owner requires the same full pubkey.
+        The self-declared location remains metadata and is never an ownership key.
         """
         connection_id = connection_id or uuid4().hex
         location = peer.location_string
-        key = peer.nick if location == "NOT-SERVING-ONION" else location
-        conflicting_keys = {
-            candidate for candidate in (key, self._nick_to_key.get(peer.nick)) if candidate
-        }
+        key = peer.nick
 
         displaced: list[DisplacedPeer] = []
-        for conflicting_key in conflicting_keys:
-            existing_peer = self._peers.get(conflicting_key)
-            existing_owner = self._owners.get(conflicting_key)
-            if existing_peer is None or existing_owner is None:
-                continue
-            # Nick authentication proves ownership of a nick, not of an onion
-            # endpoint claimed in the handshake. Never let a verified nick
-            # evict a different peer by copying its routing location.
-            if conflicting_key == key and existing_peer.nick != peer.nick:
-                raise PeerOwnershipConflictError(
-                    f"Peer location already registered: {peer.location_string}"
-                )
+        existing_peer = self._peers.get(key)
+        existing_owner = self._owners.get(key)
+        if existing_peer is not None and existing_owner is not None:
             if verified_pubkey is None:
-                raise PeerOwnershipConflictError(
-                    f"Peer nick or location already registered: {peer.nick}"
-                )
+                raise PeerOwnershipConflictError(f"Peer nick already registered: {peer.nick}")
             if existing_owner.verified and existing_owner.verified_pubkey != verified_pubkey:
                 raise PeerOwnershipConflictError(f"Verified nick already registered: {peer.nick}")
             displaced.append(
                 DisplacedPeer(
-                    peer_key=conflicting_key,
+                    peer_key=key,
                     peer=existing_peer,
                     connection_id=existing_owner.connection_id,
                 )
@@ -110,8 +96,6 @@ class PeerRegistry:
             connection_id=connection_id,
             verified_pubkey=verified_pubkey,
         )
-        if peer.nick:
-            self._nick_to_key[peer.nick] = key
 
         peer.last_seen = datetime.now(UTC)
         logger.info(f"Registered peer: {peer.nick} at {location}")
@@ -135,8 +119,6 @@ class PeerRegistry:
         peer = self._peers.pop(key, None)
         if peer is None:
             return None
-        if self._nick_to_key.get(peer.nick) == key:
-            del self._nick_to_key[peer.nick]
         self._owners.pop(key, None)
         return peer
 
@@ -156,18 +138,12 @@ class PeerRegistry:
     def get_by_key(self, key: str) -> PeerInfo | None:
         return self._peers.get(key)
 
-    def get_by_location(self, location: str) -> PeerInfo | None:
-        return self._peers.get(location)
-
     def get_by_nick(self, nick: str) -> PeerInfo | None:
-        key = self._nick_to_key.get(nick)
-        if key:
-            return self._peers.get(key)
-        return None
+        return self._peers.get(nick)
 
     def get_key_by_nick(self, nick: str) -> str | None:
         """Return the routing key currently reserved for ``nick``."""
-        return self._nick_to_key.get(nick)
+        return nick if nick in self._peers else None
 
     def update_status(
         self,
@@ -265,7 +241,6 @@ class PeerRegistry:
 
     def clear(self) -> None:
         self._peers.clear()
-        self._nick_to_key.clear()
         self._owners.clear()
 
     def get_passive_peers(self, network: NetworkType | None = None) -> list[PeerInfo]:

--- a/directory_server/src/directory_server/server.py
+++ b/directory_server/src/directory_server/server.py
@@ -566,6 +566,22 @@ class DirectoryServer:
                 if not self.peer_registry.update_last_seen(peer_key, conn_id):
                     break
 
+                envelope = MessageEnvelope.from_bytes(
+                    data,
+                    max_line_length=self.settings.max_line_length,
+                    max_json_nesting_depth=self.settings.max_json_nesting_depth,
+                )
+
+                if envelope.message_type in {
+                    MessageType.NICK_AUTH_CHALLENGE,
+                    MessageType.NICK_AUTH_PROOF,
+                    MessageType.NICK_AUTH_RESULT,
+                }:
+                    logger.warning(
+                        f"Out-of-order nick authentication message from {peer_info.nick}"
+                    )
+                    break
+
                 # Rate limiting by connection ID to prevent nick spoofing attacks.
                 # A malicious peer could claim another's nick in handshake and spam
                 # to get the legitimate peer rate-limited. Using conn_id ensures
@@ -596,12 +612,6 @@ class DirectoryServer:
                         )
                     # Drop message but stay connected - this is the "slowdown" approach
                     continue
-
-                envelope = MessageEnvelope.from_bytes(
-                    data,
-                    max_line_length=self.settings.max_line_length,
-                    max_json_nesting_depth=self.settings.max_json_nesting_depth,
-                )
 
                 await self.message_router.route_message(envelope, peer_key, conn_id)
 

--- a/directory_server/src/directory_server/server.py
+++ b/directory_server/src/directory_server/server.py
@@ -361,13 +361,12 @@ class DirectoryServer:
 
         challenge = NickAuthChallenge.from_payload(
             {
-                "kind": "challenge",
                 "challenge": secrets.token_hex(32),
                 "directory-id": directory_id,
             }
         )
         challenge_envelope = MessageEnvelope(
-            message_type=MessageType.NICK_AUTH,
+            message_type=MessageType.NICK_AUTH_CHALLENGE,
             payload=challenge.to_json(),
         )
         await asyncio.wait_for(
@@ -392,7 +391,7 @@ class DirectoryServer:
                 max_line_length=self.settings.max_line_length,
                 max_json_nesting_depth=self.settings.max_json_nesting_depth,
             )
-            if proof_envelope.message_type != MessageType.NICK_AUTH:
+            if proof_envelope.message_type != MessageType.NICK_AUTH_PROOF:
                 raise ValueError("unexpected nick authentication message type")
             proof = NickAuthProof.parse(proof_envelope.payload)
         except Exception:

--- a/directory_server/src/directory_server/server.py
+++ b/directory_server/src/directory_server/server.py
@@ -8,7 +8,6 @@ import asyncio
 import contextlib
 import json
 import secrets
-from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import Literal
 from uuid import uuid4
@@ -72,7 +71,6 @@ class DirectoryServer:
         self.peer_registry = PeerRegistry(max_peers=settings.max_peers)
         self.connections = ConnectionPool(max_connections=settings.max_peers + 1)
         self.peer_key_to_conn_id: dict[str, str] = {}
-        self._registration_lock = asyncio.Lock()
         self._owner_locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
 
         # Heartbeat manager for peer liveness detection
@@ -408,6 +406,7 @@ class DirectoryServer:
             expected_directory_id=directory_id,
             handshake_line=handshake_line,
             nick=peer_info.nick,
+            protocol_version=peer_info.protocol_version,
         ):
             logger.info(f"[{conn_id}] Nick authentication proof was invalid")
             await self._send_nick_auth_result(connection, "invalid", safe=True)
@@ -434,24 +433,12 @@ class DirectoryServer:
             return
         await asyncio.wait_for(send_result, timeout=self.nick_auth_timeout)
 
-    @staticmethod
-    def _peer_key(peer: PeerInfo) -> str:
-        return peer.nick
-
     def _owner_lock(self, peer_key: str) -> asyncio.Lock:
         lock = self._owner_locks.get(peer_key)
         if lock is None:
             lock = asyncio.Lock()
             self._owner_locks[peer_key] = lock
         return lock
-
-    @contextlib.asynccontextmanager
-    async def _lock_owner_keys(self, *peer_keys: str | None) -> AsyncIterator[None]:
-        keys = sorted({key for key in peer_keys if key is not None})
-        async with contextlib.AsyncExitStack() as stack:
-            for key in keys:
-                await stack.enter_async_context(self._owner_lock(key))
-            yield
 
     async def _register_peer(
         self,
@@ -460,18 +447,15 @@ class DirectoryServer:
         *,
         verified_pubkey: bytes | str | None = None,
     ) -> RegistrationResult:
-        """Serialize ownership replacement with writes to every affected routing key."""
-        async with self._registration_lock:
-            new_key = self._peer_key(peer)
-            current_nick_key = self.peer_registry.get_key_by_nick(peer.nick)
-            async with self._lock_owner_keys(new_key, current_nick_key):
-                registration = self.peer_registry.register(
-                    peer,
-                    connection_id,
-                    verified_pubkey=verified_pubkey,
-                )
-                self._activate_registration(registration)
-                return registration
+        """Serialize registration with writes to the affected nick owner."""
+        async with self._owner_lock(peer.nick):
+            registration = self.peer_registry.register(
+                peer,
+                connection_id,
+                verified_pubkey=verified_pubkey,
+            )
+            self._activate_registration(registration)
+            return registration
 
     def _activate_registration(self, registration: RegistrationResult) -> None:
         for displaced in registration.displaced:

--- a/directory_server/src/directory_server/server.py
+++ b/directory_server/src/directory_server/server.py
@@ -436,7 +436,7 @@ class DirectoryServer:
 
     @staticmethod
     def _peer_key(peer: PeerInfo) -> str:
-        return peer.nick if peer.location_string == "NOT-SERVING-ONION" else peer.location_string
+        return peer.nick
 
     def _owner_lock(self, peer_key: str) -> asyncio.Lock:
         lock = self._owner_locks.get(peer_key)
@@ -660,15 +660,14 @@ class DirectoryServer:
 
     async def _send_to_peer(
         self,
-        peer_location: str,
+        peer_key: str,
         data: bytes,
         expected_connection_id: str | None = None,
     ) -> None:
-        peer_key = peer_location
         async with self._owner_lock(peer_key):
             conn_id = self.peer_key_to_conn_id.get(peer_key)
             if not conn_id:
-                raise ValueError(f"No connection for peer: {peer_location}")
+                raise ValueError(f"No connection for peer: {peer_key}")
 
             expected_connection_id = expected_connection_id or conn_id
             peer = self.peer_registry.get_by_key(peer_key)
@@ -678,7 +677,7 @@ class DirectoryServer:
                 or peer.status is not PeerStatus.HANDSHAKED
                 or not self.peer_registry.is_current_owner(peer_key, expected_connection_id)
             ):
-                raise ValueError(f"Stale connection for peer: {peer_location}")
+                raise ValueError(f"Stale connection for peer: {peer_key}")
 
             connection = self.connections.get(expected_connection_id)
             if not connection:

--- a/directory_server/src/directory_server/server.py
+++ b/directory_server/src/directory_server/server.py
@@ -5,11 +5,25 @@ Implements Open/Closed Principle: extensible without modification.
 """
 
 import asyncio
+import contextlib
 import json
+import secrets
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime
+from typing import Literal
+from uuid import uuid4
+from weakref import WeakValueDictionary
 
-from jmcore.models import MessageEnvelope, NetworkType, PeerStatus
+from jmcore.models import MessageEnvelope, NetworkType, PeerInfo, PeerStatus
 from jmcore.network import ConnectionPool, TCPConnection
+from jmcore.nick_auth import (
+    NickAuthChallenge,
+    NickAuthMode,
+    NickAuthProof,
+    NickAuthResult,
+    parse_strict_json_object,
+    verify_nick_auth_proof,
+)
 from jmcore.notifications import get_notifier
 from jmcore.protocol import MessageType
 from jmcore.rate_limiter import RateLimitAction, RateLimiter
@@ -22,7 +36,13 @@ from directory_server.handshake_handler import HandshakeError, HandshakeHandler
 from directory_server.health import HealthCheckServer
 from directory_server.heartbeat import HeartbeatConfig, HeartbeatManager
 from directory_server.message_router import MessageRouter
-from directory_server.peer_registry import PeerRegistry
+from directory_server.peer_registry import (
+    PeerOwnershipConflictError,
+    PeerRegistry,
+    RegistrationResult,
+)
+
+_DIRECTORY_SEND_TIMEOUT_SEC = 30.0
 
 
 def build_motd(user_motd: str) -> str:
@@ -50,8 +70,10 @@ class DirectoryServer:
         self.server_nick = server_nick
 
         self.peer_registry = PeerRegistry(max_peers=settings.max_peers)
-        self.connections = ConnectionPool(max_connections=settings.max_peers)
+        self.connections = ConnectionPool(max_connections=settings.max_peers + 1)
         self.peer_key_to_conn_id: dict[str, str] = {}
+        self._registration_lock = asyncio.Lock()
+        self._owner_locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
 
         # Heartbeat manager for peer liveness detection
         heartbeat_config = HeartbeatConfig(
@@ -79,7 +101,19 @@ class DirectoryServer:
             network=self.network,
             server_nick=server_nick,
             motd=build_motd(settings.motd),
+            nick_auth_mode=settings.nick_auth_mode,
+            nick_auth_directory_id=settings.nick_auth_directory_id,
         )
+        if (
+            settings.nick_auth_mode is not NickAuthMode.DISABLED
+            and settings.nick_auth_directory_id is None
+        ):
+            logger.warning(
+                "Directory nick authentication is not advertised because "
+                "nick_auth_directory_id is unset"
+            )
+        configured_auth_timeout = float(settings.nick_auth_timeout)
+        self.nick_auth_timeout = min(max(configured_auth_timeout, 0.1), 30.0)
         # Rate limit by connection ID to prevent nick spoofing attacks.
         # A malicious peer could claim another's nick and spam to get them rate limited.
         # Using connection ID ensures each physical connection has its own bucket.
@@ -160,8 +194,9 @@ class DirectoryServer:
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
         peer_addr = writer.get_extra_info("peername")
-        conn_id = f"{peer_addr[0]}:{peer_addr[1]}"
-        logger.trace(f"New connection from {conn_id}")
+        remote_id = f"{peer_addr[0]}:{peer_addr[1]}"
+        conn_id = uuid4().hex
+        logger.trace(f"New connection {conn_id} from {remote_id}")
 
         transport = writer.transport
         # Set reasonable write buffer limits (64KB high, 16KB low)
@@ -193,7 +228,7 @@ class DirectoryServer:
         try:
             logger.trace(f"[{conn_id}] Waiting for handshake message...")
             data = await asyncio.wait_for(connection.receive(), timeout=30.0)
-            logger.trace(f"[{conn_id}] Received {len(data)} bytes: {data[:200]!r}...")
+            logger.trace(f"[{conn_id}] Received {len(data)} handshake bytes")
 
             envelope = MessageEnvelope.from_bytes(
                 data,
@@ -208,7 +243,6 @@ class DirectoryServer:
                 logger.warning(f"[{conn_id}] Expected handshake, got {envelope.message_type}")
                 return None
 
-            logger.trace(f"[{conn_id}] Processing handshake payload: {envelope.payload[:200]}")
             peer_info, response = self.handshake_handler.process_handshake(
                 envelope.payload, conn_id
             )
@@ -221,24 +255,85 @@ class DirectoryServer:
             )
             response_bytes = response_envelope.to_bytes()
             logger.trace(f"[{conn_id}] Sending handshake response: {len(response_bytes)} bytes")
-            logger.trace(f"[{conn_id}] Response content: {response_bytes[:200]!r}...")
+
+            if response.get("accepted") is not True:
+                await connection.send(response_bytes)
+                return None
+
+            if self.handshake_handler.negotiates_nick_auth(peer_info):
+                await connection.send(response_bytes)
+                verified_pubkey = await self._perform_nick_auth(
+                    connection,
+                    conn_id,
+                    peer_info,
+                    envelope.payload,
+                )
+                if verified_pubkey is None:
+                    return None
+                try:
+                    registration = await self._register_peer(
+                        peer_info,
+                        conn_id,
+                        verified_pubkey=verified_pubkey,
+                    )
+                except (PeerOwnershipConflictError, ValueError):
+                    await self._send_nick_auth_result(connection, "policy", safe=True)
+                    logger.info(
+                        f"[{conn_id}] Rejected verified ownership collision for {peer_info.nick}"
+                    )
+                    return None
+                await self._close_displaced_connections(registration)
+                try:
+                    async with self._owner_lock(registration.peer_key):
+                        if not self.peer_registry.is_current_owner(
+                            registration.peer_key,
+                            conn_id,
+                        ):
+                            return None
+                        await self._send_nick_auth_result(connection, "ok")
+                        if not self.peer_registry.update_status(
+                            registration.peer_key,
+                            PeerStatus.HANDSHAKED,
+                            expected_connection_id=conn_id,
+                        ):
+                            return None
+                except Exception:
+                    await self._rollback_registration(registration.peer_key, conn_id)
+                    raise
+                return registration.peer_key
 
             try:
-                await connection.send(response_bytes)
+                registration = await self._register_peer(peer_info, conn_id)
+            except (PeerOwnershipConflictError, ValueError) as e:
+                rejection = MessageEnvelope(
+                    message_type=MessageType.DN_HANDSHAKE,
+                    payload=json.dumps(self.handshake_handler.create_rejection_response(str(e))),
+                )
+                await connection.send(rejection.to_bytes())
+                logger.info(f"[{conn_id}] Rejected duplicate peer ownership for {peer_info.nick}")
+                return None
+
+            peer_key = registration.peer_key
+            logger.trace(f"[{conn_id}] Peer registered in registry")
+
+            try:
+                async with self._owner_lock(peer_key):
+                    if not self.peer_registry.is_current_owner(peer_key, conn_id):
+                        return None
+                    await connection.send(response_bytes)
                 logger.trace(f"[{conn_id}] Handshake response sent successfully")
                 # Small delay to let client process the handshake response
                 await asyncio.sleep(0.05)
             except Exception as e:
                 logger.error(f"[{conn_id}] Failed to send handshake response: {e}")
+                await self._rollback_registration(peer_key, conn_id)
                 raise
 
-            peer_location = peer_info.location_string
-            self.peer_registry.register(peer_info)
-            logger.trace(f"[{conn_id}] Peer registered in registry")
-
-            peer_key = peer_info.nick if peer_location == "NOT-SERVING-ONION" else peer_location
-            self.peer_registry.update_status(peer_key, PeerStatus.HANDSHAKED)
-            self.peer_key_to_conn_id[peer_key] = conn_id
+            async with self._owner_lock(peer_key):
+                if not self.peer_registry.update_status(
+                    peer_key, PeerStatus.HANDSHAKED, expected_connection_id=conn_id
+                ):
+                    return None
             logger.trace(f"[{conn_id}] Peer key mapped: {peer_key}")
 
             logger.trace(f"[{conn_id}] Handshake complete for {peer_key} (nick={peer_info.nick})")
@@ -254,6 +349,212 @@ class DirectoryServer:
         except Exception as e:
             logger.error(f"[{conn_id}] Handshake error: {e}", exc_info=True)
             return None
+
+    async def _perform_nick_auth(
+        self,
+        connection: TCPConnection,
+        conn_id: str,
+        peer_info: PeerInfo,
+        handshake_line: str,
+    ) -> str | None:
+        directory_id = self.handshake_handler.nick_auth_directory_id
+        if directory_id is None:
+            return None
+
+        challenge = NickAuthChallenge.from_payload(
+            {
+                "kind": "challenge",
+                "challenge": secrets.token_hex(32),
+                "directory-id": directory_id,
+            }
+        )
+        challenge_envelope = MessageEnvelope(
+            message_type=MessageType.NICK_AUTH,
+            payload=challenge.to_json(),
+        )
+        await asyncio.wait_for(
+            connection.send(challenge_envelope.to_bytes()),
+            timeout=self.nick_auth_timeout,
+        )
+
+        try:
+            data = await asyncio.wait_for(
+                connection.receive(),
+                timeout=self.nick_auth_timeout,
+            )
+        except TimeoutError:
+            logger.info(f"[{conn_id}] Nick authentication timed out")
+            await self._send_nick_auth_result(connection, "expired", safe=True)
+            return None
+
+        try:
+            parse_strict_json_object(data)
+            proof_envelope = MessageEnvelope.from_bytes(
+                data,
+                max_line_length=self.settings.max_line_length,
+                max_json_nesting_depth=self.settings.max_json_nesting_depth,
+            )
+            if proof_envelope.message_type != MessageType.NICK_AUTH:
+                raise ValueError("unexpected nick authentication message type")
+            proof = NickAuthProof.parse(proof_envelope.payload)
+        except Exception:
+            logger.info(f"[{conn_id}] Nick authentication payload was malformed")
+            await self._send_nick_auth_result(connection, "malformed", safe=True)
+            return None
+
+        if not verify_nick_auth_proof(
+            proof,
+            expected_challenge=challenge.challenge,
+            expected_directory_id=directory_id,
+            handshake_line=handshake_line,
+            nick=peer_info.nick,
+        ):
+            logger.info(f"[{conn_id}] Nick authentication proof was invalid")
+            await self._send_nick_auth_result(connection, "invalid", safe=True)
+            return None
+
+        return proof.pubkey
+
+    async def _send_nick_auth_result(
+        self,
+        connection: TCPConnection,
+        code: Literal["ok", "malformed", "expired", "invalid", "policy"],
+        *,
+        safe: bool = False,
+    ) -> None:
+        result = NickAuthResult(code=code, verified=code == "ok")
+        envelope = MessageEnvelope(
+            message_type=MessageType.NICK_AUTH_RESULT,
+            payload=result.to_json(),
+        )
+        send_result = connection.send(envelope.to_bytes())
+        if safe:
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(send_result, timeout=self.nick_auth_timeout)
+            return
+        await asyncio.wait_for(send_result, timeout=self.nick_auth_timeout)
+
+    @staticmethod
+    def _peer_key(peer: PeerInfo) -> str:
+        return peer.nick if peer.location_string == "NOT-SERVING-ONION" else peer.location_string
+
+    def _owner_lock(self, peer_key: str) -> asyncio.Lock:
+        lock = self._owner_locks.get(peer_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._owner_locks[peer_key] = lock
+        return lock
+
+    @contextlib.asynccontextmanager
+    async def _lock_owner_keys(self, *peer_keys: str | None) -> AsyncIterator[None]:
+        keys = sorted({key for key in peer_keys if key is not None})
+        async with contextlib.AsyncExitStack() as stack:
+            for key in keys:
+                await stack.enter_async_context(self._owner_lock(key))
+            yield
+
+    async def _register_peer(
+        self,
+        peer: PeerInfo,
+        connection_id: str,
+        *,
+        verified_pubkey: bytes | str | None = None,
+    ) -> RegistrationResult:
+        """Serialize ownership replacement with writes to every affected routing key."""
+        async with self._registration_lock:
+            new_key = self._peer_key(peer)
+            current_nick_key = self.peer_registry.get_key_by_nick(peer.nick)
+            async with self._lock_owner_keys(new_key, current_nick_key):
+                registration = self.peer_registry.register(
+                    peer,
+                    connection_id,
+                    verified_pubkey=verified_pubkey,
+                )
+                self._activate_registration(registration)
+                return registration
+
+    def _activate_registration(self, registration: RegistrationResult) -> None:
+        for displaced in registration.displaced:
+            self.heartbeat.forget_owner(displaced.peer_key, displaced.connection_id)
+            self.message_router.remove_peer_offers(
+                displaced.peer_key,
+                displaced.connection_id,
+            )
+            if self.peer_key_to_conn_id.get(displaced.peer_key) == displaced.connection_id:
+                del self.peer_key_to_conn_id[displaced.peer_key]
+        self.peer_key_to_conn_id[registration.peer_key] = registration.connection_id
+
+    async def _close_displaced_connections(self, registration: RegistrationResult) -> None:
+        for displaced in registration.displaced:
+            await self.message_router.broadcast_displaced_peer_disconnect(
+                displaced.peer,
+                displaced.connection_id,
+            )
+            connection = self.connections.get(displaced.connection_id)
+            if connection is not None:
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(
+                        connection.close(),
+                        timeout=min(self.nick_auth_timeout, 5.0),
+                    )
+
+    async def _rollback_registration(self, peer_key: str, connection_id: str) -> None:
+        await self._remove_owned_peer_state(
+            peer_key,
+            connection_id,
+            broadcast_disconnect=False,
+        )
+
+    async def _remove_owned_peer_state(
+        self,
+        peer_key: str,
+        connection_id: str,
+        *,
+        broadcast_disconnect: bool = True,
+        clear_unqualified_mapping: bool = False,
+    ) -> PeerInfo | None:
+        """Remove all state for one exact owner while blocking replacement and routing writes."""
+        peer: PeerInfo | None = None
+        disconnect_snapshot: PeerInfo | None = None
+        was_visible = False
+        async with self._owner_lock(peer_key):
+            if not self.peer_registry.is_current_owner(peer_key, connection_id):
+                return None
+            peer = self.peer_registry.get_by_key(peer_key)
+            if peer is None:
+                return None
+
+            was_visible = peer.status is PeerStatus.HANDSHAKED
+            if was_visible:
+                disconnect_snapshot = peer.model_copy(deep=True)
+            self.peer_registry.update_status(peer_key, PeerStatus.DISCONNECTED, connection_id)
+            self.peer_registry.unregister(peer_key, connection_id)
+            self.message_router.remove_peer_offers(peer_key, connection_id)
+            self.heartbeat.forget_owner(peer_key, connection_id)
+            if clear_unqualified_mapping or self.peer_key_to_conn_id.get(peer_key) == connection_id:
+                self.peer_key_to_conn_id.pop(peer_key, None)
+
+        # Never hold an owner lock while sending to other owners. Concurrent
+        # disconnects could otherwise deadlock by each waiting on the other's
+        # lock. The snapshot form also remains valid after registry removal.
+        if broadcast_disconnect and disconnect_snapshot is not None:
+            try:
+                await self.message_router.broadcast_displaced_peer_disconnect(
+                    disconnect_snapshot,
+                    connection_id,
+                )
+            except Exception as exc:
+                logger.debug(f"Failed to broadcast disconnect for {peer_key}: {exc}")
+        return peer
+
+    async def _close_connection_generation(self, connection_id: str) -> None:
+        self.rate_limiter.remove_peer(connection_id)
+        connection = self.connections.get(connection_id)
+        if connection is None:
+            return
+        self.connections.remove(connection_id)
+        with contextlib.suppress(Exception):
+            await connection.close()
 
     async def _handle_peer_messages(
         self, connection: TCPConnection, conn_id: str, peer_key: str
@@ -274,10 +575,13 @@ class DirectoryServer:
 
         while connection.is_connected() and not self._shutdown:
             try:
+                if not self.peer_registry.is_current_owner(peer_key, conn_id):
+                    break
                 data = await connection.receive()
 
                 # Update last_seen on every received message for heartbeat liveness
-                self.peer_registry.update_last_seen(peer_key)
+                if not self.peer_registry.update_last_seen(peer_key, conn_id):
+                    break
 
                 # Rate limiting by connection ID to prevent nick spoofing attacks.
                 # A malicious peer could claim another's nick in handshake and spam
@@ -316,7 +620,7 @@ class DirectoryServer:
                     max_json_nesting_depth=self.settings.max_json_nesting_depth,
                 )
 
-                await self.message_router.route_message(envelope, peer_key)
+                await self.message_router.route_message(envelope, peer_key, conn_id)
 
             except asyncio.CancelledError:
                 break
@@ -339,25 +643,11 @@ class DirectoryServer:
 
         try:
             if peer_key:
-                peer_info = self.peer_registry.get_by_key(peer_key)
-
+                peer_info = await self._remove_owned_peer_state(peer_key, conn_id)
                 if peer_info:
                     logger.info(f"Peer {peer_info.nick} disconnected")
-                    # Fire-and-forget notification for peer disconnect
-                    total_peers = (
-                        self.peer_registry.count() - 1
-                    )  # Minus 1 since we're about to unregister
+                    total_peers = self.peer_registry.count()
                     spawn_task(get_notifier().notify_peer_disconnected(peer_info.nick, total_peers))
-                    await self.message_router.broadcast_peer_disconnect(
-                        peer_info.location_string, peer_info.network
-                    )
-                    self.peer_registry.unregister(peer_key)
-
-                if peer_key in self.peer_key_to_conn_id:
-                    del self.peer_key_to_conn_id[peer_key]
-
-                # Clean up offer tracking
-                self.message_router.remove_peer_offers(peer_key)
 
             # Clean up rate limiter state (keyed by conn_id, not peer_key)
             self.rate_limiter.remove_peer(conn_id)
@@ -368,75 +658,101 @@ class DirectoryServer:
             except Exception as e:
                 logger.trace(f"Error closing connection: {e}")
 
-    async def _send_to_peer(self, peer_location: str, data: bytes) -> None:
+    async def _send_to_peer(
+        self,
+        peer_location: str,
+        data: bytes,
+        expected_connection_id: str | None = None,
+    ) -> None:
         peer_key = peer_location
+        async with self._owner_lock(peer_key):
+            conn_id = self.peer_key_to_conn_id.get(peer_key)
+            if not conn_id:
+                raise ValueError(f"No connection for peer: {peer_location}")
 
-        conn_id = self.peer_key_to_conn_id.get(peer_key)
-        if not conn_id:
-            raise ValueError(f"No connection for peer: {peer_location}")
+            expected_connection_id = expected_connection_id or conn_id
+            peer = self.peer_registry.get_by_key(peer_key)
+            if (
+                conn_id != expected_connection_id
+                or peer is None
+                or peer.status is not PeerStatus.HANDSHAKED
+                or not self.peer_registry.is_current_owner(peer_key, expected_connection_id)
+            ):
+                raise ValueError(f"Stale connection for peer: {peer_location}")
 
-        connection = self.connections.get(conn_id)
-        if not connection:
-            raise ValueError(f"No connection for conn_id: {conn_id}")
+            connection = self.connections.get(expected_connection_id)
+            if not connection:
+                raise ValueError(f"No connection for conn_id: {expected_connection_id}")
 
-        await connection.send(data)
+            await asyncio.wait_for(
+                connection.send(data),
+                timeout=_DIRECTORY_SEND_TIMEOUT_SEC,
+            )
 
-    async def _handle_send_failed(self, peer_key: str) -> None:
+    async def _handle_send_failed(
+        self, peer_key: str, expected_connection_id: str | None = None
+    ) -> None:
         """
         Called when sending to a peer fails.
 
         Removes the peer from both the connection mapping and the registry
         to prevent further send attempts to this dead connection.
         """
-        if peer_key in self.peer_key_to_conn_id:
-            logger.debug(f"Removing failed peer mapping: {peer_key}")
-            del self.peer_key_to_conn_id[peer_key]
+        generation_was_explicit = expected_connection_id is not None
+        expected_connection_id = expected_connection_id or self.peer_registry.get_connection_id(
+            peer_key
+        )
+        if expected_connection_id is None or not self.peer_registry.is_current_owner(
+            peer_key, expected_connection_id
+        ):
+            return
 
-        # Also unregister from peer registry to prevent further routing attempts
-        peer_info = self.peer_registry.get_by_key(peer_key)
-        if peer_info:
-            logger.debug(f"Unregistering failed peer: {peer_key}")
-            self.peer_registry.unregister(peer_key)
+        peer_info = await self._remove_owned_peer_state(
+            peer_key,
+            expected_connection_id,
+            clear_unqualified_mapping=not generation_was_explicit,
+        )
+        if peer_info is None:
+            return
+        logger.debug(f"Unregistered failed peer: {peer_key}")
+        spawn_task(
+            get_notifier().notify_peer_disconnected(peer_info.nick, self.peer_registry.count())
+        )
+        await self._close_connection_generation(expected_connection_id)
 
-    async def _evict_peer(self, peer_key: str, reason: str) -> None:
+    async def _evict_peer(
+        self,
+        peer_key: str,
+        reason: str,
+        expected_connection_id: str | None = None,
+    ) -> None:
         """Evict a peer due to heartbeat timeout.
 
         Broadcasts disconnect, unregisters from registry, closes the
         underlying TCP connection, and cleans up all mappings.
         """
+        expected_connection_id = expected_connection_id or self.peer_registry.get_connection_id(
+            peer_key
+        )
         peer_info = self.peer_registry.get_by_key(peer_key)
-        if not peer_info:
+        if (
+            not peer_info
+            or expected_connection_id is None
+            or not self.peer_registry.is_current_owner(peer_key, expected_connection_id)
+        ):
             return
 
         logger.info(f"Evicting peer {peer_info.nick} ({peer_key}): {reason}")
-
-        # Broadcast disconnect to other peers
-        try:
-            await self.message_router.broadcast_peer_disconnect(
-                peer_info.location_string, peer_info.network
+        removed_peer = await self._remove_owned_peer_state(peer_key, expected_connection_id)
+        if removed_peer is None:
+            return
+        spawn_task(
+            get_notifier().notify_peer_disconnected(
+                removed_peer.nick,
+                self.peer_registry.count(),
             )
-        except Exception as e:
-            logger.debug(f"Failed to broadcast disconnect for {peer_key}: {e}")
-
-        # Fire-and-forget notification
-        total_peers = self.peer_registry.count() - 1
-        spawn_task(get_notifier().notify_peer_disconnected(peer_info.nick, total_peers))
-
-        # Unregister from registry
-        self.peer_registry.unregister(peer_key)
-        self.message_router.remove_peer_offers(peer_key)
-
-        # Close the underlying connection
-        conn_id = self.peer_key_to_conn_id.pop(peer_key, None)
-        if conn_id:
-            self.rate_limiter.remove_peer(conn_id)
-            connection = self.connections.get(conn_id)
-            if connection:
-                self.connections.remove(conn_id)
-                try:
-                    await connection.close()
-                except Exception as e:
-                    logger.trace(f"Error closing evicted connection: {e}")
+        )
+        await self._close_connection_generation(expected_connection_id)
 
     def is_healthy(self) -> bool:
         return (

--- a/directory_server/tests/test_handshake_handler.py
+++ b/directory_server/tests/test_handshake_handler.py
@@ -6,7 +6,8 @@ import json
 
 import pytest
 from jmcore.models import NetworkType
-from jmcore.protocol import JM_VERSION, JM_VERSION_MIN
+from jmcore.nick_auth import NickAuthMode
+from jmcore.protocol import FEATURE_NICK_AUTH, JM_VERSION, JM_VERSION_MIN
 
 from directory_server.handshake_handler import HandshakeError, HandshakeHandler
 
@@ -221,6 +222,74 @@ def test_create_rejection_response(handler):
 
     assert response["accepted"] is False
     assert "Rejected: Test rejection" in response["motd"]
+
+
+def test_advertises_nick_auth_only_with_enabled_mode_and_identity():
+    enabled = HandshakeHandler(
+        network=NetworkType.MAINNET,
+        server_nick="directory",
+        motd="test",
+        nick_auth_mode=NickAuthMode.PREFER_VERIFIED,
+        nick_auth_directory_id="test:directory",
+    )
+    missing_identity = HandshakeHandler(
+        network=NetworkType.MAINNET,
+        server_nick="directory",
+        motd="test",
+        nick_auth_mode=NickAuthMode.PREFER_VERIFIED,
+    )
+    disabled = HandshakeHandler(
+        network=NetworkType.MAINNET,
+        server_nick="directory",
+        motd="test",
+        nick_auth_mode=NickAuthMode.DISABLED,
+        nick_auth_directory_id="test:directory",
+    )
+    handshake_data = json.dumps(
+        {
+            "app-name": "joinmarket",
+            "directory": False,
+            "location-string": "NOT-SERVING-ONION",
+            "proto-ver": JM_VERSION,
+            "features": {FEATURE_NICK_AUTH: True},
+            "nick": "test_client",
+            "network": "mainnet",
+        }
+    )
+
+    _, enabled_response = enabled.process_handshake(handshake_data, "connection")
+    _, missing_response = missing_identity.process_handshake(handshake_data, "connection")
+    _, disabled_response = disabled.process_handshake(handshake_data, "connection")
+
+    assert enabled_response["features"][FEATURE_NICK_AUTH] is True
+    assert FEATURE_NICK_AUTH not in missing_response["features"]
+    assert FEATURE_NICK_AUTH not in disabled_response["features"]
+
+
+def test_require_verified_rejects_legacy_client_with_ordinary_response():
+    handler = HandshakeHandler(
+        network=NetworkType.MAINNET,
+        server_nick="directory",
+        motd="test",
+        nick_auth_mode=NickAuthMode.REQUIRE_VERIFIED,
+        nick_auth_directory_id="test:directory",
+    )
+    handshake_data = json.dumps(
+        {
+            "app-name": "joinmarket",
+            "directory": False,
+            "location-string": "NOT-SERVING-ONION",
+            "proto-ver": JM_VERSION,
+            "features": {},
+            "nick": "legacy_client",
+            "network": "mainnet",
+        }
+    )
+
+    _, response = handler.process_handshake(handshake_data, "connection")
+
+    assert response["accepted"] is False
+    assert response["features"][FEATURE_NICK_AUTH] is True
 
 
 class TestVersionNegotiation:

--- a/directory_server/tests/test_heartbeat.py
+++ b/directory_server/tests/test_heartbeat.py
@@ -149,10 +149,12 @@ class TestHeartbeatSweep:
         old_time = datetime.now(UTC) - timedelta(seconds=config.hard_evict_sec + 10)
         peer = _make_peer("stale_maker", features={"ping": True})
         key = _register_and_handshake(registry, peer, last_seen=old_time)
+        connection_id = registry.get_connection_id(key)
+        assert connection_id is not None
 
         await manager._sweep()
 
-        evict_cb.assert_any_await(key, "idle timeout")
+        evict_cb.assert_any_await(key, "idle timeout", connection_id)
 
     @pytest.mark.anyio
     async def test_hard_evict_clears_pong_pending(
@@ -184,6 +186,7 @@ class TestHeartbeatSweep:
         registry: PeerRegistry,
         manager: HeartbeatManager,
         send_cb: AsyncMock,
+        evict_cb: AsyncMock,
         config: HeartbeatConfig,
     ) -> None:
         """Peers with ping feature and idle > idle_threshold get a PING."""
@@ -205,7 +208,7 @@ class TestHeartbeatSweep:
         # Peer should be in pong_pending (will be cleared after pong_wait)
         # Note: after _sweep completes, pong_pending was checked and evict was called.
         # Since we didn't send a pong, the peer would have been evicted.
-        evict_calls = [c[0][0] for c in manager.evict_callback.call_args_list]
+        evict_calls = [c[0][0] for c in evict_cb.call_args_list]
         assert key in evict_calls
 
     @pytest.mark.anyio
@@ -411,11 +414,13 @@ class TestHeartbeatSweep:
         idle_time = datetime.now(UTC) - timedelta(seconds=config.idle_threshold_sec + 10)
         peer = _make_peer("unresponsive_maker", features={"ping": True})
         key = _register_and_handshake(registry, peer, last_seen=idle_time)
+        connection_id = registry.get_connection_id(key)
+        assert connection_id is not None
 
         await manager._sweep()
 
         # Peer should have been evicted with "pong timeout" reason
-        evict_cb.assert_any_await(key, "pong timeout")
+        evict_cb.assert_any_await(key, "pong timeout", connection_id)
 
     # -- send failure --
 
@@ -497,6 +502,8 @@ class TestHeartbeatSweep:
         # 3) Hard-evict candidate
         stale_peer = _make_peer("stale_peer", onion="c" * 56 + ".onion")
         stale_key = _register_and_handshake(registry, stale_peer, last_seen=hard_evict_time)
+        stale_connection_id = registry.get_connection_id(stale_key)
+        assert stale_connection_id is not None
 
         # 4) Recently active peer (should not be touched)
         active_peer = _make_peer("active_peer", onion="d" * 56 + ".onion", features={"ping": True})
@@ -505,7 +512,7 @@ class TestHeartbeatSweep:
         await manager._sweep()
 
         # Stale peer should be hard-evicted
-        evict_cb.assert_any_await(stale_key, "idle timeout")
+        evict_cb.assert_any_await(stale_key, "idle timeout", stale_connection_id)
 
         # Ping peer should be evicted (no pong response)
         evict_calls = [c[0][0] for c in evict_cb.call_args_list]

--- a/directory_server/tests/test_heartbeat.py
+++ b/directory_server/tests/test_heartbeat.py
@@ -168,7 +168,9 @@ class TestHeartbeatSweep:
         key = _register_and_handshake(registry, peer, last_seen=old_time)
 
         # Manually mark pending
-        manager._pong_pending.add(key)
+        connection_id = registry.get_connection_id(key)
+        assert connection_id is not None
+        manager._pong_pending.add((key, connection_id))
 
         await manager._sweep()
 
@@ -495,11 +497,11 @@ class TestHandlePong:
             send_callback=AsyncMock(),
             evict_callback=AsyncMock(),
         )
-        manager._pong_pending.add("some_key")
+        manager._pong_pending.add(("some_key", "connection"))
 
-        manager.handle_pong("some_key")
+        manager.handle_pong("some_key", "connection")
 
-        assert "some_key" not in manager.pong_pending
+        assert ("some_key", "connection") not in manager.pong_pending
 
     def test_handle_pong_noop_for_unknown_key(self) -> None:
         registry = PeerRegistry()
@@ -528,16 +530,32 @@ class TestPongPendingProperty:
             send_callback=AsyncMock(),
             evict_callback=AsyncMock(),
         )
-        manager._pong_pending.add("key1")
-        manager._pong_pending.add("key2")
+        manager._pong_pending.add(("key1", "connection1"))
+        manager._pong_pending.add(("key2", "connection2"))
 
         pending = manager.pong_pending
         assert isinstance(pending, frozenset)
-        assert pending == frozenset({"key1", "key2"})
+        assert pending == frozenset({("key1", "connection1"), ("key2", "connection2")})
 
         # Mutating the internal set should not affect previously returned snapshot
-        manager._pong_pending.discard("key1")
-        assert "key1" in pending  # still in the frozenset we captured
+        manager._pong_pending.discard(("key1", "connection1"))
+        assert ("key1", "connection1") in pending
+
+    def test_stale_pong_does_not_clear_replacement_pending(self) -> None:
+        registry = PeerRegistry()
+        peer = _make_peer("maker", features={"ping": True})
+        key = registry.register(peer, "old").peer_key
+        registry.register(peer.model_copy(deep=True), "new", verified_pubkey=b"pubkey")
+        manager = HeartbeatManager(
+            peer_registry=registry,
+            send_callback=AsyncMock(),
+            evict_callback=AsyncMock(),
+        )
+        manager._pong_pending.add((key, "new"))
+
+        manager.handle_pong(key, "old")
+
+        assert manager.pong_pending == frozenset({(key, "new")})
 
 
 # ---------------------------------------------------------------------------
@@ -609,7 +627,7 @@ class TestLifecycle:
             config=HeartbeatConfig(sweep_interval_sec=999),
         )
 
-        manager._pong_pending.add("leftover_key")
+        manager._pong_pending.add(("leftover_key", "connection"))
         manager.start()
         await manager.stop()
 

--- a/directory_server/tests/test_heartbeat.py
+++ b/directory_server/tests/test_heartbeat.py
@@ -60,7 +60,7 @@ def _register_and_handshake(
     Returns the peer key used in the registry.
     """
     registry.register(peer)
-    key = peer.nick if peer.location_string == "NOT-SERVING-ONION" else peer.location_string
+    key = peer.nick
     registry.update_status(key, PeerStatus.HANDSHAKED)
     if last_seen is not None:
         p = registry.get_by_key(key)
@@ -174,7 +174,7 @@ class TestHeartbeatSweep:
 
         await manager._sweep()
 
-        assert key not in manager.pong_pending
+        assert (key, connection_id) not in manager.pong_pending
 
     # -- probing idle peers --
 
@@ -242,6 +242,37 @@ class TestHeartbeatSweep:
         assert "orderbook" in payload
         assert "!PUBLIC!" in payload
         assert payload.startswith("J5DNtestdir!")
+
+    @pytest.mark.anyio
+    async def test_shared_location_peers_are_probed_by_nick(
+        self,
+        registry: PeerRegistry,
+        send_cb: AsyncMock,
+        config: HeartbeatConfig,
+    ) -> None:
+        manager = HeartbeatManager(
+            peer_registry=registry,
+            send_callback=send_cb,
+            evict_callback=AsyncMock(),
+            config=config,
+            server_nick="J5DNtestdir",
+        )
+        idle_time = datetime.now(UTC) - timedelta(seconds=config.idle_threshold_sec + 10)
+        shared_onion = "a" * 56 + ".onion"
+        first_key = _register_and_handshake(
+            registry,
+            _make_peer("first_maker", onion=shared_onion),
+            last_seen=idle_time,
+        )
+        second_key = _register_and_handshake(
+            registry,
+            _make_peer("second_maker", onion=shared_onion),
+            last_seen=idle_time,
+        )
+
+        await manager._sweep()
+
+        assert {call.args[0] for call in send_cb.await_args_list} == {first_key, second_key}
 
     @pytest.mark.anyio
     async def test_orderbook_probe_format_compatible_with_reference(

--- a/directory_server/tests/test_message_router.py
+++ b/directory_server/tests/test_message_router.py
@@ -97,7 +97,7 @@ class TestMessageRouterFailedSendCleanup:
             send_callback=failing_send,
         )
 
-        targets = [(sample_peers[0].location_string, sample_peers[0].nick)]
+        targets = [(sample_peers[0].nick, sample_peers[0].nick)]
 
         # First broadcast - peer fails
         await router._batched_broadcast(targets, b"test data")
@@ -113,7 +113,7 @@ class TestMessageRouterFailedSendCleanup:
     ):
         """Failed peers should be filtered out within the same broadcast."""
         send_attempts = []
-        fail_peer = sample_peers[0].location_string
+        fail_peer = sample_peers[0].nick
 
         async def selective_failing_send(peer_key: str, data: bytes) -> None:
             send_attempts.append(peer_key)
@@ -128,7 +128,7 @@ class TestMessageRouterFailedSendCleanup:
 
         # Create targets with the failing peer appearing in multiple batches conceptually
         # (in practice they're unique, but the failed set should prevent retries)
-        targets = [(p.location_string, p.nick) for p in sample_peers]
+        targets = [(p.nick, p.nick) for p in sample_peers]
 
         await router._batched_broadcast(targets, b"test data")
 
@@ -203,10 +203,10 @@ class TestMessageRouterPrivateMessageFailedSend:
         payload = f"{from_peer.nick}!{to_peer.nick}!test message"
         envelope = MessageEnvelope(message_type=MessageType.PRIVMSG, payload=payload)
 
-        await router._handle_private_message(envelope, from_peer.location_string)
+        await router._handle_private_message(envelope, from_peer.nick)
 
         # The target peer should have been marked as failed
-        assert to_peer.location_string in failed_peers
+        assert to_peer.nick in failed_peers
 
     @pytest.mark.anyio
     async def test_private_send_failure_reports_failed_generation(self, registry):
@@ -289,6 +289,44 @@ class TestMessageRouterPrivateMessageFailedSend:
 
         assert sent_messages == []
 
+    @pytest.mark.anyio
+    async def test_private_message_routes_by_nick_when_locations_match(self, registry):
+        shared_onion = "a" * 56 + ".onion"
+        sender = PeerInfo(
+            nick="sender",
+            onion_address=shared_onion,
+            port=5222,
+            network=NetworkType.MAINNET,
+            status=PeerStatus.HANDSHAKED,
+        )
+        recipient = PeerInfo(
+            nick="recipient",
+            onion_address=shared_onion,
+            port=5222,
+            network=NetworkType.MAINNET,
+            status=PeerStatus.HANDSHAKED,
+        )
+        sender_key = registry.register(sender, "sender-connection").peer_key
+        recipient_key = registry.register(recipient, "recipient-connection").peer_key
+        sent_messages: list[tuple[str, MessageType, str]] = []
+
+        async def record_send(peer_key: str, data: bytes, connection_id: str) -> None:
+            envelope = MessageEnvelope.from_bytes(data)
+            sent_messages.append((peer_key, envelope.message_type, connection_id))
+
+        router = MessageRouter(peer_registry=registry, send_callback=record_send)
+        envelope = MessageEnvelope(
+            message_type=MessageType.PRIVMSG,
+            payload="sender!recipient!fill payload pubkey signature",
+        )
+
+        await router.route_message(envelope, sender_key, "sender-connection")
+
+        assert sent_messages == [
+            (recipient_key, MessageType.PRIVMSG, "recipient-connection"),
+            (recipient_key, MessageType.PEERLIST, "recipient-connection"),
+        ]
+
 
 class TestMessageRouterSenderBinding:
     """Messages cannot claim a nick other than the handshaked connection."""
@@ -308,7 +346,7 @@ class TestMessageRouterSenderBinding:
             payload=f"{forged.nick}!PUBLIC!sw0reloffer 0 30000 72590 0 0.001",
         )
 
-        await router._handle_public_message(envelope, sender.location_string)
+        await router._handle_public_message(envelope, sender.nick)
 
         assert sent_messages == []
 
@@ -371,7 +409,7 @@ class TestMessageRouterSenderBinding:
             payload=f"{forged.nick}!{recipient.nick}!fill payload pubkey signature",
         )
 
-        await router._handle_private_message(envelope, connection_owner.location_string)
+        await router._handle_private_message(envelope, connection_owner.nick)
 
         assert sent_messages == []
 
@@ -406,7 +444,7 @@ class TestOfferTracking:
         payload = f"{maker.nick}!PUBLIC!sw0absoffer 0 30000 72590 0 1000"
         envelope = MessageEnvelope(message_type=MessageType.PUBMSG, payload=payload)
 
-        await router._handle_public_message(envelope, maker.location_string)
+        await router._handle_public_message(envelope, maker.nick)
 
         # Check offer was tracked
         stats = router.get_offer_stats()
@@ -440,7 +478,7 @@ class TestOfferTracking:
         for i in range(3):
             payload = f"{maker.nick}!PUBLIC!sw0absoffer {i} 30000 72590 0 1000"
             envelope = MessageEnvelope(message_type=MessageType.PUBMSG, payload=payload)
-            await router._handle_public_message(envelope, maker.location_string)
+            await router._handle_public_message(envelope, maker.nick)
 
         # Check offers were tracked
         stats = router.get_offer_stats()
@@ -476,7 +514,7 @@ class TestOfferTracking:
             for i in range(num_offers):
                 payload = f"{maker.nick}!PUBLIC!sw0reloffer {i} 30000 72590 0 0.001"
                 envelope = MessageEnvelope(message_type=MessageType.PUBMSG, payload=payload)
-                await router._handle_public_message(envelope, maker.location_string)
+                await router._handle_public_message(envelope, maker.nick)
 
         # Check stats
         stats = router.get_offer_stats()
@@ -511,14 +549,14 @@ class TestOfferTracking:
         # Send offer message
         payload = f"{maker.nick}!PUBLIC!sw0absoffer 0 30000 72590 0 1000"
         envelope = MessageEnvelope(message_type=MessageType.PUBMSG, payload=payload)
-        await router._handle_public_message(envelope, maker.location_string)
+        await router._handle_public_message(envelope, maker.nick)
 
         # Verify offer is tracked
         stats = router.get_offer_stats()
         assert stats["total_offers"] == 1
 
         # Remove peer offers
-        router.remove_peer_offers(maker.location_string)
+        router.remove_peer_offers(maker.nick)
 
         # Verify offers were removed
         stats = router.get_offer_stats()
@@ -572,7 +610,7 @@ class TestChunkedPeerlist:
         registry.register(requester)
 
         # Send peerlist
-        await router.send_peerlist(requester.location_string, NetworkType.MAINNET, chunk_size=20)
+        await router.send_peerlist(requester.nick, NetworkType.MAINNET, chunk_size=20)
 
         # Should have sent 3 chunks (50 peers / 20 = 2.5, rounded up)
         # Note: requester is also in the registry so it's 51 total, but requester
@@ -582,7 +620,7 @@ class TestChunkedPeerlist:
         # Parse messages to verify content
         total_peers = 0
         for peer_key, data in sent_messages:
-            assert peer_key == requester.location_string
+            assert peer_key == requester.nick
             envelope = MessageEnvelope.from_bytes(data)
             assert envelope.message_type == MessageType.PEERLIST
             # Count comma-separated entries (each peer is an entry)
@@ -628,7 +666,7 @@ class TestChunkedPeerlist:
         registry.register(requester)
 
         # Send peerlist
-        await router.send_peerlist(requester.location_string, NetworkType.MAINNET, chunk_size=20)
+        await router.send_peerlist(requester.nick, NetworkType.MAINNET, chunk_size=20)
 
         # Should have sent exactly 1 chunk (6 peers including requester < 20)
         assert len(sent_messages) == 1
@@ -677,7 +715,7 @@ class TestPingPongRouting:
             send_callback=mock_send,
         )
 
-        from_key = sample_peers[0].location_string
+        from_key = sample_peers[0].nick
         envelope = MessageEnvelope(message_type=MessageType.PING, payload="")
 
         await router.route_message(envelope, from_key)
@@ -706,7 +744,7 @@ class TestPingPongRouting:
             on_pong=on_pong,
         )
 
-        from_key = sample_peers[0].location_string
+        from_key = sample_peers[0].nick
         envelope = MessageEnvelope(message_type=MessageType.PONG, payload="")
 
         await router.route_message(envelope, from_key)
@@ -726,7 +764,7 @@ class TestPingPongRouting:
             on_pong=None,
         )
 
-        from_key = sample_peers[0].location_string
+        from_key = sample_peers[0].nick
         envelope = MessageEnvelope(message_type=MessageType.PONG, payload="")
 
         # Should not raise
@@ -744,7 +782,7 @@ class TestPingPongRouting:
             send_callback=failing_send,
         )
 
-        from_key = sample_peers[0].location_string
+        from_key = sample_peers[0].nick
         envelope = MessageEnvelope(message_type=MessageType.PING, payload="")
 
         # Should not raise

--- a/directory_server/tests/test_message_router.py
+++ b/directory_server/tests/test_message_router.py
@@ -2,6 +2,8 @@
 Tests for message router, focusing on failed send cleanup and offer tracking.
 """
 
+import asyncio
+
 import pytest
 from jmcore.models import MessageEnvelope, NetworkType, PeerInfo, PeerStatus
 from jmcore.protocol import MessageType
@@ -42,10 +44,10 @@ class TestMessageRouterFailedSendCleanup:
         """When a send fails, the on_send_failed callback should be invoked."""
         failed_peers = []
 
-        async def failing_send(peer_key: str, data: bytes) -> None:
+        async def failing_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             raise ConnectionError("Connection closed")
 
-        async def on_failed(peer_key: str) -> None:
+        async def on_failed(peer_key: str, connection_id: str) -> None:
             failed_peers.append(peer_key)
 
         router = MessageRouter(
@@ -64,7 +66,7 @@ class TestMessageRouterFailedSendCleanup:
         """Peers that have already failed should be skipped on subsequent attempts."""
         send_attempts = []
 
-        async def failing_send(peer_key: str, data: bytes) -> None:
+        async def failing_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             send_attempts.append(peer_key)
             raise ConnectionError("Connection closed")
 
@@ -73,22 +75,24 @@ class TestMessageRouterFailedSendCleanup:
             send_callback=failing_send,
         )
 
+        failed: set[tuple[str, str]] = set()
+
         # First attempt - should try to send
-        await router._safe_send("peer0", b"test data", "peer0")
+        await router._safe_send("peer0", b"test data", "peer0", failed=failed)
         assert len(send_attempts) == 1
 
-        # Second attempt - should skip because peer is in _failed_peers
-        await router._safe_send("peer0", b"test data", "peer0")
+        # Second attempt - should skip because peer failed in this operation
+        await router._safe_send("peer0", b"test data", "peer0", failed=failed)
         assert len(send_attempts) == 1  # No additional attempt
 
     @pytest.mark.anyio
-    async def test_batched_broadcast_clears_failed_peers_on_new_broadcast(
+    async def test_batched_broadcast_uses_fresh_failures_for_new_broadcast(
         self, registry, sample_peers
     ):
-        """Each new broadcast should clear the failed peers set."""
+        """Each new broadcast should use an independent failed peers set."""
         send_attempts = []
 
-        async def failing_send(peer_key: str, data: bytes) -> None:
+        async def failing_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             send_attempts.append(peer_key)
             raise ConnectionError("Connection closed")
 
@@ -103,7 +107,7 @@ class TestMessageRouterFailedSendCleanup:
         await router._batched_broadcast(targets, b"test data")
         assert len(send_attempts) == 1
 
-        # Second broadcast - should try again because _failed_peers was cleared
+        # Second broadcast has an independent failure set and should try again
         await router._batched_broadcast(targets, b"test data")
         assert len(send_attempts) == 2
 
@@ -115,7 +119,9 @@ class TestMessageRouterFailedSendCleanup:
         send_attempts = []
         fail_peer = sample_peers[0].nick
 
-        async def selective_failing_send(peer_key: str, data: bytes) -> None:
+        async def selective_failing_send(
+            peer_key: str, data: bytes, connection_id: str | None
+        ) -> None:
             send_attempts.append(peer_key)
             if peer_key == fail_peer:
                 raise ConnectionError("Connection closed")
@@ -126,24 +132,121 @@ class TestMessageRouterFailedSendCleanup:
             broadcast_batch_size=2,  # Small batch to test filtering across batches
         )
 
-        # Create targets with the failing peer appearing in multiple batches conceptually
-        # (in practice they're unique, but the failed set should prevent retries)
-        targets = [(p.nick, p.nick) for p in sample_peers]
+        targets = [
+            (sample_peers[0].nick, sample_peers[0].nick),
+            (sample_peers[1].nick, sample_peers[1].nick),
+            (sample_peers[0].nick, sample_peers[0].nick),
+        ]
 
         await router._batched_broadcast(targets, b"test data")
 
-        # Each peer should only be attempted once
-        unique_attempts = set(send_attempts)
-        assert len(unique_attempts) == len(send_attempts)
+        assert send_attempts.count(fail_peer) == 1
+
+    @pytest.mark.anyio
+    async def test_reentrant_broadcast_keeps_outer_failures(self, registry, sample_peers) -> None:
+        failed_peer = sample_peers[0].nick
+        nested_peer = sample_peers[1].nick
+        send_attempts: list[str] = []
+        router: MessageRouter
+
+        async def selective_failing_send(
+            peer_key: str, data: bytes, connection_id: str | None
+        ) -> None:
+            send_attempts.append(peer_key)
+            if peer_key == failed_peer:
+                raise ConnectionError("Connection closed")
+
+        async def on_failed(peer_key: str, connection_id: str) -> None:
+            nested_connection_id = registry.get_connection_id(nested_peer)
+            assert nested_connection_id is not None
+            await router._batched_broadcast(
+                [(nested_peer, nested_peer, nested_connection_id)], b"nested"
+            )
+
+        router = MessageRouter(
+            peer_registry=registry,
+            send_callback=selective_failing_send,
+            broadcast_batch_size=1,
+            on_send_failed=on_failed,
+        )
+        failed_connection_id = registry.get_connection_id(failed_peer)
+        assert failed_connection_id is not None
+
+        await router._batched_broadcast(
+            [
+                (failed_peer, failed_peer, failed_connection_id),
+                (failed_peer, failed_peer, failed_connection_id),
+            ],
+            b"outer",
+        )
+
+        assert send_attempts == [failed_peer, nested_peer]
+
+    @pytest.mark.anyio
+    async def test_concurrent_broadcasts_keep_failures_isolated(
+        self, registry, sample_peers
+    ) -> None:
+        failed_peer = sample_peers[0].nick
+        gate_peer = sample_peers[1].nick
+        gate_started = asyncio.Event()
+        first_failure_recorded = asyncio.Event()
+        release_first_cleanup = asyncio.Event()
+        failed_payloads: list[bytes] = []
+        failure_count = 0
+
+        async def coordinated_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
+            if peer_key == gate_peer:
+                gate_started.set()
+                await first_failure_recorded.wait()
+                return
+            failed_payloads.append(data)
+            raise ConnectionError("Connection closed")
+
+        async def on_failed(peer_key: str, connection_id: str) -> None:
+            nonlocal failure_count
+            failure_count += 1
+            first_failure_recorded.set()
+            if failure_count == 1:
+                await release_first_cleanup.wait()
+
+        router = MessageRouter(
+            peer_registry=registry,
+            send_callback=coordinated_send,
+            broadcast_batch_size=1,
+            on_send_failed=on_failed,
+        )
+        failed_connection_id = registry.get_connection_id(failed_peer)
+        gate_connection_id = registry.get_connection_id(gate_peer)
+        assert failed_connection_id is not None
+        assert gate_connection_id is not None
+
+        first = asyncio.create_task(
+            router._batched_broadcast(
+                [
+                    (gate_peer, gate_peer, gate_connection_id),
+                    (failed_peer, failed_peer, failed_connection_id),
+                ],
+                b"first",
+            )
+        )
+        await gate_started.wait()
+        second = asyncio.create_task(
+            router._batched_broadcast([(failed_peer, failed_peer, failed_connection_id)], b"second")
+        )
+        await first
+        release_first_cleanup.set()
+        await second
+
+        assert failed_payloads == [b"second", b"first"]
 
     @pytest.mark.anyio
     async def test_on_send_failed_callback_error_is_handled(self, registry, sample_peers):
         """Errors in the on_send_failed callback should not propagate."""
 
-        async def failing_send(peer_key: str, data: bytes) -> None:
+        async def failing_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             raise ConnectionError("Connection closed")
 
-        async def broken_callback(peer_key: str) -> None:
+        async def broken_callback(peer_key: str, connection_id: str) -> None:
             raise RuntimeError("Callback error")
 
         router = MessageRouter(
@@ -160,10 +263,10 @@ class TestMessageRouterFailedSendCleanup:
         """Successful sends should not trigger the on_send_failed callback."""
         failed_peers = []
 
-        async def successful_send(peer_key: str, data: bytes) -> None:
+        async def successful_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             pass  # Success
 
-        async def on_failed(peer_key: str) -> None:
+        async def on_failed(peer_key: str, connection_id: str) -> None:
             failed_peers.append(peer_key)
 
         router = MessageRouter(
@@ -187,10 +290,10 @@ class TestMessageRouterPrivateMessageFailedSend:
         from_peer = sample_peers[0]
         to_peer = sample_peers[1]
 
-        async def failing_send(peer_key: str, data: bytes) -> None:
+        async def failing_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             raise ConnectionError("Connection closed")
 
-        async def on_failed(peer_key: str) -> None:
+        async def on_failed(peer_key: str, connection_id: str) -> None:
             failed_peers.append(peer_key)
 
         router = MessageRouter(
@@ -230,7 +333,7 @@ class TestMessageRouterPrivateMessageFailedSend:
             recipient, "old-recipient", verified_pubkey=b"recipient-pubkey"
         ).peer_key
 
-        async def replace_then_fail(peer_key: str, data: bytes, connection_id: str) -> None:
+        async def replace_then_fail(peer_key: str, data: bytes, connection_id: str | None) -> None:
             registry.register(
                 recipient.model_copy(deep=True),
                 "new-recipient",
@@ -276,7 +379,8 @@ class TestMessageRouterPrivateMessageFailedSend:
         )
         registry.register(recipient, "pending-recipient", verified_pubkey=b"recipient-key")
 
-        async def record_send(peer_key: str, data: bytes, connection_id: str) -> None:
+        async def record_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
+            assert connection_id is not None
             sent_messages.append((peer_key, connection_id))
 
         router = MessageRouter(peer_registry=registry, send_callback=record_send)
@@ -308,9 +412,10 @@ class TestMessageRouterPrivateMessageFailedSend:
         )
         sender_key = registry.register(sender, "sender-connection").peer_key
         recipient_key = registry.register(recipient, "recipient-connection").peer_key
-        sent_messages: list[tuple[str, MessageType, str]] = []
+        sent_messages: list[tuple[str, int, str]] = []
 
-        async def record_send(peer_key: str, data: bytes, connection_id: str) -> None:
+        async def record_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
+            assert connection_id is not None
             envelope = MessageEnvelope.from_bytes(data)
             sent_messages.append((peer_key, envelope.message_type, connection_id))
 
@@ -335,7 +440,7 @@ class TestMessageRouterSenderBinding:
     async def test_drops_public_message_with_forged_sender(self, registry, sample_peers):
         sent_messages = []
 
-        async def record_send(peer_key: str, data: bytes) -> None:
+        async def record_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             sent_messages.append((peer_key, data))
 
         router = MessageRouter(peer_registry=registry, send_callback=record_send)
@@ -354,7 +459,8 @@ class TestMessageRouterSenderBinding:
     async def test_stale_generation_cannot_route_or_publish_offers(self, registry):
         sent_messages: list[tuple[str, str]] = []
 
-        async def record_send(peer_key: str, data: bytes, connection_id: str) -> None:
+        async def record_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
+            assert connection_id is not None
             sent_messages.append((peer_key, connection_id))
 
         sender = PeerInfo(
@@ -397,7 +503,7 @@ class TestMessageRouterSenderBinding:
     async def test_drops_private_message_with_forged_sender(self, registry, sample_peers):
         sent_messages = []
 
-        async def record_send(peer_key: str, data: bytes) -> None:
+        async def record_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             sent_messages.append((peer_key, data))
 
         router = MessageRouter(peer_registry=registry, send_callback=record_send)
@@ -422,7 +528,7 @@ class TestOfferTracking:
         """Should track sw0absoffer messages."""
         sent_messages = []
 
-        async def mock_send(peer_key: str, data: bytes) -> None:
+        async def mock_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             sent_messages.append((peer_key, data))
 
         router = MessageRouter(
@@ -456,7 +562,7 @@ class TestOfferTracking:
         """Should track multiple offers from same peer."""
         sent_messages = []
 
-        async def mock_send(peer_key: str, data: bytes) -> None:
+        async def mock_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             sent_messages.append((peer_key, data))
 
         router = MessageRouter(
@@ -490,7 +596,7 @@ class TestOfferTracking:
         """Should identify peers with more than 2 offers."""
         sent_messages = []
 
-        async def mock_send(peer_key: str, data: bytes) -> None:
+        async def mock_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             sent_messages.append((peer_key, data))
 
         router = MessageRouter(
@@ -528,7 +634,7 @@ class TestOfferTracking:
         """Should remove offers when peer disconnects."""
         sent_messages = []
 
-        async def mock_send(peer_key: str, data: bytes) -> None:
+        async def mock_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             sent_messages.append((peer_key, data))
 
         router = MessageRouter(
@@ -572,7 +678,7 @@ class TestChunkedPeerlist:
         """Should send peerlist in chunks for large peer lists."""
         sent_messages: list[tuple[str, bytes]] = []
 
-        async def mock_send(peer_key: str, data: bytes) -> None:
+        async def mock_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             sent_messages.append((peer_key, data))
 
         router = MessageRouter(
@@ -636,7 +742,7 @@ class TestChunkedPeerlist:
         """Should send single chunk for small peer lists."""
         sent_messages: list[tuple[str, bytes]] = []
 
-        async def mock_send(peer_key: str, data: bytes) -> None:
+        async def mock_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             sent_messages.append((peer_key, data))
 
         router = MessageRouter(
@@ -676,7 +782,7 @@ class TestChunkedPeerlist:
         """Should send empty peerlist response when registry is empty."""
         sent_messages: list[tuple[str, bytes]] = []
 
-        async def mock_send(peer_key: str, data: bytes) -> None:
+        async def mock_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             sent_messages.append((peer_key, data))
 
         router = MessageRouter(
@@ -707,7 +813,7 @@ class TestPingPongRouting:
         """When a PING is received, the router should respond with a PONG."""
         sent_messages: list[tuple[str, bytes]] = []
 
-        async def mock_send(peer_key: str, data: bytes) -> None:
+        async def mock_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             sent_messages.append((peer_key, data))
 
         router = MessageRouter(
@@ -730,13 +836,13 @@ class TestPingPongRouting:
     @pytest.mark.anyio
     async def test_pong_calls_on_pong_callback(self, registry, sample_peers):
         """When a PONG is received, the on_pong callback should be invoked."""
-        pong_keys: list[str] = []
+        pong_keys: list[tuple[str, str]] = []
 
-        async def mock_send(peer_key: str, data: bytes) -> None:
+        async def mock_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             pass
 
-        def on_pong(peer_key: str) -> None:
-            pong_keys.append(peer_key)
+        def on_pong(peer_key: str, connection_id: str) -> None:
+            pong_keys.append((peer_key, connection_id))
 
         router = MessageRouter(
             peer_registry=registry,
@@ -749,13 +855,15 @@ class TestPingPongRouting:
 
         await router.route_message(envelope, from_key)
 
-        assert pong_keys == [from_key]
+        connection_id = registry.get_connection_id(from_key)
+        assert connection_id is not None
+        assert pong_keys == [(from_key, connection_id)]
 
     @pytest.mark.anyio
     async def test_pong_without_callback_does_not_raise(self, registry, sample_peers):
         """When a PONG is received with no on_pong callback, nothing should happen."""
 
-        async def mock_send(peer_key: str, data: bytes) -> None:
+        async def mock_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             pass
 
         router = MessageRouter(
@@ -774,7 +882,7 @@ class TestPingPongRouting:
     async def test_ping_send_failure_does_not_raise(self, registry, sample_peers):
         """If sending the PONG response fails, it should be handled gracefully."""
 
-        async def failing_send(peer_key: str, data: bytes) -> None:
+        async def failing_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             raise ConnectionError("Connection closed")
 
         router = MessageRouter(
@@ -792,7 +900,7 @@ class TestPingPongRouting:
     async def test_connected_peer_cannot_route_before_handshake(self, registry):
         sent_messages: list[str] = []
 
-        async def record_send(peer_key: str, data: bytes) -> None:
+        async def record_send(peer_key: str, data: bytes, connection_id: str | None) -> None:
             sent_messages.append(peer_key)
 
         peer = PeerInfo(

--- a/directory_server/tests/test_message_router.py
+++ b/directory_server/tests/test_message_router.py
@@ -208,6 +208,87 @@ class TestMessageRouterPrivateMessageFailedSend:
         # The target peer should have been marked as failed
         assert to_peer.location_string in failed_peers
 
+    @pytest.mark.anyio
+    async def test_private_send_failure_reports_failed_generation(self, registry):
+        failed_owners: list[tuple[str, str]] = []
+        sender = PeerInfo(
+            nick="sender",
+            onion_address="a" * 56 + ".onion",
+            port=5222,
+            network=NetworkType.MAINNET,
+            status=PeerStatus.HANDSHAKED,
+        )
+        sender_key = registry.register(sender, "sender-connection").peer_key
+        recipient = PeerInfo(
+            nick="recipient",
+            onion_address="b" * 56 + ".onion",
+            port=5222,
+            network=NetworkType.MAINNET,
+            status=PeerStatus.HANDSHAKED,
+        )
+        recipient_key = registry.register(
+            recipient, "old-recipient", verified_pubkey=b"recipient-pubkey"
+        ).peer_key
+
+        async def replace_then_fail(peer_key: str, data: bytes, connection_id: str) -> None:
+            registry.register(
+                recipient.model_copy(deep=True),
+                "new-recipient",
+                verified_pubkey=b"recipient-pubkey",
+            )
+            raise ConnectionError("old connection closed")
+
+        async def on_failed(peer_key: str, connection_id: str) -> None:
+            failed_owners.append((peer_key, connection_id))
+
+        router = MessageRouter(
+            peer_registry=registry,
+            send_callback=replace_then_fail,
+            on_send_failed=on_failed,
+        )
+        envelope = MessageEnvelope(
+            message_type=MessageType.PRIVMSG,
+            payload="sender!recipient!fill payload pubkey signature",
+        )
+
+        await router.route_message(envelope, sender_key, "sender-connection")
+
+        assert failed_owners == [(recipient_key, "old-recipient")]
+        assert registry.get_connection_id(recipient_key) == "new-recipient"
+
+    @pytest.mark.anyio
+    async def test_private_message_does_not_route_to_pending_owner(self, registry):
+        sent_messages: list[tuple[str, str]] = []
+        sender = PeerInfo(
+            nick="sender",
+            onion_address="a" * 56 + ".onion",
+            port=5222,
+            network=NetworkType.MAINNET,
+            status=PeerStatus.HANDSHAKED,
+        )
+        sender_key = registry.register(sender, "sender-connection").peer_key
+        recipient = PeerInfo(
+            nick="recipient",
+            onion_address="b" * 56 + ".onion",
+            port=5222,
+            network=NetworkType.MAINNET,
+            status=PeerStatus.CONNECTED,
+        )
+        registry.register(recipient, "pending-recipient", verified_pubkey=b"recipient-key")
+
+        async def record_send(peer_key: str, data: bytes, connection_id: str) -> None:
+            sent_messages.append((peer_key, connection_id))
+
+        router = MessageRouter(peer_registry=registry, send_callback=record_send)
+        envelope = MessageEnvelope(
+            message_type=MessageType.PRIVMSG,
+            payload="sender!recipient!fill payload pubkey signature",
+        )
+
+        await router.route_message(envelope, sender_key, "sender-connection")
+
+        assert sent_messages == []
+
 
 class TestMessageRouterSenderBinding:
     """Messages cannot claim a nick other than the handshaked connection."""
@@ -230,7 +311,49 @@ class TestMessageRouterSenderBinding:
         await router._handle_public_message(envelope, sender.location_string)
 
         assert sent_messages == []
+
+    @pytest.mark.anyio
+    async def test_stale_generation_cannot_route_or_publish_offers(self, registry):
+        sent_messages: list[tuple[str, str]] = []
+
+        async def record_send(peer_key: str, data: bytes, connection_id: str) -> None:
+            sent_messages.append((peer_key, connection_id))
+
+        sender = PeerInfo(
+            nick="sender",
+            onion_address="a" * 56 + ".onion",
+            port=5222,
+            network=NetworkType.MAINNET,
+            status=PeerStatus.HANDSHAKED,
+        )
+        sender_key = registry.register(sender, "old").peer_key
+        recipient = PeerInfo(
+            nick="recipient",
+            onion_address="b" * 56 + ".onion",
+            port=5222,
+            network=NetworkType.MAINNET,
+            status=PeerStatus.HANDSHAKED,
+        )
+        recipient_key = registry.register(recipient, "recipient-connection").peer_key
+        router = MessageRouter(peer_registry=registry, send_callback=record_send)
+        envelope = MessageEnvelope(
+            message_type=MessageType.PUBMSG,
+            payload="sender!PUBLIC!sw0absoffer 0 30000 72590 0 1000",
+        )
+
+        await router.route_message(envelope, sender_key, "old")
+        assert router.get_offer_stats()["total_offers"] == 1
+
+        registry.register(sender.model_copy(deep=True), "new", verified_pubkey=b"verified-pubkey")
+        sent_messages.clear()
+        await router.route_message(envelope, sender_key, "old")
+
+        assert sent_messages == []
         assert router.get_offer_stats()["total_offers"] == 0
+
+        await router.route_message(envelope, sender_key, "new")
+        assert sent_messages == [(recipient_key, "recipient-connection")]
+        assert router.get_offer_stats()["total_offers"] == 1
 
     @pytest.mark.anyio
     async def test_drops_private_message_with_forged_sender(self, registry, sample_peers):
@@ -626,3 +749,26 @@ class TestPingPongRouting:
 
         # Should not raise
         await router.route_message(envelope, from_key)
+
+    @pytest.mark.anyio
+    async def test_connected_peer_cannot_route_before_handshake(self, registry):
+        sent_messages: list[str] = []
+
+        async def record_send(peer_key: str, data: bytes) -> None:
+            sent_messages.append(peer_key)
+
+        peer = PeerInfo(
+            nick="connecting",
+            onion_address="a" * 56 + ".onion",
+            port=5222,
+            network=NetworkType.MAINNET,
+            status=PeerStatus.CONNECTED,
+        )
+        key = registry.register(peer, "connection").peer_key
+        router = MessageRouter(peer_registry=registry, send_callback=record_send)
+
+        await router.route_message(
+            MessageEnvelope(message_type=MessageType.PING, payload=""), key, "connection"
+        )
+
+        assert sent_messages == []

--- a/directory_server/tests/test_peer_registry.py
+++ b/directory_server/tests/test_peer_registry.py
@@ -44,7 +44,7 @@ def test_register_duplicate_nick(registry, sample_peer):
         registry.register(peer2, "second")
 
     assert registry.count() == 1
-    assert registry.get_connection_id(sample_peer.location_string) == "first"
+    assert registry.get_connection_id(sample_peer.nick) == "first"
 
 
 def test_verified_peer_atomically_displaces_legacy_owner(registry, sample_peer):
@@ -61,13 +61,16 @@ def test_verified_peer_atomically_displaces_legacy_owner(registry, sample_peer):
 
 def test_same_verified_pubkey_reconnect_replaces_owner(registry, sample_peer):
     key = registry.register(sample_peer, "first", verified_pubkey=b"same-key").peer_key
-
-    result = registry.register(
-        sample_peer.model_copy(deep=True), "second", verified_pubkey=b"same-key"
+    replacement = sample_peer.model_copy(
+        update={"onion_address": f"{'b' * 56}.onion"},
+        deep=True,
     )
+
+    result = registry.register(replacement, "second", verified_pubkey=b"same-key")
 
     assert result.displaced[0].connection_id == "first"
     assert registry.get_connection_id(key) == "second"
+    assert registry.get_by_key(key) is replacement
 
 
 def test_different_verified_pubkey_for_same_nick_is_rejected(registry, sample_peer):
@@ -81,15 +84,26 @@ def test_different_verified_pubkey_for_same_nick_is_rejected(registry, sample_pe
     assert registry.get_connection_id(key) == "first"
 
 
-def test_verified_nick_cannot_displace_different_nick_at_same_location(registry, sample_peer):
-    key = registry.register(sample_peer, "location-owner").peer_key
-    attacker = sample_peer.model_copy(update={"nick": "authenticated-attacker"})
+@pytest.mark.parametrize("verified_pubkey", [None, b"second-key"])
+def test_different_nicks_can_share_location(registry, sample_peer, verified_pubkey):
+    first = registry.register(sample_peer, "first")
+    second_peer = sample_peer.model_copy(update={"nick": "second-peer"})
 
-    with pytest.raises(PeerOwnershipConflictError, match="location already registered"):
-        registry.register(attacker, "attacker", verified_pubkey=b"attacker-key")
+    second = registry.register(second_peer, "second", verified_pubkey=verified_pubkey)
 
-    assert registry.get_connection_id(key) == "location-owner"
+    assert first.peer_key == sample_peer.nick
+    assert second.peer_key == second_peer.nick
+    assert second.displaced == ()
+    assert registry.count() == 2
     assert registry.get_by_nick(sample_peer.nick) is sample_peer
+    assert registry.get_by_nick(second_peer.nick) is second_peer
+
+    registry.update_status(first.peer_key, PeerStatus.HANDSHAKED, "first")
+    registry.update_status(second.peer_key, PeerStatus.HANDSHAKED, "second")
+    assert set(registry.get_peerlist_for_network(NetworkType.MAINNET)) == {
+        (sample_peer.nick, sample_peer.location_string),
+        (second_peer.nick, second_peer.location_string),
+    }
 
 
 def test_stale_generation_cannot_mutate_or_unregister_owner(registry, sample_peer):
@@ -122,30 +136,19 @@ def test_max_peers_limit(registry):
 
 def test_unregister_peer(registry, sample_peer):
     registry.register(sample_peer)
-    location = sample_peer.location_string
 
-    registry.unregister(location)
+    registry.unregister(sample_peer.nick)
 
     assert registry.count() == 0
     assert registry.get_by_nick("test_peer") is None
 
 
-def test_get_by_location(registry, sample_peer):
-    registry.register(sample_peer)
-    location = sample_peer.location_string
-
-    retrieved = registry.get_by_location(location)
-    assert retrieved is not None
-    assert retrieved.nick == "test_peer"
-
-
 def test_update_status(registry, sample_peer):
     registry.register(sample_peer)
-    location = sample_peer.location_string
 
-    registry.update_status(location, PeerStatus.HANDSHAKED)
+    registry.update_status(sample_peer.nick, PeerStatus.HANDSHAKED)
 
-    peer = registry.get_by_location(location)
+    peer = registry.get_by_nick(sample_peer.nick)
     assert peer.status == PeerStatus.HANDSHAKED
 
 
@@ -158,7 +161,7 @@ def test_get_all_connected(registry):
             network=NetworkType.MAINNET,
         )
         registry.register(peer)
-        registry.update_status(peer.location_string, PeerStatus.HANDSHAKED)
+        registry.update_status(peer.nick, PeerStatus.HANDSHAKED)
 
     connected = registry.get_all_connected(NetworkType.MAINNET)
     assert len(connected) == 3
@@ -174,8 +177,8 @@ def test_get_all_connected_filters_network(registry):
 
     registry.register(mainnet_peer)
     registry.register(testnet_peer)
-    registry.update_status(mainnet_peer.location_string, PeerStatus.HANDSHAKED)
-    registry.update_status(testnet_peer.location_string, PeerStatus.HANDSHAKED)
+    registry.update_status(mainnet_peer.nick, PeerStatus.HANDSHAKED)
+    registry.update_status(testnet_peer.nick, PeerStatus.HANDSHAKED)
 
     mainnet_peers = registry.get_all_connected(NetworkType.MAINNET)
     assert len(mainnet_peers) == 1
@@ -187,7 +190,7 @@ def test_get_peerlist_for_network(registry):
         nick="peer1", onion_address=f"{'a' * 56}.onion", port=5222, network=NetworkType.MAINNET
     )
     registry.register(peer)
-    registry.update_status(peer.location_string, PeerStatus.HANDSHAKED)
+    registry.update_status(peer.nick, PeerStatus.HANDSHAKED)
 
     peerlist = registry.get_peerlist_for_network(NetworkType.MAINNET)
     assert len(peerlist) == 1
@@ -474,7 +477,7 @@ class TestUpdateLastSeen:
             network=NetworkType.MAINNET,
         )
         registry.register(peer)
-        key = peer.location_string
+        key = peer.nick
 
         # Backdate last_seen
         p = registry.get_by_key(key)
@@ -598,7 +601,7 @@ class TestSupportsPing:
             features={"ping": True},
         )
         registry.register(peer)
-        key = peer.location_string
+        key = peer.nick
 
         assert registry.supports_ping(key) is True
 
@@ -611,7 +614,7 @@ class TestSupportsPing:
             features={},
         )
         registry.register(peer)
-        key = peer.location_string
+        key = peer.nick
 
         assert registry.supports_ping(key) is False
 
@@ -624,7 +627,7 @@ class TestSupportsPing:
             features={"ping": False},
         )
         registry.register(peer)
-        key = peer.location_string
+        key = peer.nick
 
         assert registry.supports_ping(key) is False
 
@@ -643,7 +646,7 @@ class TestIsMaker:
             network=NetworkType.MAINNET,
         )
         registry.register(peer)
-        key = peer.location_string
+        key = peer.nick
 
         assert registry.is_maker(key) is True
 

--- a/directory_server/tests/test_peer_registry.py
+++ b/directory_server/tests/test_peer_registry.py
@@ -5,7 +5,7 @@ Tests for peer registry.
 import pytest
 from jmcore.models import NetworkType, PeerInfo, PeerStatus
 
-from directory_server.peer_registry import PeerRegistry
+from directory_server.peer_registry import PeerOwnershipConflictError, PeerRegistry
 
 
 @pytest.fixture
@@ -33,16 +33,79 @@ def test_register_peer(registry, sample_peer):
 
 
 def test_register_duplicate_nick(registry, sample_peer):
-    registry.register(sample_peer)
+    registry.register(sample_peer, "first")
 
     peer2 = PeerInfo(
         nick="test_peer",
         onion_address="abcdefghijklmnopqrstuvwxyz234567abcdefghijklmnopqrstuvw2.onion",
         port=5222,
     )
-    registry.register(peer2)
+    with pytest.raises(PeerOwnershipConflictError):
+        registry.register(peer2, "second")
 
-    assert registry.count() == 2
+    assert registry.count() == 1
+    assert registry.get_connection_id(sample_peer.location_string) == "first"
+
+
+def test_verified_peer_atomically_displaces_legacy_owner(registry, sample_peer):
+    first = registry.register(sample_peer, "legacy")
+    replacement = sample_peer.model_copy(deep=True)
+
+    result = registry.register(replacement, "verified", verified_pubkey=b"full-pubkey")
+
+    assert result.peer_key == first.peer_key
+    assert result.displaced[0].connection_id == "legacy"
+    assert registry.get_by_key(first.peer_key) is replacement
+    assert registry.get_connection_id(first.peer_key) == "verified"
+
+
+def test_same_verified_pubkey_reconnect_replaces_owner(registry, sample_peer):
+    key = registry.register(sample_peer, "first", verified_pubkey=b"same-key").peer_key
+
+    result = registry.register(
+        sample_peer.model_copy(deep=True), "second", verified_pubkey=b"same-key"
+    )
+
+    assert result.displaced[0].connection_id == "first"
+    assert registry.get_connection_id(key) == "second"
+
+
+def test_different_verified_pubkey_for_same_nick_is_rejected(registry, sample_peer):
+    key = registry.register(sample_peer, "first", verified_pubkey=b"first-key").peer_key
+
+    with pytest.raises(PeerOwnershipConflictError):
+        registry.register(
+            sample_peer.model_copy(deep=True), "second", verified_pubkey=b"different-key"
+        )
+
+    assert registry.get_connection_id(key) == "first"
+
+
+def test_verified_nick_cannot_displace_different_nick_at_same_location(registry, sample_peer):
+    key = registry.register(sample_peer, "location-owner").peer_key
+    attacker = sample_peer.model_copy(update={"nick": "authenticated-attacker"})
+
+    with pytest.raises(PeerOwnershipConflictError, match="location already registered"):
+        registry.register(attacker, "attacker", verified_pubkey=b"attacker-key")
+
+    assert registry.get_connection_id(key) == "location-owner"
+    assert registry.get_by_nick(sample_peer.nick) is sample_peer
+
+
+def test_stale_generation_cannot_mutate_or_unregister_owner(registry, sample_peer):
+    key = registry.register(sample_peer, "old", verified_pubkey=b"same-key").peer_key
+    registry.register(sample_peer.model_copy(deep=True), "new", verified_pubkey=b"same-key")
+    current = registry.get_by_key(key)
+    assert current is not None
+    last_seen = current.last_seen
+
+    assert registry.update_status(key, PeerStatus.DISCONNECTED, "old") is False
+    assert registry.update_last_seen(key, "old") is False
+    assert registry.unregister(key, "old") is False
+
+    assert registry.get_by_key(key) is current
+    assert current.status != PeerStatus.DISCONNECTED
+    assert current.last_seen == last_seen
 
 
 def test_max_peers_limit(registry):

--- a/directory_server/tests/test_server_nick_auth.py
+++ b/directory_server/tests/test_server_nick_auth.py
@@ -313,7 +313,7 @@ async def test_duplicate_outer_proof_keys_are_malformed() -> None:
             proof_envelope = MessageEnvelope.from_bytes(connection.received.pop())
             connection.received.append(
                 (
-                    '{"type":804,"type":804,"line":' + json.dumps(proof_envelope.payload) + "}"
+                    '{"type":805,"type":805,"line":' + json.dumps(proof_envelope.payload) + "}"
                 ).encode()
             )
 

--- a/directory_server/tests/test_server_nick_auth.py
+++ b/directory_server/tests/test_server_nick_auth.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import Callable
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from jmcore.crypto import NickIdentity
@@ -16,6 +16,7 @@ from jmcore.nick_auth import (
     create_nick_auth_proof,
 )
 from jmcore.protocol import FEATURE_NICK_AUTH, JM_VERSION, MessageType
+from jmcore.rate_limiter import RateLimitAction
 from jmcore.settings import DirectoryServerSettings
 
 from directory_server.handshake_handler import HandshakeHandler
@@ -327,12 +328,18 @@ async def test_duplicate_outer_proof_keys_are_malformed() -> None:
 
 
 @pytest.mark.anyio
-async def test_challenge_type_is_rejected_before_parsing_proof_payload() -> None:
+@pytest.mark.parametrize(
+    "message_type",
+    [MessageType.NICK_AUTH_CHALLENGE, MessageType.NICK_AUTH_RESULT],
+)
+async def test_out_of_order_type_is_rejected_before_parsing_proof_payload(
+    message_type: MessageType,
+) -> None:
     server = _server()
     identity = NickIdentity()
     line = _handshake_line(identity, advertise_auth=True)
     wrong_direction = MessageEnvelope(
-        message_type=MessageType.NICK_AUTH_CHALLENGE,
+        message_type=message_type,
         payload="not a proof payload",
     ).to_bytes()
     connection = ScriptedConnection([_handshake_envelope(line), wrong_direction])
@@ -344,6 +351,57 @@ async def test_challenge_type_is_rejected_before_parsing_proof_payload() -> None
     result = NickAuthResult.parse(_sent_envelopes(connection)[-1].payload)
     assert peer_key is None
     assert result.code == "malformed"
+
+
+@pytest.mark.anyio
+async def test_nick_auth_proof_before_handshake_is_rejected() -> None:
+    server = _server()
+    connection = ScriptedConnection(
+        [MessageEnvelope(message_type=MessageType.NICK_AUTH_PROOF, payload="{}").to_bytes()]
+    )
+
+    peer_key = await server._perform_handshake(connection, "proof-before-handshake")  # type: ignore[arg-type]
+
+    assert peer_key is None
+    assert server.peer_registry.count() == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "message_type",
+    [
+        MessageType.NICK_AUTH_CHALLENGE,
+        MessageType.NICK_AUTH_PROOF,
+        MessageType.NICK_AUTH_RESULT,
+    ],
+)
+async def test_nick_auth_message_after_handshake_is_not_routed(
+    message_type: MessageType,
+) -> None:
+    server = _server()
+    identity = NickIdentity()
+    line = _handshake_line(identity, advertise_auth=True)
+
+    def create_proof(challenge: NickAuthChallenge) -> NickAuthProof:
+        return create_nick_auth_proof(identity, challenge.challenge, DIRECTORY_ID, line)
+
+    connection = ScriptedConnection([_handshake_envelope(line)], create_proof)
+    peer_key = await server._perform_handshake(connection, "late-auth")  # type: ignore[arg-type]
+    assert peer_key == identity.nick
+    connection.received.append(MessageEnvelope(message_type=message_type, payload="{}").to_bytes())
+
+    with (
+        patch.object(
+            server.rate_limiter,
+            "check",
+            return_value=(RateLimitAction.DELAY, 1.0),
+        ) as check_rate_limit,
+        patch.object(server.message_router, "route_message", new_callable=AsyncMock) as route,
+    ):
+        await server._handle_peer_messages(connection, "late-auth", peer_key)
+
+    check_rate_limit.assert_not_called()
+    route.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/directory_server/tests/test_server_nick_auth.py
+++ b/directory_server/tests/test_server_nick_auth.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+
+import pytest
+from jmcore.crypto import NickIdentity
+from jmcore.models import MessageEnvelope, NetworkType, PeerInfo, PeerStatus
+from jmcore.nick_auth import (
+    NickAuthChallenge,
+    NickAuthMode,
+    NickAuthProof,
+    NickAuthResult,
+    create_nick_auth_proof,
+)
+from jmcore.protocol import FEATURE_NICK_AUTH, JM_VERSION, MessageType
+from jmcore.settings import DirectoryServerSettings
+
+from directory_server.handshake_handler import HandshakeHandler
+from directory_server.server import DirectoryServer
+
+DIRECTORY_ID = "test:directory"
+
+
+class ScriptedConnection:
+    def __init__(
+        self,
+        received: list[bytes],
+        proof_factory: Callable[[NickAuthChallenge], NickAuthProof] | None = None,
+    ) -> None:
+        self.received = received
+        self.proof_factory = proof_factory
+        self.sent: list[bytes] = []
+        self.closed = False
+
+    async def receive(self) -> bytes:
+        return self.received.pop(0)
+
+    async def send(self, data: bytes) -> None:
+        self.sent.append(data)
+        envelope = MessageEnvelope.from_bytes(data)
+        if envelope.message_type == MessageType.NICK_AUTH and self.proof_factory is not None:
+            challenge = NickAuthChallenge.parse(envelope.payload)
+            proof = self.proof_factory(challenge)
+            self.received.append(
+                MessageEnvelope(
+                    message_type=MessageType.NICK_AUTH,
+                    payload=proof.to_json(),
+                ).to_bytes()
+            )
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def is_connected(self) -> bool:
+        return not self.closed
+
+
+class BlockingConnection(ScriptedConnection):
+    def __init__(self) -> None:
+        super().__init__([])
+        self.send_started = asyncio.Event()
+        self.release_send = asyncio.Event()
+
+    async def send(self, data: bytes) -> None:
+        self.send_started.set()
+        await self.release_send.wait()
+        self.sent.append(data)
+
+
+class ResultFailingConnection(ScriptedConnection):
+    async def send(self, data: bytes) -> None:
+        envelope = MessageEnvelope.from_bytes(data)
+        if envelope.message_type == MessageType.NICK_AUTH_RESULT:
+            raise ConnectionError("result send failed")
+        await super().send(data)
+
+
+def _server(mode: NickAuthMode = NickAuthMode.PREFER_VERIFIED) -> DirectoryServer:
+    settings = DirectoryServerSettings(host="127.0.0.1", port=0, max_peers=10)
+    server = DirectoryServer(settings, NetworkType.MAINNET, "J5DirectoryOOOO")
+    server.handshake_handler = HandshakeHandler(
+        network=NetworkType.MAINNET,
+        server_nick=server.server_nick,
+        motd="test",
+        nick_auth_mode=mode,
+        nick_auth_directory_id=DIRECTORY_ID,
+    )
+    server.nick_auth_timeout = 1.0
+    return server
+
+
+def _handshake_line(identity: NickIdentity, *, advertise_auth: bool) -> str:
+    return json.dumps(
+        {
+            "app-name": "joinmarket",
+            "directory": False,
+            "location-string": "NOT-SERVING-ONION",
+            "proto-ver": JM_VERSION,
+            "features": {FEATURE_NICK_AUTH: True} if advertise_auth else {},
+            "nick": identity.nick,
+            "network": "mainnet",
+        }
+    )
+
+
+def _handshake_envelope(line: str) -> bytes:
+    return MessageEnvelope(message_type=MessageType.HANDSHAKE, payload=line).to_bytes()
+
+
+def _sent_envelopes(connection: ScriptedConnection) -> list[MessageEnvelope]:
+    return [MessageEnvelope.from_bytes(data) for data in connection.sent]
+
+
+@pytest.mark.anyio
+async def test_legacy_handshake_reserves_before_acceptance() -> None:
+    server = _server()
+    identity = NickIdentity()
+    line = _handshake_line(identity, advertise_auth=False)
+    connection = ScriptedConnection([_handshake_envelope(line)])
+
+    peer_key = await server._perform_handshake(connection, "legacy-connection")  # type: ignore[arg-type]
+
+    assert peer_key == identity.nick
+    response = json.loads(_sent_envelopes(connection)[0].payload)
+    assert response["accepted"] is True
+    assert server.peer_registry.get_connection_id(peer_key) == "legacy-connection"
+    assert server.peer_registry.get_by_key(peer_key).status is PeerStatus.HANDSHAKED
+
+
+@pytest.mark.anyio
+async def test_legacy_duplicate_gets_ordinary_rejection() -> None:
+    server = _server()
+    identity = NickIdentity()
+    line = _handshake_line(identity, advertise_auth=False)
+    existing = PeerInfo(
+        nick=identity.nick,
+        onion_address="NOT-SERVING-ONION",
+        port=-1,
+        network=NetworkType.MAINNET,
+        status=PeerStatus.HANDSHAKED,
+    )
+    server.peer_registry.register(existing, "first")
+    connection = ScriptedConnection([_handshake_envelope(line)])
+
+    peer_key = await server._perform_handshake(connection, "second")  # type: ignore[arg-type]
+
+    assert peer_key is None
+    response = json.loads(_sent_envelopes(connection)[0].payload)
+    assert response["accepted"] is False
+    assert server.peer_registry.get_connection_id(identity.nick) == "first"
+
+
+@pytest.mark.anyio
+async def test_valid_nick_auth_replaces_legacy_owner_and_clears_offers() -> None:
+    server = _server()
+    identity = NickIdentity()
+    line = _handshake_line(identity, advertise_auth=True)
+
+    def create_proof(challenge: NickAuthChallenge) -> NickAuthProof:
+        return create_nick_auth_proof(identity, challenge.challenge, DIRECTORY_ID, line)
+
+    old_peer = PeerInfo(
+        nick=identity.nick,
+        onion_address="NOT-SERVING-ONION",
+        port=-1,
+        network=NetworkType.MAINNET,
+        status=PeerStatus.HANDSHAKED,
+    )
+    peer_key = server.peer_registry.register(old_peer, "old").peer_key
+    old_connection = ScriptedConnection([])
+    server.connections.add("old", old_connection)  # type: ignore[arg-type]
+    server.peer_key_to_conn_id[peer_key] = "old"
+    server.message_router._peer_offers[(peer_key, "old")] = {"0"}
+    server.heartbeat._pong_pending.add((peer_key, "old"))
+    observer = PeerInfo(
+        nick="observer",
+        onion_address="a" * 56 + ".onion",
+        port=5222,
+        network=NetworkType.MAINNET,
+        status=PeerStatus.HANDSHAKED,
+    )
+    observer_key = server.peer_registry.register(observer, "observer").peer_key
+    observer_connection = ScriptedConnection([])
+    server.connections.add("observer", observer_connection)  # type: ignore[arg-type]
+    server.peer_key_to_conn_id[observer_key] = "observer"
+    connection = ScriptedConnection([_handshake_envelope(line)], create_proof)
+
+    result_key = await server._perform_handshake(connection, "verified")  # type: ignore[arg-type]
+
+    envelopes = _sent_envelopes(connection)
+    assert [envelope.message_type for envelope in envelopes] == [
+        MessageType.DN_HANDSHAKE,
+        MessageType.NICK_AUTH,
+        MessageType.NICK_AUTH_RESULT,
+    ]
+    result = NickAuthResult.parse(envelopes[-1].payload)
+    assert result.verified is True
+    assert result_key == peer_key
+    assert server.peer_registry.get_connection_id(peer_key) == "verified"
+    assert server.peer_registry.get_owner(peer_key).verified_pubkey == identity.public_key_hex
+    assert server.peer_registry.get_by_key(peer_key).status is PeerStatus.HANDSHAKED
+    assert old_connection.closed is True
+    assert server.message_router.get_offer_stats()["total_offers"] == 0
+    assert (peer_key, "old") not in server.heartbeat.pong_pending
+    disconnects = [MessageEnvelope.from_bytes(data) for data in observer_connection.sent]
+    assert len(disconnects) == 1
+    assert disconnects[0].message_type == MessageType.PEERLIST
+    assert disconnects[0].payload == f"{identity.nick};NOT-SERVING-ONION;D"
+
+
+@pytest.mark.anyio
+async def test_invalid_nick_auth_proof_has_no_legacy_fallback() -> None:
+    server = _server()
+    identity = NickIdentity()
+    line = _handshake_line(identity, advertise_auth=True)
+
+    def create_invalid_proof(challenge: NickAuthChallenge) -> NickAuthProof:
+        return create_nick_auth_proof(
+            identity,
+            challenge.challenge,
+            DIRECTORY_ID,
+            f"{line} ",
+        )
+
+    connection = ScriptedConnection([_handshake_envelope(line)], create_invalid_proof)
+
+    peer_key = await server._perform_handshake(connection, "invalid")  # type: ignore[arg-type]
+
+    envelopes = _sent_envelopes(connection)
+    result = NickAuthResult.parse(envelopes[-1].payload)
+    assert peer_key is None
+    assert result.code == "invalid"
+    assert result.verified is False
+    assert server.peer_registry.get_by_nick(identity.nick) is None
+
+
+@pytest.mark.anyio
+async def test_duplicate_outer_proof_keys_are_malformed() -> None:
+    server = _server()
+    identity = NickIdentity()
+    line = _handshake_line(identity, advertise_auth=True)
+
+    def create_proof(challenge: NickAuthChallenge) -> NickAuthProof:
+        return create_nick_auth_proof(identity, challenge.challenge, DIRECTORY_ID, line)
+
+    connection = ScriptedConnection([_handshake_envelope(line)], create_proof)
+    original_send = connection.send
+
+    async def duplicate_proof_send(data: bytes) -> None:
+        await original_send(data)
+        envelope = MessageEnvelope.from_bytes(data)
+        if envelope.message_type == MessageType.NICK_AUTH:
+            proof_envelope = MessageEnvelope.from_bytes(connection.received.pop())
+            connection.received.append(
+                (
+                    '{"type":803,"type":803,"line":' + json.dumps(proof_envelope.payload) + "}"
+                ).encode()
+            )
+
+    connection.send = duplicate_proof_send  # type: ignore[method-assign]
+
+    peer_key = await server._perform_handshake(connection, "duplicate-proof")  # type: ignore[arg-type]
+
+    result = NickAuthResult.parse(_sent_envelopes(connection)[-1].payload)
+    assert peer_key is None
+    assert result.code == "malformed"
+    assert server.peer_registry.get_by_nick(identity.nick) is None
+
+
+@pytest.mark.anyio
+async def test_failed_success_result_rolls_back_pending_registration() -> None:
+    server = _server()
+    identity = NickIdentity()
+    line = _handshake_line(identity, advertise_auth=True)
+
+    def create_proof(challenge: NickAuthChallenge) -> NickAuthProof:
+        return create_nick_auth_proof(identity, challenge.challenge, DIRECTORY_ID, line)
+
+    connection = ResultFailingConnection([_handshake_envelope(line)], create_proof)
+
+    peer_key = await server._perform_handshake(connection, "failed-result")  # type: ignore[arg-type]
+
+    assert peer_key is None
+    assert server.peer_registry.get_by_nick(identity.nick) is None
+    assert identity.nick not in server.peer_key_to_conn_id
+
+
+@pytest.mark.anyio
+async def test_replacement_waits_for_inflight_write_to_old_owner() -> None:
+    server = _server()
+    identity = NickIdentity()
+    old_peer = PeerInfo(
+        nick=identity.nick,
+        onion_address="NOT-SERVING-ONION",
+        port=-1,
+        network=NetworkType.MAINNET,
+        status=PeerStatus.HANDSHAKED,
+    )
+    peer_key = server.peer_registry.register(
+        old_peer,
+        "old",
+        verified_pubkey=identity.public_key_hex,
+    ).peer_key
+    old_connection = BlockingConnection()
+    server.connections.add("old", old_connection)  # type: ignore[arg-type]
+    server.peer_key_to_conn_id[peer_key] = "old"
+
+    send_task = asyncio.create_task(server._send_to_peer(peer_key, b"message", "old"))
+    await old_connection.send_started.wait()
+    replacement = old_peer.model_copy(deep=True)
+    registration_task = asyncio.create_task(
+        server._register_peer(
+            replacement,
+            "new",
+            verified_pubkey=identity.public_key_hex,
+        )
+    )
+    await asyncio.sleep(0)
+
+    assert not registration_task.done()
+    assert server.peer_registry.get_connection_id(peer_key) == "old"
+
+    old_connection.release_send.set()
+    await send_task
+    await registration_task
+
+    assert old_connection.sent == [b"message"]
+    assert server.peer_registry.get_connection_id(peer_key) == "new"
+
+
+@pytest.mark.anyio
+async def test_require_mode_rejects_nonadvertising_client() -> None:
+    server = _server(NickAuthMode.REQUIRE_VERIFIED)
+    identity = NickIdentity()
+    line = _handshake_line(identity, advertise_auth=False)
+    connection = ScriptedConnection([_handshake_envelope(line)])
+
+    peer_key = await server._perform_handshake(connection, "legacy")  # type: ignore[arg-type]
+
+    envelopes = _sent_envelopes(connection)
+    response = json.loads(envelopes[0].payload)
+    assert peer_key is None
+    assert len(envelopes) == 1
+    assert envelopes[0].message_type == MessageType.DN_HANDSHAKE
+    assert response["accepted"] is False
+    assert server.peer_registry.count() == 0

--- a/directory_server/tests/test_server_nick_auth.py
+++ b/directory_server/tests/test_server_nick_auth.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import Callable
+from unittest.mock import patch
 
 import pytest
 from jmcore.crypto import NickIdentity
@@ -40,12 +41,15 @@ class ScriptedConnection:
     async def send(self, data: bytes) -> None:
         self.sent.append(data)
         envelope = MessageEnvelope.from_bytes(data)
-        if envelope.message_type == MessageType.NICK_AUTH and self.proof_factory is not None:
+        if (
+            envelope.message_type == MessageType.NICK_AUTH_CHALLENGE
+            and self.proof_factory is not None
+        ):
             challenge = NickAuthChallenge.parse(envelope.payload)
             proof = self.proof_factory(challenge)
             self.received.append(
                 MessageEnvelope(
-                    message_type=MessageType.NICK_AUTH,
+                    message_type=MessageType.NICK_AUTH_PROOF,
                     payload=proof.to_json(),
                 ).to_bytes()
             )
@@ -197,7 +201,7 @@ async def test_valid_nick_auth_replaces_legacy_owner_and_clears_offers() -> None
     envelopes = _sent_envelopes(connection)
     assert [envelope.message_type for envelope in envelopes] == [
         MessageType.DN_HANDSHAKE,
-        MessageType.NICK_AUTH,
+        MessageType.NICK_AUTH_CHALLENGE,
         MessageType.NICK_AUTH_RESULT,
     ]
     result = NickAuthResult.parse(envelopes[-1].payload)
@@ -304,11 +308,11 @@ async def test_duplicate_outer_proof_keys_are_malformed() -> None:
     async def duplicate_proof_send(data: bytes) -> None:
         await original_send(data)
         envelope = MessageEnvelope.from_bytes(data)
-        if envelope.message_type == MessageType.NICK_AUTH:
+        if envelope.message_type == MessageType.NICK_AUTH_CHALLENGE:
             proof_envelope = MessageEnvelope.from_bytes(connection.received.pop())
             connection.received.append(
                 (
-                    '{"type":803,"type":803,"line":' + json.dumps(proof_envelope.payload) + "}"
+                    '{"type":804,"type":804,"line":' + json.dumps(proof_envelope.payload) + "}"
                 ).encode()
             )
 
@@ -320,6 +324,26 @@ async def test_duplicate_outer_proof_keys_are_malformed() -> None:
     assert peer_key is None
     assert result.code == "malformed"
     assert server.peer_registry.get_by_nick(identity.nick) is None
+
+
+@pytest.mark.anyio
+async def test_challenge_type_is_rejected_before_parsing_proof_payload() -> None:
+    server = _server()
+    identity = NickIdentity()
+    line = _handshake_line(identity, advertise_auth=True)
+    wrong_direction = MessageEnvelope(
+        message_type=MessageType.NICK_AUTH_CHALLENGE,
+        payload="not a proof payload",
+    ).to_bytes()
+    connection = ScriptedConnection([_handshake_envelope(line), wrong_direction])
+
+    with patch("directory_server.server.NickAuthProof.parse") as parse_proof:
+        peer_key = await server._perform_handshake(connection, "wrong-direction")  # type: ignore[arg-type]
+
+    parse_proof.assert_not_called()
+    result = NickAuthResult.parse(_sent_envelopes(connection)[-1].payload)
+    assert peer_key is None
+    assert result.code == "malformed"
 
 
 @pytest.mark.anyio

--- a/directory_server/tests/test_server_nick_auth.py
+++ b/directory_server/tests/test_server_nick_auth.py
@@ -91,12 +91,17 @@ def _server(mode: NickAuthMode = NickAuthMode.PREFER_VERIFIED) -> DirectoryServe
     return server
 
 
-def _handshake_line(identity: NickIdentity, *, advertise_auth: bool) -> str:
+def _handshake_line(
+    identity: NickIdentity,
+    *,
+    advertise_auth: bool,
+    location: str = "NOT-SERVING-ONION",
+) -> str:
     return json.dumps(
         {
             "app-name": "joinmarket",
             "directory": False,
-            "location-string": "NOT-SERVING-ONION",
+            "location-string": location,
             "proto-ver": JM_VERSION,
             "features": {FEATURE_NICK_AUTH: True} if advertise_auth else {},
             "nick": identity.nick,
@@ -208,6 +213,54 @@ async def test_valid_nick_auth_replaces_legacy_owner_and_clears_offers() -> None
     assert len(disconnects) == 1
     assert disconnects[0].message_type == MessageType.PEERLIST
     assert disconnects[0].payload == f"{identity.nick};NOT-SERVING-ONION;D"
+
+
+@pytest.mark.anyio
+async def test_verified_maker_is_not_blocked_by_legacy_location_squatter() -> None:
+    server = _server()
+    mallory = NickIdentity()
+    bob = NickIdentity()
+    bob_location = f"{'b' * 56}.onion:5222"
+    mallory_line = _handshake_line(
+        mallory,
+        advertise_auth=False,
+        location=bob_location,
+    )
+    bob_line = _handshake_line(
+        bob,
+        advertise_auth=True,
+        location=bob_location,
+    )
+
+    def create_bob_proof(challenge: NickAuthChallenge) -> NickAuthProof:
+        return create_nick_auth_proof(bob, challenge.challenge, DIRECTORY_ID, bob_line)
+
+    mallory_connection = ScriptedConnection([_handshake_envelope(mallory_line)])
+    bob_connection = ScriptedConnection([_handshake_envelope(bob_line)], create_bob_proof)
+
+    mallory_key = await server._perform_handshake(  # type: ignore[arg-type]
+        mallory_connection,
+        "mallory-connection",
+    )
+    bob_key = await server._perform_handshake(  # type: ignore[arg-type]
+        bob_connection,
+        "bob-connection",
+    )
+
+    assert mallory_key == mallory.nick
+    assert bob_key == bob.nick
+    assert server.peer_registry.count() == 2
+    assert server.peer_registry.get_connection_id(mallory.nick) == "mallory-connection"
+    assert server.peer_registry.get_connection_id(bob.nick) == "bob-connection"
+    mallory_peer = server.peer_registry.get_by_nick(mallory.nick)
+    bob_peer = server.peer_registry.get_by_nick(bob.nick)
+    assert mallory_peer is not None
+    assert bob_peer is not None
+    assert mallory_peer.location_string == bob_location
+    assert bob_peer.location_string == bob_location
+    result = NickAuthResult.parse(_sent_envelopes(bob_connection)[-1].payload)
+    assert result.code == "ok"
+    assert result.verified is True
 
 
 @pytest.mark.anyio

--- a/directory_server/tests/test_server_nick_auth.py
+++ b/directory_server/tests/test_server_nick_auth.py
@@ -384,6 +384,43 @@ async def test_replacement_waits_for_inflight_write_to_old_owner() -> None:
 
 
 @pytest.mark.anyio
+async def test_unrelated_registration_does_not_wait_for_inflight_write() -> None:
+    server = _server()
+    blocked_peer = PeerInfo(
+        nick="blocked",
+        onion_address="NOT-SERVING-ONION",
+        port=-1,
+        network=NetworkType.MAINNET,
+        status=PeerStatus.HANDSHAKED,
+    )
+    blocked_key = server.peer_registry.register(blocked_peer, "blocked-connection").peer_key
+    blocked_connection = BlockingConnection()
+    server.connections.add("blocked-connection", blocked_connection)  # type: ignore[arg-type]
+    server.peer_key_to_conn_id[blocked_key] = "blocked-connection"
+
+    send_task = asyncio.create_task(
+        server._send_to_peer(blocked_key, b"message", "blocked-connection")
+    )
+    await blocked_connection.send_started.wait()
+    unrelated = PeerInfo(
+        nick="unrelated",
+        onion_address="NOT-SERVING-ONION",
+        port=-1,
+        network=NetworkType.MAINNET,
+    )
+
+    registration = await asyncio.wait_for(
+        server._register_peer(unrelated, "unrelated-connection"),
+        timeout=0.1,
+    )
+
+    assert registration.peer_key == unrelated.nick
+    assert server.peer_registry.get_connection_id(unrelated.nick) == "unrelated-connection"
+    blocked_connection.release_send.set()
+    await send_task
+
+
+@pytest.mark.anyio
 async def test_require_mode_rejects_nonadvertising_client() -> None:
     server = _server(NickAuthMode.REQUIRE_VERIFIED)
     identity = NickIdentity()

--- a/directory_server/tests/test_server_send_failure.py
+++ b/directory_server/tests/test_server_send_failure.py
@@ -49,7 +49,7 @@ class TestHandleSendFailed:
         """When send fails, the peer_key_to_conn_id mapping should be removed."""
         # Register the peer
         server.peer_registry.register(sample_peer)
-        peer_key = sample_peer.location_string
+        peer_key = sample_peer.nick
 
         # Simulate connection mapping
         server.peer_key_to_conn_id[peer_key] = "conn_123"
@@ -65,7 +65,7 @@ class TestHandleSendFailed:
         """When send fails, the peer should be unregistered from the registry."""
         # Register the peer
         server.peer_registry.register(sample_peer)
-        peer_key = sample_peer.location_string
+        peer_key = sample_peer.nick
 
         # Verify peer is registered
         assert server.peer_registry.get_by_key(peer_key) is not None
@@ -89,7 +89,7 @@ class TestHandleSendFailed:
         """_handle_send_failed should handle missing connection mapping gracefully."""
         # Register the peer but don't create a connection mapping
         server.peer_registry.register(sample_peer)
-        peer_key = sample_peer.location_string
+        peer_key = sample_peer.nick
 
         # Should not raise despite missing mapping
         await server._handle_send_failed(peer_key)
@@ -102,7 +102,7 @@ class TestHandleSendFailed:
         """_handle_send_failed should clean up both mapping and registry."""
         # Register the peer
         server.peer_registry.register(sample_peer)
-        peer_key = sample_peer.location_string
+        peer_key = sample_peer.nick
 
         # Create connection mapping
         server.peer_key_to_conn_id[peer_key] = "conn_456"
@@ -120,7 +120,7 @@ class TestHandleSendFailed:
         """After send failure, peer should not appear in iter_connected."""
         # Register the peer
         server.peer_registry.register(sample_peer)
-        peer_key = sample_peer.location_string
+        peer_key = sample_peer.nick
 
         # Verify peer appears in connected list
         connected_before = list(server.peer_registry.iter_connected(NetworkType.MAINNET))
@@ -195,6 +195,26 @@ class TestHandleSendFailed:
         failed_connection.close.assert_awaited_once()
         sent = MessageEnvelope.from_bytes(observer_connection.send.await_args.args[0])
         assert sent.message_type == MessageType.PEERLIST
+        assert sent.payload == f"{sample_peer.nick};{sample_peer.location_string};D"
+
+    @pytest.mark.anyio
+    async def test_send_failure_preserves_peer_with_same_location(self, server, sample_peer):
+        failed_connection = AsyncMock()
+        surviving_connection = AsyncMock()
+        peer_key = server.peer_registry.register(sample_peer, "failed").peer_key
+        server.peer_key_to_conn_id[peer_key] = "failed"
+        server.connections.add("failed", failed_connection)
+        survivor = sample_peer.model_copy(update={"nick": "survivor"}, deep=True)
+        survivor_key = server.peer_registry.register(survivor, "survivor").peer_key
+        server.peer_key_to_conn_id[survivor_key] = "survivor"
+        server.connections.add("survivor", surviving_connection)
+
+        await server._handle_send_failed(peer_key, "failed")
+
+        assert server.peer_registry.get_by_key(peer_key) is None
+        assert server.peer_registry.get_by_key(survivor_key) is survivor
+        assert server.peer_key_to_conn_id[survivor_key] == "survivor"
+        sent = MessageEnvelope.from_bytes(surviving_connection.send.await_args.args[0])
         assert sent.payload == f"{sample_peer.nick};{sample_peer.location_string};D"
 
 

--- a/directory_server/tests/test_server_send_failure.py
+++ b/directory_server/tests/test_server_send_failure.py
@@ -5,8 +5,11 @@ These tests verify that when sending to a peer fails, the peer is properly
 cleaned up from both the connection mapping and the peer registry.
 """
 
+from unittest.mock import AsyncMock
+
 import pytest
-from jmcore.models import NetworkType, PeerInfo, PeerStatus
+from jmcore.models import MessageEnvelope, NetworkType, PeerInfo, PeerStatus
+from jmcore.protocol import MessageType
 from jmcore.settings import DirectoryServerSettings
 
 from directory_server.server import DirectoryServer
@@ -129,6 +132,70 @@ class TestHandleSendFailed:
         # Verify peer no longer appears in connected list
         connected_after = list(server.peer_registry.iter_connected(NetworkType.MAINNET))
         assert not any(p.nick == sample_peer.nick for p in connected_after)
+
+    @pytest.mark.anyio
+    async def test_stale_send_failure_does_not_remove_replacement(self, server, sample_peer):
+        peer_key = server.peer_registry.register(
+            sample_peer, "old", verified_pubkey=b"same-pubkey"
+        ).peer_key
+        replacement = sample_peer.model_copy(deep=True)
+        server.peer_registry.register(replacement, "new", verified_pubkey=b"same-pubkey")
+        server.peer_key_to_conn_id[peer_key] = "new"
+
+        await server._handle_send_failed(peer_key, "old")
+
+        assert server.peer_registry.get_by_key(peer_key) is replacement
+        assert server.peer_key_to_conn_id[peer_key] == "new"
+
+    @pytest.mark.anyio
+    async def test_stale_connection_cleanup_does_not_remove_replacement(self, server, sample_peer):
+        peer_key = server.peer_registry.register(
+            sample_peer, "old", verified_pubkey=b"same-pubkey"
+        ).peer_key
+        replacement = sample_peer.model_copy(deep=True)
+        server.peer_registry.register(replacement, "new", verified_pubkey=b"same-pubkey")
+        server.peer_key_to_conn_id[peer_key] = "new"
+        server.message_router._peer_offers[(peer_key, "new")] = {"new-offer"}
+        old_connection = AsyncMock()
+
+        await server._cleanup_peer(old_connection, "old", peer_key)
+
+        assert server.peer_registry.get_by_key(peer_key) is replacement
+        assert server.peer_key_to_conn_id[peer_key] == "new"
+        assert server.message_router.get_offer_stats()["total_offers"] == 1
+
+    @pytest.mark.anyio
+    async def test_send_failure_cleans_generation_state_and_broadcasts_disconnect(
+        self, server, sample_peer
+    ):
+        failed_connection = AsyncMock()
+        observer_connection = AsyncMock()
+        peer_key = server.peer_registry.register(sample_peer, "failed").peer_key
+        server.peer_key_to_conn_id[peer_key] = "failed"
+        server.connections.add("failed", failed_connection)
+        server.message_router._peer_offers[(peer_key, "failed")] = {"offer"}
+        server.heartbeat._pong_pending.add((peer_key, "failed"))
+        observer = PeerInfo(
+            nick="observer",
+            onion_address="b" * 56 + ".onion",
+            port=5222,
+            network=NetworkType.MAINNET,
+            status=PeerStatus.HANDSHAKED,
+        )
+        observer_key = server.peer_registry.register(observer, "observer").peer_key
+        server.peer_key_to_conn_id[observer_key] = "observer"
+        server.connections.add("observer", observer_connection)
+
+        await server._handle_send_failed(peer_key, "failed")
+
+        assert server.peer_registry.get_by_key(peer_key) is None
+        assert server.message_router.get_offer_stats()["total_offers"] == 0
+        assert (peer_key, "failed") not in server.heartbeat.pong_pending
+        assert server.connections.get("failed") is None
+        failed_connection.close.assert_awaited_once()
+        sent = MessageEnvelope.from_bytes(observer_connection.send.await_args.args[0])
+        assert sent.message_type == MessageType.PEERLIST
+        assert sent.payload == f"{sample_peer.nick};{sample_peer.location_string};D"
 
 
 class TestPassivePeerSendFailure:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,6 +227,7 @@ services:
       - NETWORK_CONFIG__NETWORK=testnet
       - LOGGING__LEVEL=DEBUG
       - DIRECTORY_NODES=jm-directory:5222
+      - 'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":"test:jm-directory-5222"}'
       - ORDERBOOK_WATCHER__HTTP_HOST=0.0.0.0
     ports:
       - "8080:8000"
@@ -268,6 +269,7 @@ services:
       # Directory servers for CoinJoin (tumbler/do_coinjoin taker needs these).
       # Regtest has no defaults so we must supply the local compose directories.
       - NETWORK_CONFIG__DIRECTORY_SERVERS=jm-directory:5222,jm-directory2:5223
+      - 'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":"test:jm-directory-5222","jm-directory2:5223":"test:jm-directory2-5223"}'
       - JMWALLETD_HOST=0.0.0.0
       - LOGGING__LEVEL=DEBUG
       - OBWATCH_URL=http://jm-orderbook-watcher:8000
@@ -338,6 +340,7 @@ services:
       - NETWORK_CONFIG__NETWORK=testnet
       - NETWORK_CONFIG__BITCOIN_NETWORK=regtest
       - NETWORK_CONFIG__DIRECTORY_SERVERS=jm-directory:5222,jm-directory2:5223
+      - 'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":"test:jm-directory-5222","jm-directory2:5223":"test:jm-directory2-5223"}'
       - LOGGING__LEVEL=DEBUG
       # standalone-ng supervises its own Tor and orderbook watcher. Keep their
       # loopback defaults so the Tor control cookie and nginx upstreams match.
@@ -389,6 +392,7 @@ services:
       - BITCOIN__RPC_USER=test
       - BITCOIN__RPC_PASSWORD=test
       - DIRECTORY_SERVERS=jm-directory:5222
+      - 'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":"test:jm-directory-5222"}'
       - LOGGING__LEVEL=DEBUG
       - MAKER__MIN_SIZE=10000
       - MAKER__TX_FEE_CONTRIBUTION=500
@@ -435,6 +439,7 @@ services:
       - BITCOIN__RPC_USER=test
       - BITCOIN__RPC_PASSWORD=test
       - DIRECTORY_SERVERS=jm-directory:5222
+      - 'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":"test:jm-directory-5222"}'
       - LOGGING__LEVEL=DEBUG
       - COINJOIN_AMOUNT=1000000
       - TAKER__MINIMUM_MAKERS=2
@@ -481,6 +486,7 @@ services:
       - BITCOIN__RPC_USER=test
       - BITCOIN__RPC_PASSWORD=test
       - DIRECTORY_SERVERS=jm-directory:5222,jm-directory2:5223
+      - 'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":"test:jm-directory-5222","jm-directory2:5223":"test:jm-directory2-5223"}'
       - LOGGING__LEVEL=DEBUG
       - COINJOIN_AMOUNT=1000000
       - TAKER__MINIMUM_MAKERS=2
@@ -570,6 +576,7 @@ services:
       # Cookie-based auth: reads credentials from Bitcoin Core's .cookie file
       - BITCOIN__RPC_COOKIE_FILE=/shared/.cookie
       - DIRECTORY_SERVERS=jm-directory:5222,jm-directory2:5223
+      - 'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":"test:jm-directory-5222","jm-directory2:5223":"test:jm-directory2-5223"}'
       - LOGGING__LEVEL=DEBUG
       - MAKER__MIN_SIZE=10000
       - MAKER__TX_FEE_CONTRIBUTION=500
@@ -636,6 +643,7 @@ services:
       - BITCOIN__RPC_USER=test
       - BITCOIN__RPC_PASSWORD=test
       - DIRECTORY_SERVERS=jm-directory:5222,jm-directory2:5223
+      - 'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":"test:jm-directory-5222","jm-directory2:5223":"test:jm-directory2-5223"}'
       - LOGGING__LEVEL=DEBUG
       - MAKER__MIN_SIZE=10000
       - MAKER__TX_FEE_CONTRIBUTION=500
@@ -701,6 +709,7 @@ services:
       - BITCOIN__RPC_PASSWORD=test
       # Connect to both directories to test multi-directory handling
       - DIRECTORY_SERVERS=jm-directory:5222,jm-directory2:5223
+      - 'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":"test:jm-directory-5222","jm-directory2:5223":"test:jm-directory2-5223"}'
       - LOGGING__LEVEL=DEBUG
       - MAKER__MIN_SIZE=10000
       - MAKER__TX_FEE_CONTRIBUTION=500
@@ -763,6 +772,7 @@ services:
       - BITCOIN__RPC_URL=http://jm-bitcoin:18443
       - BITCOIN__RPC_COOKIE_FILE=/shared/.cookie
       - DIRECTORY_SERVERS=jm-directory:5222,jm-directory2:5223
+      - 'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":"test:jm-directory-5222","jm-directory2:5223":"test:jm-directory2-5223"}'
       - LOGGING__LEVEL=DEBUG
       - MAKER__MIN_SIZE=10000
       - MAKER__TX_FEE_CONTRIBUTION=500
@@ -824,6 +834,7 @@ services:
       - BITCOIN__RPC_URL=http://jm-bitcoin:18443
       - BITCOIN__RPC_COOKIE_FILE=/shared/.cookie
       - DIRECTORY_SERVERS=jm-directory:5222,jm-directory2:5223
+      - 'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":"test:jm-directory-5222","jm-directory2:5223":"test:jm-directory2-5223"}'
       - LOGGING__LEVEL=DEBUG
       - MAKER__MIN_SIZE=10000
       - MAKER__TX_FEE_CONTRIBUTION=500
@@ -1302,6 +1313,7 @@ services:
       - BITCOIN__NEUTRINO_TLS_CERT=/data/neutrino/tls.cert
       - BITCOIN__NEUTRINO_AUTH_TOKEN_FILE=/data/neutrino/auth_token
       - DIRECTORY_SERVERS=jm-directory:5222
+      - 'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":"test:jm-directory-5222"}'
       - LOGGING__LEVEL=DEBUG
       - MAKER__MIN_SIZE=10000
       - MAKER__TX_FEE_CONTRIBUTION=500
@@ -1349,6 +1361,7 @@ services:
       - BITCOIN__NEUTRINO_TLS_CERT=/data/neutrino/tls.cert
       - BITCOIN__NEUTRINO_AUTH_TOKEN_FILE=/data/neutrino/auth_token
       - DIRECTORY_SERVERS=jm-directory:5222
+      - 'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":"test:jm-directory-5222"}'
       - LOGGING__LEVEL=DEBUG
       - COINJOIN_AMOUNT=1000000
       - TAKER__MINIMUM_MAKERS=2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,7 @@ services:
       - LOGGING__LEVEL=DEBUG
       - DIRECTORY_SERVER__PORT=5222
       - DIRECTORY_SERVER__HOST=0.0.0.0
+      - DIRECTORY_SERVER__NICK_AUTH_DIRECTORY_ID=test:jm-directory-5222
     ports:
       - "5222:5222"
     networks:
@@ -184,6 +185,7 @@ services:
       - LOGGING__LEVEL=DEBUG
       - DIRECTORY_SERVER__PORT=5223
       - DIRECTORY_SERVER__HOST=0.0.0.0
+      - DIRECTORY_SERVER__NICK_AUTH_DIRECTORY_ID=test:jm-directory2-5223
     ports:
       - "5223:5223"
     networks:

--- a/docs/README-directory-server.md
+++ b/docs/README-directory-server.md
@@ -128,6 +128,9 @@ Nick ownership authentication settings (section `[directory_server]`):
   identity is configured. Local tests may use an explicit `test:` identity.
 - `nick_auth_timeout` controls the proof deadline and cannot exceed 30 seconds.
 
+The directory keys relay ownership by nick. A peer's self-declared onion location is
+advertised connection metadata and is not reserved or treated as proof of endpoint ownership.
+
 For local test deployments, clients accept the directory's configured `test:`
 identity even when Docker or the test runner maps the service through a different
 host port. Production `.onion` identities are always matched exactly against the

--- a/docs/README-directory-server.md
+++ b/docs/README-directory-server.md
@@ -131,10 +131,10 @@ Nick ownership authentication settings (section `[directory_server]`):
 The directory keys relay ownership by nick. A peer's self-declared onion location is
 advertised connection metadata and is not reserved or treated as proof of endpoint ownership.
 
-For local test deployments, clients accept the directory's configured `test:`
-identity even when Docker or the test runner maps the service through a different
-host port. Production `.onion` identities are always matched exactly against the
-endpoint selected by the client.
+For local test deployments reached through an alias or forwarded port, configure
+`network_config.nick_auth_directory_ids` on each client. The map key is the exact selected
+`host:port`, and the value is the directory's configured `test:` identity. Production
+`.onion` identities are derived from and matched exactly against the selected endpoint.
 
 For the production Compose stack, retrieve the generated hostname first, configure the resulting
 `hostname.onion:5222` value as `DIRECTORY_SERVER__NICK_AUTH_DIRECTORY_ID`, then restart the

--- a/docs/README-directory-server.md
+++ b/docs/README-directory-server.md
@@ -118,6 +118,26 @@ Behavior summary:
 - Legacy/non-ping makers receive `!orderbook` as a compatibility liveness probe
 - Peers idle beyond hard eviction threshold are disconnected
 
+Nick ownership authentication settings (section `[directory_server]`):
+
+- `nick_auth_mode` defaults to `prefer_verified`, which authenticates upgraded clients while
+  retaining legacy client compatibility. `require_verified` rejects legacy clients, and
+  `disabled` does not advertise the extension.
+- `nick_auth_directory_id` must be the canonical lowercase Tor v3 endpoint, including the port,
+  for example `your56characterhostname.onion:5222`. Authentication is not advertised until this
+  identity is configured. Local tests may use an explicit `test:` identity.
+- `nick_auth_timeout` controls the proof deadline and cannot exceed 30 seconds.
+
+For local test deployments, clients accept the directory's configured `test:`
+identity even when Docker or the test runner maps the service through a different
+host port. Production `.onion` identities are always matched exactly against the
+endpoint selected by the client.
+
+For the production Compose stack, retrieve the generated hostname first, configure the resulting
+`hostname.onion:5222` value as `DIRECTORY_SERVER__NICK_AUTH_DIRECTORY_ID`, then restart the
+directory server container. Do not use the container hostname as the identity for a public Tor
+endpoint.
+
 ## Optional
 
 ### Vanity Onion Address

--- a/jmcore/src/jmcore/config.py
+++ b/jmcore/src/jmcore/config.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field, SecretStr, model_validator
 
 from jmcore.constants import DUST_THRESHOLD
 from jmcore.models import NetworkType
+from jmcore.nick_auth import NickAuthMode
 
 
 class TorConfig(BaseModel):
@@ -209,6 +210,10 @@ class WalletConfig(BaseModel):
     directory_servers: list[str] = Field(
         default_factory=list,
         description="List of directory server URLs (e.g., ['onion_host:port', ...])",
+    )
+    nick_auth_mode: NickAuthMode = Field(
+        default=NickAuthMode.PREFER_VERIFIED,
+        description="Client policy for authenticating nick ownership to directory servers",
     )
 
     # Tor/SOCKS configuration

--- a/jmcore/src/jmcore/config.py
+++ b/jmcore/src/jmcore/config.py
@@ -11,11 +11,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field, SecretStr, model_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
 
 from jmcore.constants import DUST_THRESHOLD
 from jmcore.models import NetworkType
-from jmcore.nick_auth import NickAuthMode
+from jmcore.nick_auth import NickAuthMode, validate_directory_endpoint, validate_directory_id
 
 
 class TorConfig(BaseModel):
@@ -215,6 +215,18 @@ class WalletConfig(BaseModel):
         default=NickAuthMode.PREFER_VERIFIED,
         description="Client policy for authenticating nick ownership to directory servers",
     )
+    nick_auth_directory_ids: dict[str, str] = Field(
+        default_factory=dict,
+        description="Expected nick authentication identity by selected host:port endpoint",
+    )
+
+    @field_validator("nick_auth_directory_ids")
+    @classmethod
+    def validate_nick_auth_directory_ids(cls, value: dict[str, str]) -> dict[str, str]:
+        return {
+            validate_directory_endpoint(endpoint): validate_directory_id(directory_id)
+            for endpoint, directory_id in value.items()
+        }
 
     # Tor/SOCKS configuration
     socks_host: str = Field(default="127.0.0.1", description="Tor SOCKS5 proxy host")

--- a/jmcore/src/jmcore/crypto.py
+++ b/jmcore/src/jmcore/crypto.py
@@ -285,6 +285,12 @@ class NickIdentity:
 
         return f"{message} {self.public_key_hex} {sig_b64}"
 
+    def sign_bytes(self, message: bytes) -> str:
+        """Sign raw bytes using the Bitcoin Signed Message algorithm."""
+        msg_hash = bitcoin_message_hash_bytes(message)
+        signature = self._private_key.sign(msg_hash, hasher=None)
+        return base64.b64encode(signature).decode("ascii")
+
 
 class KeyPair:
     def __init__(self, private_key: PrivateKey | None = None):

--- a/jmcore/src/jmcore/data/config.toml.template
+++ b/jmcore/src/jmcore/data/config.toml.template
@@ -165,6 +165,11 @@
 # Override with a custom list if needed:
 # directory_servers = ["custom1.onion:5222", "custom2.onion:5222"]
 
+# Directory nick authentication policy (JMP-0005):
+# "prefer_verified" authenticates when supported and falls back to legacy servers.
+# "require_verified" rejects legacy servers. "disabled" uses the legacy handshake.
+# nick_auth_mode = "prefer_verified"
+
 # ============================================================================
 # Wallet Settings
 # ============================================================================
@@ -544,6 +549,15 @@
 # Server listening address
 # host = "127.0.0.1"
 # port = 5222
+
+# Directory nick authentication (JMP-0005). "prefer_verified" negotiates the
+# extension while accepting legacy clients, "require_verified" rejects clients
+# without it, and "disabled" keeps the legacy handshake only.
+# nick_auth_mode = "prefer_verified"
+# Stable identifier for this directory endpoint. Production onion directories
+# use their canonical "host.onion:port" endpoint; local tests may use a test ID.
+# nick_auth_directory_id = "test:jm-directory-5222"  # Local/test example only
+# nick_auth_timeout = 30.0
 
 # Limits
 # max_peers = 10000

--- a/jmcore/src/jmcore/data/config.toml.template
+++ b/jmcore/src/jmcore/data/config.toml.template
@@ -169,6 +169,10 @@
 # "prefer_verified" authenticates when supported and falls back to legacy servers.
 # "require_verified" rejects legacy servers. "disabled" uses the legacy handshake.
 # nick_auth_mode = "prefer_verified"
+# Expected identity for each selected directory endpoint. Keys must exactly match
+# the host:port string used after directory address selection. V3 onion identities
+# are derived automatically; explicit entries are required for clearnet and test IDs.
+# nick_auth_directory_ids = { "127.0.0.1:5222" = "test:local-directory" }
 
 # ============================================================================
 # Wallet Settings

--- a/jmcore/src/jmcore/directory_client.py
+++ b/jmcore/src/jmcore/directory_client.py
@@ -34,9 +34,18 @@ from jmcore.network import (
 from jmcore.network import (
     ConnectionError as NetworkConnectionError,
 )
+from jmcore.nick_auth import (
+    NickAuthChallenge,
+    NickAuthMode,
+    NickAuthResult,
+    create_nick_auth_proof,
+    directory_id_for_endpoint,
+    parse_strict_json_object,
+)
 from jmcore.protocol import (
     COMMAND_PREFIX,
     FEATURE_NEUTRINO_COMPAT,
+    FEATURE_NICK_AUTH,
     FEATURE_PEERLIST_FEATURES,
     FEATURE_PING,
     JM_VERSION,
@@ -189,6 +198,7 @@ class DirectoryClient:
         peerlist_timeout: float = 60.0,
         socks_username: str | None = None,
         socks_password: str | None = None,
+        nick_auth_mode: NickAuthMode = NickAuthMode.PREFER_VERIFIED,
     ) -> None:
         """
         Initialize DirectoryClient.
@@ -208,6 +218,7 @@ class DirectoryClient:
             peerlist_timeout: Timeout for first PEERLIST chunk (default 60s, subsequent chunks use 5s)
             socks_username: SOCKS5 username for Tor stream isolation (optional)
             socks_password: SOCKS5 password for Tor stream isolation (optional)
+            nick_auth_mode: Policy for authenticating nick ownership to directory servers
         """
         self.host = host
         self.port = port
@@ -241,11 +252,13 @@ class DirectoryClient:
         self.last_orderbook_request_time: float = 0.0
         self.last_offer_received_time: float | None = None
         self.neutrino_compat = neutrino_compat
+        self.nick_auth_mode = nick_auth_mode
 
         # Version negotiation state (set after handshake)
         self.negotiated_version: int | None = None
         self.directory_neutrino_compat: bool = False
         self.directory_peerlist_features: bool = False  # True if directory supports F: suffix
+        self.directory_nick_authenticated: bool = False
 
         # Directory metadata from handshake
         self.directory_motd: str | None = None
@@ -337,12 +350,16 @@ class DirectoryClient:
         if not self.connection:
             raise DirectoryClientError("Not connected")
 
+        self.directory_nick_authenticated = False
+
         # Build our feature set - always include peerlist_features to indicate we support
         # the extended peerlist format with F: suffix for feature information.
         # Always include ping to indicate we support application-level PING/PONG heartbeat.
         our_features: set[str] = {FEATURE_PEERLIST_FEATURES, FEATURE_PING}
         if self.neutrino_compat:
             our_features.add(FEATURE_NEUTRINO_COMPAT)
+        if self.nick_auth_mode is not NickAuthMode.DISABLED:
+            our_features.add(FEATURE_NICK_AUTH)
         feature_set = FeatureSet(features=our_features)
 
         # Send our handshake with current version and features
@@ -354,9 +371,10 @@ class DirectoryClient:
             features=feature_set,
         )
         logger.debug(f"DirectoryClient._handshake: created handshake data: {handshake_data}")
+        handshake_line = json.dumps(handshake_data)
         handshake_msg = {
             "type": MessageType.HANDSHAKE.value,
-            "line": json.dumps(handshake_data),
+            "line": handshake_line,
         }
         logger.debug("DirectoryClient._handshake: sending handshake message")
         await self.connection.send(json.dumps(handshake_msg).encode("utf-8"))
@@ -408,12 +426,93 @@ class DirectoryClient:
         self.directory_proto_ver_max = dir_ver_max
         self.directory_features = dir_features
 
+        directory_supports_nick_auth = dir_features.get(FEATURE_NICK_AUTH, False) is True
+        if (
+            self.nick_auth_mode is NickAuthMode.REQUIRE_VERIFIED
+            and not directory_supports_nick_auth
+        ):
+            raise DirectoryClientError("Directory does not support required nick authentication")
+        if self.nick_auth_mode is not NickAuthMode.DISABLED and directory_supports_nick_auth:
+            await self._authenticate_nick(handshake_line)
+
         logger.info(
             f"Handshake successful with {self.host}:{self.port} (nick: {self.nick}, "
             f"negotiated_version: v{self.negotiated_version}, "
             f"neutrino_compat: {self.directory_neutrino_compat}, "
-            f"peerlist_features: {self.directory_peerlist_features})"
+            f"peerlist_features: {self.directory_peerlist_features}, "
+            f"nick_authenticated: {self.directory_nick_authenticated})"
         )
+
+    async def _authenticate_nick(self, handshake_line: str) -> None:
+        """Complete the mutually negotiated JMP-0005 challenge-response exchange."""
+        if not self.connection:
+            raise DirectoryClientError("Not connected")
+
+        try:
+            challenge_data = await asyncio.wait_for(self.connection.receive(), timeout=self.timeout)
+            challenge_envelope = parse_strict_json_object(challenge_data)
+            if challenge_envelope.get("type") != MessageType.NICK_AUTH.value:
+                raise DirectoryClientError(
+                    f"Unexpected nick authentication challenge type: "
+                    f"{challenge_envelope.get('type')}"
+                )
+            challenge_line = challenge_envelope.get("line")
+            if not isinstance(challenge_line, str):
+                raise DirectoryClientError("Nick authentication challenge line must be a string")
+            challenge = NickAuthChallenge.parse(challenge_line)
+
+            selected_directory_id = directory_id_for_endpoint(self.host, self.port)
+            directory_id = selected_directory_id
+            if selected_directory_id.startswith("test:") and challenge.directory_id.startswith(
+                "test:"
+            ):
+                # Non-production endpoints are commonly reached through a
+                # randomized host-side forwarded port. Their explicitly
+                # configured test identity is stable even when the selected
+                # transport alias is not.
+                directory_id = challenge.directory_id
+            elif challenge.directory_id != selected_directory_id:
+                raise DirectoryClientError(
+                    f"Nick authentication directory-id mismatch: expected {selected_directory_id}, "
+                    f"received {challenge.directory_id}"
+                )
+
+            proof = create_nick_auth_proof(
+                self.nick_identity,
+                challenge.challenge,
+                directory_id,
+                handshake_line,
+            )
+            proof_envelope = {
+                "type": MessageType.NICK_AUTH.value,
+                "line": proof.to_json(),
+            }
+            await self.connection.send(json.dumps(proof_envelope).encode("utf-8"))
+
+            result_data = await asyncio.wait_for(self.connection.receive(), timeout=self.timeout)
+            result_envelope = parse_strict_json_object(result_data)
+            if result_envelope.get("type") != MessageType.NICK_AUTH_RESULT.value:
+                raise DirectoryClientError(
+                    f"Unexpected nick authentication result type: {result_envelope.get('type')}"
+                )
+            result_line = result_envelope.get("line")
+            if not isinstance(result_line, str):
+                raise DirectoryClientError("Nick authentication result line must be a string")
+            result = NickAuthResult.parse(result_line)
+            if result.code != "ok" or not result.verified:
+                raise DirectoryClientError(
+                    f"Directory rejected nick authentication with code: {result.code}"
+                )
+        except DirectoryClientError:
+            raise
+        except TimeoutError as exc:
+            raise DirectoryClientError("Nick authentication timed out") from exc
+        except Exception:
+            # Validation errors can embed the untrusted challenge value. Keep it
+            # out of exception chains because connect() logs handshake failures.
+            raise DirectoryClientError("Invalid nick authentication response") from None
+
+        self.directory_nick_authenticated = True
 
     async def get_peerlist(self) -> list[str] | None:
         """

--- a/jmcore/src/jmcore/directory_client.py
+++ b/jmcore/src/jmcore/directory_client.py
@@ -76,6 +76,15 @@ class DirectoryClientError(Exception):
     """Error raised by DirectoryClient operations."""
 
 
+_NICK_AUTH_MESSAGE_TYPES = frozenset(
+    {
+        MessageType.NICK_AUTH_CHALLENGE.value,
+        MessageType.NICK_AUTH_PROOF.value,
+        MessageType.NICK_AUTH_RESULT.value,
+    }
+)
+
+
 def _fidelity_bond_claim_key(bond_data: dict[str, Any]) -> str:
     return (
         f"{bond_data['utxo_txid']}:{bond_data['utxo_vout']}:"
@@ -542,6 +551,12 @@ class DirectoryClient:
 
         self.directory_nick_authenticated = True
 
+    async def _reject_out_of_order_nick_auth(self, message_type: object) -> None:
+        if message_type not in _NICK_AUTH_MESSAGE_TYPES:
+            return
+        await self.close()
+        raise DirectoryClientError(f"Out-of-order nick authentication message type: {message_type}")
+
     async def get_peerlist(self) -> list[str] | None:
         """
         Fetch the current list of connected peers.
@@ -707,6 +722,7 @@ class DirectoryClient:
                     )
                     response = json.loads(response_data.decode("utf-8"))
                     msg_type = response.get("type")
+                    await self._reject_out_of_order_nick_auth(msg_type)
                     consecutive_errors = 0
 
                     if msg_type == MessageType.PEERLIST.value:
@@ -927,6 +943,7 @@ class DirectoryClient:
         while not self._message_buffer.empty():
             try:
                 buffered_msg = self._message_buffer.get_nowait()
+                await self._reject_out_of_order_nick_auth(buffered_msg.get("type"))
                 logger.trace(
                     f"Processing buffered message type {buffered_msg.get('type')}: "
                     f"{buffered_msg.get('line', '')[:80]}..."
@@ -949,6 +966,7 @@ class DirectoryClient:
                     self.connection.receive(), timeout=remaining_time
                 )
                 response = json.loads(response_data.decode("utf-8"))
+                await self._reject_out_of_order_nick_auth(response.get("type"))
                 logger.trace(
                     f"Received message type {response.get('type')}: "
                     f"{response.get('line', '')[:80]}..."
@@ -969,6 +987,8 @@ class DirectoryClient:
             except NetworkConnectionError as e:
                 # Connection-level errors from our network layer - always propagate
                 raise DirectoryClientError(f"Connection lost: {e}") from e
+            except DirectoryClientError:
+                raise
             except (ConnectionResetError, BrokenPipeError, OSError) as e:
                 # System-level connection errors that bypassed our network layer
                 raise DirectoryClientError(f"Connection lost: {e}") from e
@@ -1242,16 +1262,16 @@ class DirectoryClient:
 
     async def close(self) -> None:
         """Close the connection to the directory server."""
-        if self.connection:
+        connection = self.connection
+        if connection:
             try:
-                # NOTE: We skip sending DISCONNECT (801) because the reference implementation
+                # Do not send DISCONNECT (801): the reference implementation
                 # crashes on unhandled control messages.
-                pass
-            except Exception:
-                pass
+                await connection.close()
             finally:
-                await self.connection.close()
-                self.connection = None
+                if self.connection is connection:
+                    self.connection = None
+                    self.directory_nick_authenticated = False
 
     async def _send_pong(self) -> None:
         """Send a PONG response to a PING from the directory server."""
@@ -1359,6 +1379,7 @@ class DirectoryClient:
 
                     message = json.loads(data.decode("utf-8"))
                 msg_type = message.get("type")
+                await self._reject_out_of_order_nick_auth(msg_type)
                 line = message.get("line", "")
 
                 # Handle PEERLIST responses (from periodic or automatic requests)

--- a/jmcore/src/jmcore/directory_client.py
+++ b/jmcore/src/jmcore/directory_client.py
@@ -41,6 +41,7 @@ from jmcore.nick_auth import (
     create_nick_auth_proof,
     directory_id_for_endpoint,
     parse_strict_json_object,
+    validate_directory_id,
 )
 from jmcore.protocol import (
     COMMAND_PREFIX,
@@ -199,6 +200,7 @@ class DirectoryClient:
         socks_username: str | None = None,
         socks_password: str | None = None,
         nick_auth_mode: NickAuthMode = NickAuthMode.PREFER_VERIFIED,
+        nick_auth_directory_id: str | None = None,
     ) -> None:
         """
         Initialize DirectoryClient.
@@ -219,6 +221,7 @@ class DirectoryClient:
             socks_username: SOCKS5 username for Tor stream isolation (optional)
             socks_password: SOCKS5 password for Tor stream isolation (optional)
             nick_auth_mode: Policy for authenticating nick ownership to directory servers
+            nick_auth_directory_id: Expected identity of this selected directory endpoint
         """
         self.host = host
         self.port = port
@@ -253,6 +256,14 @@ class DirectoryClient:
         self.last_offer_received_time: float | None = None
         self.neutrino_compat = neutrino_compat
         self.nick_auth_mode = nick_auth_mode
+        self.nick_auth_directory_id = (
+            validate_directory_id(nick_auth_directory_id)
+            if nick_auth_directory_id is not None
+            else None
+        )
+        if self.nick_auth_directory_id is None:
+            with contextlib.suppress(ValueError):
+                self.nick_auth_directory_id = directory_id_for_endpoint(self.host, self.port)
 
         # Version negotiation state (set after handshake)
         self.negotiated_version: int | None = None
@@ -352,13 +363,25 @@ class DirectoryClient:
 
         self.directory_nick_authenticated = False
 
+        if (
+            self.nick_auth_mode is NickAuthMode.REQUIRE_VERIFIED
+            and self.nick_auth_directory_id is None
+        ):
+            raise DirectoryClientError(
+                f"No expected nick authentication directory identity configured for "
+                f"{self.host}:{self.port}"
+            )
+
         # Build our feature set - always include peerlist_features to indicate we support
         # the extended peerlist format with F: suffix for feature information.
         # Always include ping to indicate we support application-level PING/PONG heartbeat.
         our_features: set[str] = {FEATURE_PEERLIST_FEATURES, FEATURE_PING}
         if self.neutrino_compat:
             our_features.add(FEATURE_NEUTRINO_COMPAT)
-        if self.nick_auth_mode is not NickAuthMode.DISABLED:
+        if (
+            self.nick_auth_mode is not NickAuthMode.DISABLED
+            and self.nick_auth_directory_id is not None
+        ):
             our_features.add(FEATURE_NICK_AUTH)
         feature_set = FeatureSet(features=our_features)
 
@@ -432,7 +455,11 @@ class DirectoryClient:
             and not directory_supports_nick_auth
         ):
             raise DirectoryClientError("Directory does not support required nick authentication")
-        if self.nick_auth_mode is not NickAuthMode.DISABLED and directory_supports_nick_auth:
+        if (
+            self.nick_auth_mode is not NickAuthMode.DISABLED
+            and self.nick_auth_directory_id is not None
+            and directory_supports_nick_auth
+        ):
             await self._authenticate_nick(handshake_line)
 
         logger.info(
@@ -447,9 +474,14 @@ class DirectoryClient:
         """Complete the mutually negotiated JMP-0005 challenge-response exchange."""
         if not self.connection:
             raise DirectoryClientError("Not connected")
+        if self.nick_auth_directory_id is None:
+            raise DirectoryClientError("No expected nick authentication directory identity")
 
         try:
-            challenge_data = await asyncio.wait_for(self.connection.receive(), timeout=self.timeout)
+            nick_auth_timeout = min(self.timeout, 30.0)
+            challenge_data = await asyncio.wait_for(
+                self.connection.receive(), timeout=nick_auth_timeout
+            )
             challenge_envelope = parse_strict_json_object(challenge_data)
             if challenge_envelope.get("type") != MessageType.NICK_AUTH.value:
                 raise DirectoryClientError(
@@ -461,35 +493,31 @@ class DirectoryClient:
                 raise DirectoryClientError("Nick authentication challenge line must be a string")
             challenge = NickAuthChallenge.parse(challenge_line)
 
-            selected_directory_id = directory_id_for_endpoint(self.host, self.port)
-            directory_id = selected_directory_id
-            if selected_directory_id.startswith("test:") and challenge.directory_id.startswith(
-                "test:"
-            ):
-                # Non-production endpoints are commonly reached through a
-                # randomized host-side forwarded port. Their explicitly
-                # configured test identity is stable even when the selected
-                # transport alias is not.
-                directory_id = challenge.directory_id
-            elif challenge.directory_id != selected_directory_id:
+            if challenge.directory_id != self.nick_auth_directory_id:
                 raise DirectoryClientError(
-                    f"Nick authentication directory-id mismatch: expected {selected_directory_id}, "
+                    f"Nick authentication directory-id mismatch: expected "
+                    f"{self.nick_auth_directory_id}, "
                     f"received {challenge.directory_id}"
                 )
 
             proof = create_nick_auth_proof(
                 self.nick_identity,
                 challenge.challenge,
-                directory_id,
+                self.nick_auth_directory_id,
                 handshake_line,
             )
             proof_envelope = {
                 "type": MessageType.NICK_AUTH.value,
                 "line": proof.to_json(),
             }
-            await self.connection.send(json.dumps(proof_envelope).encode("utf-8"))
+            await asyncio.wait_for(
+                self.connection.send(json.dumps(proof_envelope).encode("utf-8")),
+                timeout=nick_auth_timeout,
+            )
 
-            result_data = await asyncio.wait_for(self.connection.receive(), timeout=self.timeout)
+            result_data = await asyncio.wait_for(
+                self.connection.receive(), timeout=nick_auth_timeout
+            )
             result_envelope = parse_strict_json_object(result_data)
             if result_envelope.get("type") != MessageType.NICK_AUTH_RESULT.value:
                 raise DirectoryClientError(

--- a/jmcore/src/jmcore/directory_client.py
+++ b/jmcore/src/jmcore/directory_client.py
@@ -483,7 +483,7 @@ class DirectoryClient:
                 self.connection.receive(), timeout=nick_auth_timeout
             )
             challenge_envelope = parse_strict_json_object(challenge_data)
-            if challenge_envelope.get("type") != MessageType.NICK_AUTH.value:
+            if challenge_envelope.get("type") != MessageType.NICK_AUTH_CHALLENGE.value:
                 raise DirectoryClientError(
                     f"Unexpected nick authentication challenge type: "
                     f"{challenge_envelope.get('type')}"
@@ -507,7 +507,7 @@ class DirectoryClient:
                 handshake_line,
             )
             proof_envelope = {
-                "type": MessageType.NICK_AUTH.value,
+                "type": MessageType.NICK_AUTH_PROOF.value,
                 "line": proof.to_json(),
             }
             await asyncio.wait_for(

--- a/jmcore/src/jmcore/directory_pool.py
+++ b/jmcore/src/jmcore/directory_pool.py
@@ -36,6 +36,7 @@ from loguru import logger
 
 from jmcore.crypto import NickIdentity
 from jmcore.directory_client import DirectoryClient
+from jmcore.nick_auth import NickAuthMode
 from jmcore.tasks import parse_directory_address
 from jmcore.tor_isolation import IsolationCategory, get_isolation_credentials
 
@@ -74,6 +75,7 @@ class DirectoryClientPool:
         socks_port: int = 9050,
         connection_timeout: float = 120.0,
         stream_isolation: bool = False,
+        nick_auth_mode: NickAuthMode = NickAuthMode.PREFER_VERIFIED,
     ):
         self.directory_servers = directory_servers
         self.network = network
@@ -82,6 +84,7 @@ class DirectoryClientPool:
         self.socks_port = socks_port
         self.connection_timeout = connection_timeout
         self.stream_isolation = stream_isolation
+        self.nick_auth_mode = nick_auth_mode
 
         # Pre-compute isolation credentials (None when disabled). The peer
         # credentials are exposed for subclasses that establish direct
@@ -116,6 +119,7 @@ class DirectoryClientPool:
             "socks_host": self.socks_host,
             "socks_port": self.socks_port,
             "timeout": self.connection_timeout,
+            "nick_auth_mode": self.nick_auth_mode,
             "socks_username": self._dir_creds[0],
             "socks_password": self._dir_creds[1],
         }

--- a/jmcore/src/jmcore/directory_pool.py
+++ b/jmcore/src/jmcore/directory_pool.py
@@ -76,6 +76,7 @@ class DirectoryClientPool:
         connection_timeout: float = 120.0,
         stream_isolation: bool = False,
         nick_auth_mode: NickAuthMode = NickAuthMode.PREFER_VERIFIED,
+        nick_auth_directory_ids: dict[str, str] | None = None,
     ):
         self.directory_servers = directory_servers
         self.network = network
@@ -85,6 +86,7 @@ class DirectoryClientPool:
         self.connection_timeout = connection_timeout
         self.stream_isolation = stream_isolation
         self.nick_auth_mode = nick_auth_mode
+        self.nick_auth_directory_ids = nick_auth_directory_ids or {}
 
         # Pre-compute isolation credentials (None when disabled). The peer
         # credentials are exposed for subclasses that establish direct
@@ -120,6 +122,7 @@ class DirectoryClientPool:
             "socks_port": self.socks_port,
             "timeout": self.connection_timeout,
             "nick_auth_mode": self.nick_auth_mode,
+            "nick_auth_directory_id": self.nick_auth_directory_ids.get(f"{host}:{port}"),
             "socks_username": self._dir_creds[0],
             "socks_password": self._dir_creds[1],
         }

--- a/jmcore/src/jmcore/nick_auth.py
+++ b/jmcore/src/jmcore/nick_auth.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 import binascii
 import hashlib
-import ipaddress
 import json
 import re
 from collections.abc import Mapping
@@ -17,14 +16,14 @@ from coincurve import verify_signature as coincurve_verify
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from jmcore.crypto import NickIdentity, bitcoin_message_hash_bytes, nick_from_pubkey_hex
-from jmcore.protocol import get_nick_version
 
 _LOWER_HEX_64_RE = re.compile(r"[0-9a-f]{64}")
 _COMPRESSED_PUBKEY_RE = re.compile(r"0[23][0-9a-f]{64}")
 _ONION_HOST_RE = re.compile(r"[a-z2-7]{56}\.onion")
-_DNS_LABEL_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
-_TEST_DIRECTORY_ID_RE = re.compile(r"test:[a-z0-9][a-z0-9._:-]{0,253}")
+_NICK_RE = re.compile(r"J[0-9][1-9A-HJ-NP-Za-km-zO]{14}")
+_DIRECTORY_ID_RE = re.compile(r"[a-z0-9][a-z0-9.:_-]*")
 _SECP256K1_ORDER = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+_NICK_AUTH_DOMAIN = b"nick-auth-v1"
 
 
 class NickAuthMode(StrEnum):
@@ -69,21 +68,29 @@ def _validate_lower_hex_64(value: str, field_name: str) -> str:
 
 
 def validate_directory_id(value: str) -> str:
-    """Validate and return a canonical JMP-0005 directory identity."""
-    if value.startswith("test:"):
-        if _TEST_DIRECTORY_ID_RE.fullmatch(value) is None:
-            raise ValueError("invalid test directory-id")
-        return value
+    """Validate and return a JMP-0005 directory identity."""
+    if not isinstance(value, str) or _DIRECTORY_ID_RE.fullmatch(value) is None:
+        raise ValueError("invalid directory-id")
+    return value
 
+
+def validate_directory_endpoint(value: str) -> str:
+    """Validate an exact host:port key used to select an expected directory identity."""
+    if not isinstance(value, str) or value != value.strip():
+        raise ValueError("invalid directory endpoint")
     try:
         host, port_text = value.rsplit(":", 1)
         port = int(port_text)
     except ValueError as exc:
-        raise ValueError("invalid onion directory-id") from exc
-    if _ONION_HOST_RE.fullmatch(host) is None or not 1 <= port <= 65535:
-        raise ValueError("invalid onion directory-id")
-    if value != f"{host}:{port}":
-        raise ValueError("directory-id is not canonical")
+        raise ValueError("directory endpoint must use host:port") from exc
+    if (
+        not host
+        or ":" in host
+        or any(char.isspace() for char in host)
+        or not 1 <= port <= 65535
+        or value != f"{host}:{port}"
+    ):
+        raise ValueError("directory endpoint must use canonical host:port")
     return value
 
 
@@ -228,28 +235,8 @@ def handshake_line_sha256(line: str) -> str:
     return hashlib.sha256(line.encode("utf-8")).hexdigest()
 
 
-def _normalize_test_host(host: str) -> str:
-    try:
-        address = ipaddress.ip_address(host)
-    except ValueError:
-        if len(host) > 253:
-            raise ValueError("host is too long") from None
-        labels = host.split(".")
-        if not labels or any(_DNS_LABEL_RE.fullmatch(label) is None for label in labels):
-            raise ValueError("invalid host") from None
-        if len(labels) > 1 and labels[-1] not in {"local", "localhost", "test"}:
-            raise ValueError("non-onion host must be a local or test endpoint") from None
-        return host
-
-    if address.version != 4:
-        raise ValueError("only IPv4 local/test endpoints are supported")
-    if not (address.is_private or address.is_loopback or address.is_unspecified):
-        raise ValueError("non-onion IP address must be local")
-    return address.compressed
-
-
 def directory_id_for_endpoint(host: str, port: int) -> str:
-    """Return the canonical JMP-0005 identity for a selected directory endpoint."""
+    """Derive a JMP-0005 identity from a selected Tor v3 endpoint."""
     if not isinstance(host, str) or isinstance(port, bool) or not isinstance(port, int):
         raise ValueError("host and port have invalid types")
     if not 1 <= port <= 65535:
@@ -264,19 +251,7 @@ def directory_id_for_endpoint(host: str, port: int) -> str:
         if _ONION_HOST_RE.fullmatch(normalized_host) is None:
             raise ValueError("onion endpoint must use a 56-character v3 hostname")
         return f"{normalized_host}:{port}"
-
-    normalized_host = _normalize_test_host(normalized_host)
-    return f"test:{normalized_host}-{port}"
-
-
-def _validate_transcript_part(value: str, name: str) -> str:
-    if not value or "|" in value:
-        raise ValueError(f"invalid {name}")
-    try:
-        value.encode("ascii")
-    except UnicodeEncodeError as exc:
-        raise ValueError(f"{name} must be ASCII") from exc
-    return value
+    raise ValueError("non-onion endpoint requires an explicitly configured directory-id")
 
 
 def build_nick_auth_signed_message(
@@ -289,10 +264,11 @@ def build_nick_auth_signed_message(
     challenge = _validate_lower_hex_64(challenge, "challenge")
     directory_id = validate_directory_id(directory_id)
     handshake_sha256 = _validate_lower_hex_64(handshake_sha256, "handshake-sha256")
-    _validate_transcript_part(nick, "nick")
+    if _NICK_RE.fullmatch(nick) is None:
+        raise ValueError("nick must use the JMP-0001 nick format")
     NickAuthProof.validate_pubkey(pubkey)
     transcript = f"nick-auth|{challenge}|{directory_id}|{handshake_sha256}|{nick}|{pubkey}"
-    return transcript.encode("ascii") + b"onion-network"
+    return transcript.encode("ascii") + _NICK_AUTH_DOMAIN
 
 
 def create_nick_auth_proof(
@@ -326,6 +302,7 @@ def verify_nick_auth_proof(
     expected_directory_id: str,
     handshake_line: str,
     nick: str,
+    protocol_version: int,
 ) -> bool:
     try:
         if proof.challenge != expected_challenge:
@@ -333,7 +310,7 @@ def verify_nick_auth_proof(
         handshake_sha256 = handshake_line_sha256(handshake_line)
         if proof.handshake_sha256 != handshake_sha256:
             return False
-        if nick_from_pubkey_hex(proof.pubkey, get_nick_version(nick)) != nick:
+        if nick_from_pubkey_hex(proof.pubkey, protocol_version) != nick:
             return False
 
         signature = _decode_canonical_der_signature(proof.signature)

--- a/jmcore/src/jmcore/nick_auth.py
+++ b/jmcore/src/jmcore/nick_auth.py
@@ -1,0 +1,350 @@
+"""Shared JMP-0005 nick ownership authentication primitives."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import ipaddress
+import json
+import re
+from collections.abc import Mapping
+from enum import StrEnum
+from typing import Any, ClassVar, Literal, Self, cast
+
+from coincurve import PublicKey
+from coincurve import verify_signature as coincurve_verify
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from jmcore.crypto import NickIdentity, bitcoin_message_hash_bytes, nick_from_pubkey_hex
+from jmcore.protocol import get_nick_version
+
+_LOWER_HEX_64_RE = re.compile(r"[0-9a-f]{64}")
+_COMPRESSED_PUBKEY_RE = re.compile(r"0[23][0-9a-f]{64}")
+_ONION_HOST_RE = re.compile(r"[a-z2-7]{56}\.onion")
+_DNS_LABEL_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
+_TEST_DIRECTORY_ID_RE = re.compile(r"test:[a-z0-9][a-z0-9._:-]{0,253}")
+_SECP256K1_ORDER = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+
+class NickAuthMode(StrEnum):
+    PREFER_VERIFIED = "prefer_verified"
+    REQUIRE_VERIFIED = "require_verified"
+    DISABLED = "disabled"
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON number is not allowed: {value}")
+
+
+def _object_without_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def parse_strict_json_object(payload: str | bytes) -> dict[str, Any]:
+    """Parse a JSON object while rejecting duplicate keys and non-finite numbers."""
+    if isinstance(payload, bytes):
+        payload = payload.decode("utf-8")
+    if not isinstance(payload, str):
+        raise TypeError("JSON payload must be str or bytes")
+    parsed = json.loads(
+        payload,
+        object_pairs_hook=_object_without_duplicate_keys,
+        parse_constant=_reject_json_constant,
+    )
+    if not isinstance(parsed, dict):
+        raise ValueError("nick authentication payload must be a JSON object")
+    return cast(dict[str, Any], parsed)
+
+
+def _validate_lower_hex_64(value: str, field_name: str) -> str:
+    if _LOWER_HEX_64_RE.fullmatch(value) is None:
+        raise ValueError(f"{field_name} must be exactly 64 lowercase hexadecimal characters")
+    return value
+
+
+def validate_directory_id(value: str) -> str:
+    """Validate and return a canonical JMP-0005 directory identity."""
+    if value.startswith("test:"):
+        if _TEST_DIRECTORY_ID_RE.fullmatch(value) is None:
+            raise ValueError("invalid test directory-id")
+        return value
+
+    try:
+        host, port_text = value.rsplit(":", 1)
+        port = int(port_text)
+    except ValueError as exc:
+        raise ValueError("invalid onion directory-id") from exc
+    if _ONION_HOST_RE.fullmatch(host) is None or not 1 <= port <= 65535:
+        raise ValueError("invalid onion directory-id")
+    if value != f"{host}:{port}":
+        raise ValueError("directory-id is not canonical")
+    return value
+
+
+def _is_strict_der_signature(signature: bytes) -> bool:
+    if not 8 <= len(signature) <= 72:
+        return False
+    if signature[0] != 0x30 or signature[1] != len(signature) - 2:
+        return False
+    if signature[2] != 0x02:
+        return False
+
+    r_length = signature[3]
+    if r_length == 0 or 5 + r_length >= len(signature):
+        return False
+    r_start = 4
+    if signature[r_start] & 0x80:
+        return False
+    if r_length > 1 and signature[r_start] == 0 and not signature[r_start + 1] & 0x80:
+        return False
+    r_value = int.from_bytes(signature[r_start : r_start + r_length], "big")
+    if not 1 <= r_value < _SECP256K1_ORDER:
+        return False
+
+    s_type_index = r_start + r_length
+    if signature[s_type_index] != 0x02:
+        return False
+    s_length = signature[s_type_index + 1]
+    s_start = s_type_index + 2
+    if s_length == 0 or s_start + s_length != len(signature):
+        return False
+    if signature[s_start] & 0x80:
+        return False
+    if s_length > 1 and signature[s_start] == 0 and not signature[s_start + 1] & 0x80:
+        return False
+    s_value = int.from_bytes(signature[s_start : s_start + s_length], "big")
+    return 1 <= s_value < _SECP256K1_ORDER
+
+
+def _decode_canonical_der_signature(value: str) -> bytes:
+    try:
+        encoded = value.encode("ascii")
+        signature = base64.b64decode(encoded, validate=True)
+    except (UnicodeEncodeError, binascii.Error, ValueError) as exc:
+        raise ValueError("signature must use strict Base64") from exc
+    if base64.b64encode(signature) != encoded:
+        raise ValueError("signature Base64 encoding is not canonical")
+    if not _is_strict_der_signature(signature):
+        raise ValueError("signature is not strict DER")
+    return signature
+
+
+class _NickAuthPayload(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        extra="forbid",
+        strict=True,
+        populate_by_name=True,
+    )
+
+    @classmethod
+    def parse(cls, payload: str | bytes) -> Self:
+        return cls.from_payload(parse_strict_json_object(payload))
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, object] | str | bytes) -> Self:
+        if isinstance(payload, (str, bytes)):
+            return cls.parse(payload)
+        data = dict(payload)
+        if "kind" in cls.model_fields and "kind" not in data:
+            raise ValueError("payload is missing required field: kind")
+        for field_name, field in cls.model_fields.items():
+            if field.alias is not None and field.alias != field_name and field_name in data:
+                raise ValueError(f"payload field must use wire name: {field.alias}")
+        return cls.model_validate(data, strict=True)
+
+    def to_payload(self) -> dict[str, object]:
+        return cast(dict[str, object], self.model_dump(mode="json", by_alias=True))
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_payload(), allow_nan=False, separators=(",", ":"))
+
+
+class NickAuthChallenge(_NickAuthPayload):
+    kind: Literal["challenge"] = "challenge"
+    challenge: str
+    directory_id: str = Field(alias="directory-id")
+
+    @field_validator("challenge")
+    @classmethod
+    def validate_challenge(cls, value: str) -> str:
+        return _validate_lower_hex_64(value, "challenge")
+
+    @field_validator("directory_id")
+    @classmethod
+    def validate_directory_id(cls, value: str) -> str:
+        return validate_directory_id(value)
+
+
+class NickAuthProof(_NickAuthPayload):
+    kind: Literal["proof"] = "proof"
+    challenge: str
+    handshake_sha256: str = Field(alias="handshake-sha256")
+    pubkey: str
+    signature: str
+
+    @field_validator("challenge", "handshake_sha256")
+    @classmethod
+    def validate_hash(cls, value: str, info: Any) -> str:
+        return _validate_lower_hex_64(value, info.field_name)
+
+    @field_validator("pubkey")
+    @classmethod
+    def validate_pubkey(cls, value: str) -> str:
+        if _COMPRESSED_PUBKEY_RE.fullmatch(value) is None:
+            raise ValueError("pubkey must be a lowercase compressed secp256k1 public key")
+        try:
+            PublicKey(bytes.fromhex(value))
+        except ValueError as exc:
+            raise ValueError("pubkey is not a valid secp256k1 public key") from exc
+        return value
+
+    @field_validator("signature")
+    @classmethod
+    def validate_signature(cls, value: str) -> str:
+        _decode_canonical_der_signature(value)
+        return value
+
+
+class NickAuthResult(_NickAuthPayload):
+    code: Literal["ok", "malformed", "expired", "invalid", "policy"]
+    verified: bool
+
+    @model_validator(mode="after")
+    def validate_result(self) -> Self:
+        if self.verified != (self.code == "ok"):
+            raise ValueError("only code 'ok' may have verified=true")
+        return self
+
+
+def handshake_line_sha256(line: str) -> str:
+    if not isinstance(line, str):
+        raise TypeError("handshake line must be str")
+    return hashlib.sha256(line.encode("utf-8")).hexdigest()
+
+
+def _normalize_test_host(host: str) -> str:
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        if len(host) > 253:
+            raise ValueError("host is too long") from None
+        labels = host.split(".")
+        if not labels or any(_DNS_LABEL_RE.fullmatch(label) is None for label in labels):
+            raise ValueError("invalid host") from None
+        if len(labels) > 1 and labels[-1] not in {"local", "localhost", "test"}:
+            raise ValueError("non-onion host must be a local or test endpoint") from None
+        return host
+
+    if address.version != 4:
+        raise ValueError("only IPv4 local/test endpoints are supported")
+    if not (address.is_private or address.is_loopback or address.is_unspecified):
+        raise ValueError("non-onion IP address must be local")
+    return address.compressed
+
+
+def directory_id_for_endpoint(host: str, port: int) -> str:
+    """Return the canonical JMP-0005 identity for a selected directory endpoint."""
+    if not isinstance(host, str) or isinstance(port, bool) or not isinstance(port, int):
+        raise ValueError("host and port have invalid types")
+    if not 1 <= port <= 65535:
+        raise ValueError("port must be between 1 and 65535")
+    if not host or host != host.strip() or any(char.isspace() for char in host):
+        raise ValueError("invalid host")
+
+    normalized_host = host.lower()
+    if normalized_host.endswith("."):
+        normalized_host = normalized_host[:-1]
+    if normalized_host.endswith(".onion"):
+        if _ONION_HOST_RE.fullmatch(normalized_host) is None:
+            raise ValueError("onion endpoint must use a 56-character v3 hostname")
+        return f"{normalized_host}:{port}"
+
+    normalized_host = _normalize_test_host(normalized_host)
+    return f"test:{normalized_host}-{port}"
+
+
+def _validate_transcript_part(value: str, name: str) -> str:
+    if not value or "|" in value:
+        raise ValueError(f"invalid {name}")
+    try:
+        value.encode("ascii")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{name} must be ASCII") from exc
+    return value
+
+
+def build_nick_auth_signed_message(
+    challenge: str,
+    directory_id: str,
+    handshake_sha256: str,
+    nick: str,
+    pubkey: str,
+) -> bytes:
+    challenge = _validate_lower_hex_64(challenge, "challenge")
+    directory_id = validate_directory_id(directory_id)
+    handshake_sha256 = _validate_lower_hex_64(handshake_sha256, "handshake-sha256")
+    _validate_transcript_part(nick, "nick")
+    NickAuthProof.validate_pubkey(pubkey)
+    transcript = f"nick-auth|{challenge}|{directory_id}|{handshake_sha256}|{nick}|{pubkey}"
+    return transcript.encode("ascii") + b"onion-network"
+
+
+def create_nick_auth_proof(
+    identity: NickIdentity,
+    challenge: str,
+    directory_id: str,
+    handshake_line: str,
+) -> NickAuthProof:
+    handshake_sha256 = handshake_line_sha256(handshake_line)
+    message = build_nick_auth_signed_message(
+        challenge,
+        directory_id,
+        handshake_sha256,
+        identity.nick,
+        identity.public_key_hex,
+    )
+    return NickAuthProof.from_payload(
+        {
+            "kind": "proof",
+            "challenge": challenge,
+            "handshake-sha256": handshake_sha256,
+            "pubkey": identity.public_key_hex,
+            "signature": identity.sign_bytes(message),
+        }
+    )
+
+
+def verify_nick_auth_proof(
+    proof: NickAuthProof,
+    expected_challenge: str,
+    expected_directory_id: str,
+    handshake_line: str,
+    nick: str,
+) -> bool:
+    try:
+        if proof.challenge != expected_challenge:
+            return False
+        handshake_sha256 = handshake_line_sha256(handshake_line)
+        if proof.handshake_sha256 != handshake_sha256:
+            return False
+        if nick_from_pubkey_hex(proof.pubkey, get_nick_version(nick)) != nick:
+            return False
+
+        signature = _decode_canonical_der_signature(proof.signature)
+        message = build_nick_auth_signed_message(
+            expected_challenge,
+            expected_directory_id,
+            handshake_sha256,
+            nick,
+            proof.pubkey,
+        )
+        message_hash = bitcoin_message_hash_bytes(message)
+        return coincurve_verify(signature, message_hash, bytes.fromhex(proof.pubkey), hasher=None)
+    except (TypeError, ValueError):
+        return False

--- a/jmcore/src/jmcore/nick_auth.py
+++ b/jmcore/src/jmcore/nick_auth.py
@@ -158,8 +158,6 @@ class _NickAuthPayload(BaseModel):
         if isinstance(payload, (str, bytes)):
             return cls.parse(payload)
         data = dict(payload)
-        if "kind" in cls.model_fields and "kind" not in data:
-            raise ValueError("payload is missing required field: kind")
         for field_name, field in cls.model_fields.items():
             if field.alias is not None and field.alias != field_name and field_name in data:
                 raise ValueError(f"payload field must use wire name: {field.alias}")
@@ -173,7 +171,6 @@ class _NickAuthPayload(BaseModel):
 
 
 class NickAuthChallenge(_NickAuthPayload):
-    kind: Literal["challenge"] = "challenge"
     challenge: str
     directory_id: str = Field(alias="directory-id")
 
@@ -189,16 +186,8 @@ class NickAuthChallenge(_NickAuthPayload):
 
 
 class NickAuthProof(_NickAuthPayload):
-    kind: Literal["proof"] = "proof"
-    challenge: str
-    handshake_sha256: str = Field(alias="handshake-sha256")
     pubkey: str
     signature: str
-
-    @field_validator("challenge", "handshake_sha256")
-    @classmethod
-    def validate_hash(cls, value: str, info: Any) -> str:
-        return _validate_lower_hex_64(value, info.field_name)
 
     @field_validator("pubkey")
     @classmethod
@@ -287,9 +276,6 @@ def create_nick_auth_proof(
     )
     return NickAuthProof.from_payload(
         {
-            "kind": "proof",
-            "challenge": challenge,
-            "handshake-sha256": handshake_sha256,
             "pubkey": identity.public_key_hex,
             "signature": identity.sign_bytes(message),
         }
@@ -305,11 +291,7 @@ def verify_nick_auth_proof(
     protocol_version: int,
 ) -> bool:
     try:
-        if proof.challenge != expected_challenge:
-            return False
         handshake_sha256 = handshake_line_sha256(handshake_line)
-        if proof.handshake_sha256 != handshake_sha256:
-            return False
         if nick_from_pubkey_hex(proof.pubkey, protocol_version) != nick:
             return False
 

--- a/jmcore/src/jmcore/protocol.py
+++ b/jmcore/src/jmcore/protocol.py
@@ -77,6 +77,7 @@ FEATURE_NEUTRINO_COMPAT = "neutrino_compat"
 FEATURE_PUSH_ENCRYPTED = "push_encrypted"
 FEATURE_PEERLIST_FEATURES = "peerlist_features"  # Supports extended peerlist with F: suffix
 FEATURE_PING = "ping"  # Supports application-level PING/PONG heartbeat
+FEATURE_NICK_AUTH = "nick_auth"
 
 # Feature dependencies: feature -> list of required features
 FEATURE_DEPENDENCIES: dict[str, list[str]] = {
@@ -84,6 +85,7 @@ FEATURE_DEPENDENCIES: dict[str, list[str]] = {
     FEATURE_PUSH_ENCRYPTED: [],  # Requires NaCl session, but that's implicit
     FEATURE_PEERLIST_FEATURES: [],  # No dependencies
     FEATURE_PING: [],  # No dependencies
+    FEATURE_NICK_AUTH: [],  # No dependencies
 }
 
 # All known features
@@ -92,6 +94,7 @@ ALL_FEATURES = {
     FEATURE_PUSH_ENCRYPTED,
     FEATURE_PEERLIST_FEATURES,
     FEATURE_PING,
+    FEATURE_NICK_AUTH,
 }
 
 
@@ -165,6 +168,10 @@ class FeatureSet:
     def supports_ping(self) -> bool:
         """Check if peer supports application-level PING/PONG heartbeat."""
         return FEATURE_PING in self.features
+
+    def supports_nick_auth(self) -> bool:
+        """Check if peer supports JMP-0005 nick ownership authentication."""
+        return FEATURE_NICK_AUTH in self.features
 
     def validate_dependencies(self) -> tuple[bool, str]:
         """Check that all feature dependencies are satisfied."""
@@ -387,6 +394,8 @@ class MessageType(IntEnum):
     PING = 798
     PONG = 799
     DISCONNECT = 801
+    NICK_AUTH = 803
+    NICK_AUTH_RESULT = 805
 
     # Local-only control messages, never sent over the wire.
     # The reference implementation uses 797 for CONNECT_IN (a local-only

--- a/jmcore/src/jmcore/protocol.py
+++ b/jmcore/src/jmcore/protocol.py
@@ -394,7 +394,8 @@ class MessageType(IntEnum):
     PING = 798
     PONG = 799
     DISCONNECT = 801
-    NICK_AUTH = 803
+    NICK_AUTH_CHALLENGE = 803
+    NICK_AUTH_PROOF = 804
     NICK_AUTH_RESULT = 805
 
     # Local-only control messages, never sent over the wire.

--- a/jmcore/src/jmcore/protocol.py
+++ b/jmcore/src/jmcore/protocol.py
@@ -395,8 +395,8 @@ class MessageType(IntEnum):
     PONG = 799
     DISCONNECT = 801
     NICK_AUTH_CHALLENGE = 803
-    NICK_AUTH_PROOF = 804
-    NICK_AUTH_RESULT = 805
+    NICK_AUTH_PROOF = 805
+    NICK_AUTH_RESULT = 807
 
     # Local-only control messages, never sent over the wire.
     # The reference implementation uses 797 for CONNECT_IN (a local-only

--- a/jmcore/src/jmcore/settings.py
+++ b/jmcore/src/jmcore/settings.py
@@ -60,7 +60,7 @@ from jmcore.models import (
     DIRECTORY_NODES_TESTNET,
     NetworkType,
 )
-from jmcore.nick_auth import NickAuthMode, validate_directory_id
+from jmcore.nick_auth import NickAuthMode, validate_directory_endpoint, validate_directory_id
 from jmcore.paths import get_default_data_dir
 
 # Default directory servers per network (single source of truth in models.py)
@@ -346,6 +346,10 @@ class NetworkSettings(BaseModel):
         default=NickAuthMode.PREFER_VERIFIED,
         description="Client policy for authenticating nick ownership to directory servers",
     )
+    nick_auth_directory_ids: dict[str, str] = Field(
+        default_factory=dict,
+        description="Expected nick authentication identity by selected host:port endpoint",
+    )
 
     @field_validator("directory_servers", mode="before")
     @classmethod
@@ -372,6 +376,14 @@ class NetworkSettings(BaseModel):
             # Fall back to comma-separated plain string
             return [s.strip() for s in v.split(",") if s.strip()]
         return v
+
+    @field_validator("nick_auth_directory_ids")
+    @classmethod
+    def validate_nick_auth_directory_ids(cls, value: dict[str, str]) -> dict[str, str]:
+        return {
+            validate_directory_endpoint(endpoint): validate_directory_id(directory_id)
+            for endpoint, directory_id in value.items()
+        }
 
 
 class WalletSettings(BaseModel):

--- a/jmcore/src/jmcore/settings.py
+++ b/jmcore/src/jmcore/settings.py
@@ -60,6 +60,7 @@ from jmcore.models import (
     DIRECTORY_NODES_TESTNET,
     NetworkType,
 )
+from jmcore.nick_auth import NickAuthMode, validate_directory_id
 from jmcore.paths import get_default_data_dir
 
 # Default directory servers per network (single source of truth in models.py)
@@ -340,6 +341,10 @@ class NetworkSettings(BaseModel):
     directory_servers: list[str] = Field(
         default_factory=list,
         description="Directory server addresses (host:port). Uses defaults if empty.",
+    )
+    nick_auth_mode: NickAuthMode = Field(
+        default=NickAuthMode.PREFER_VERIFIED,
+        description="Client policy for authenticating nick ownership to directory servers",
     )
 
     @field_validator("directory_servers", mode="before")
@@ -1112,6 +1117,35 @@ class DirectoryServerSettings(BaseModel):
         le=65535,
         description="Port to listen on (0 = let OS assign)",
     )
+    nick_auth_mode: NickAuthMode = Field(
+        default=NickAuthMode.PREFER_VERIFIED,
+        description="Server policy for verifying client nick ownership",
+    )
+    nick_auth_directory_id: str | None = Field(
+        default=None,
+        description="Stable JMP-0005 identifier for this directory endpoint",
+    )
+    nick_auth_timeout: float = Field(
+        default=30.0,
+        gt=0.0,
+        le=30.0,
+        description="Seconds to wait for a negotiated nick authentication proof",
+    )
+
+    @field_validator("nick_auth_directory_id")
+    @classmethod
+    def validate_nick_auth_directory_id(cls, value: str | None) -> str | None:
+        return validate_directory_id(value) if value is not None else None
+
+    @model_validator(mode="after")
+    def require_nick_auth_directory_id(self) -> Self:
+        if (
+            self.nick_auth_mode is NickAuthMode.REQUIRE_VERIFIED
+            and self.nick_auth_directory_id is None
+        ):
+            raise ValueError("require_verified nick authentication needs nick_auth_directory_id")
+        return self
+
     max_peers: int = Field(
         default=10000,
         ge=1,

--- a/jmcore/tests/test_base_config.py
+++ b/jmcore/tests/test_base_config.py
@@ -271,6 +271,24 @@ class TestWalletConfig:
         assert default_config.nick_auth_mode is NickAuthMode.PREFER_VERIFIED
         assert required_config.nick_auth_mode is NickAuthMode.REQUIRE_VERIFIED
 
+    def test_nick_auth_directory_ids(self):
+        config = WalletConfig(
+            mnemonic="test " * 12,
+            nick_auth_directory_ids={"directory.internal:5222": "test:directory-a"},
+        )
+
+        assert config.nick_auth_directory_ids == {"directory.internal:5222": "test:directory-a"}
+        with pytest.raises(ValidationError, match="invalid directory-id"):
+            WalletConfig(
+                mnemonic="test " * 12,
+                nick_auth_directory_ids={"directory.internal:5222": "bad|identity"},
+            )
+        with pytest.raises(ValidationError, match="host:port"):
+            WalletConfig(
+                mnemonic="test " * 12,
+                nick_auth_directory_ids={"directory.internal": "test:directory-a"},
+            )
+
 
 class TestDirectoryServerConfig:
     def test_default_values(self):

--- a/jmcore/tests/test_base_config.py
+++ b/jmcore/tests/test_base_config.py
@@ -15,6 +15,7 @@ from jmcore.config import (
     WalletConfig,
 )
 from jmcore.models import NetworkType
+from jmcore.nick_auth import NickAuthMode
 
 
 class TestTorConfig:
@@ -262,6 +263,13 @@ class TestWalletConfig:
             WalletConfig(mnemonic="test " * 12, connection_timeout=0.0)
         with pytest.raises(ValidationError):
             WalletConfig(mnemonic="test " * 12, connection_timeout=-1.0)
+
+    def test_nick_auth_mode(self):
+        default_config = WalletConfig(mnemonic="test " * 12)
+        required_config = WalletConfig(mnemonic="test " * 12, nick_auth_mode="require_verified")
+
+        assert default_config.nick_auth_mode is NickAuthMode.PREFER_VERIFIED
+        assert required_config.nick_auth_mode is NickAuthMode.REQUIRE_VERIFIED
 
 
 class TestDirectoryServerConfig:

--- a/jmcore/tests/test_directory_client.py
+++ b/jmcore/tests/test_directory_client.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import json
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -371,6 +371,85 @@ async def test_nick_auth_rejects_proof_type_before_parsing_challenge_payload() -
 
     parse_challenge.assert_not_called()
     assert connection.send.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message_type",
+    [MessageType.NICK_AUTH_CHALLENGE, MessageType.NICK_AUTH_PROOF],
+)
+async def test_nick_auth_rejects_out_of_order_result_type_before_parsing(
+    message_type: MessageType,
+) -> None:
+    challenge = NickAuthChallenge(challenge="22" * 32, directory_id=TEST_DIRECTORY_ID)
+    connection = AsyncMock()
+    connection.receive.side_effect = [
+        _handshake_response(nick_auth=True),
+        json.dumps(
+            {"type": MessageType.NICK_AUTH_CHALLENGE.value, "line": challenge.to_json()}
+        ).encode(),
+        json.dumps({"type": message_type.value, "line": "not a result payload"}).encode(),
+    ]
+    client = DirectoryClient(
+        "directory-a", 5222, "regtest", nick_auth_directory_id=TEST_DIRECTORY_ID
+    )
+    client.connection = connection
+
+    with (
+        patch("jmcore.directory_client.NickAuthResult.parse") as parse_result,
+        pytest.raises(DirectoryClientError, match="Unexpected nick authentication result type"),
+    ):
+        await client._handshake()
+
+    parse_result.assert_not_called()
+    assert connection.send.await_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("buffered", [False, True])
+@pytest.mark.parametrize(
+    "message_type",
+    [
+        MessageType.NICK_AUTH_CHALLENGE,
+        MessageType.NICK_AUTH_PROOF,
+        MessageType.NICK_AUTH_RESULT,
+    ],
+)
+async def test_nick_auth_message_after_handshake_closes_connection(
+    message_type: MessageType,
+    buffered: bool,
+) -> None:
+    message = {"type": message_type.value, "line": {}}
+    connection = AsyncMock()
+    connection.is_connected = Mock(return_value=True)
+    connection.receive.return_value = json.dumps(message).encode()
+    client = DirectoryClient("directory-a", 5222, "regtest")
+    client.connection = connection
+    client.directory_nick_authenticated = True
+    if buffered:
+        await client._message_buffer.put(message)
+
+    with pytest.raises(DirectoryClientError, match="Out-of-order nick authentication"):
+        await client.listen_for_messages(duration=0.01)
+
+    connection.close.assert_awaited_once()
+    assert client.connection is None
+    assert client.directory_nick_authenticated is False
+
+
+@pytest.mark.asyncio
+async def test_close_clears_authentication_state_when_transport_close_fails() -> None:
+    connection = AsyncMock()
+    connection.close.side_effect = ConnectionResetError("already closed")
+    client = DirectoryClient("directory-a", 5222, "regtest")
+    client.connection = connection
+    client.directory_nick_authenticated = True
+
+    with pytest.raises(ConnectionResetError, match="already closed"):
+        await client.close()
+
+    assert client.connection is None
+    assert client.directory_nick_authenticated is False
 
 
 @pytest.mark.asyncio

--- a/jmcore/tests/test_directory_client.py
+++ b/jmcore/tests/test_directory_client.py
@@ -23,6 +23,8 @@ from jmcore.nick_auth import (
 )
 from jmcore.protocol import FEATURE_NICK_AUTH, FEATURE_PEERLIST_FEATURES
 
+TEST_DIRECTORY_ID = "test:directory-a"
+
 
 def _handshake_response(*, nick_auth: bool = False) -> bytes:
     features = {FEATURE_NICK_AUTH: True} if nick_auth else {}
@@ -142,7 +144,9 @@ def test_offer_bond_rotation_removes_old_reverse_index() -> None:
 async def test_nick_auth_prefer_verified_falls_back_to_legacy_directory() -> None:
     connection = AsyncMock()
     connection.receive.return_value = _handshake_response()
-    client = DirectoryClient("directory-a", 5222, "regtest")
+    client = DirectoryClient(
+        "directory-a", 5222, "regtest", nick_auth_directory_id=TEST_DIRECTORY_ID
+    )
     client.connection = connection
 
     await client._handshake()
@@ -158,7 +162,11 @@ async def test_nick_auth_require_verified_rejects_legacy_directory() -> None:
     connection = AsyncMock()
     connection.receive.return_value = _handshake_response()
     client = DirectoryClient(
-        "directory-a", 5222, "regtest", nick_auth_mode=NickAuthMode.REQUIRE_VERIFIED
+        "directory-a",
+        5222,
+        "regtest",
+        nick_auth_mode=NickAuthMode.REQUIRE_VERIFIED,
+        nick_auth_directory_id=TEST_DIRECTORY_ID,
     )
     client.connection = connection
 
@@ -170,9 +178,38 @@ async def test_nick_auth_require_verified_rejects_legacy_directory() -> None:
 
 
 @pytest.mark.asyncio
+async def test_nick_auth_prefer_verified_does_not_advertise_without_expected_identity() -> None:
+    connection = AsyncMock()
+    connection.receive.return_value = _handshake_response(nick_auth=True)
+    client = DirectoryClient("directory.example", 5222, "regtest")
+    client.connection = connection
+
+    await client._handshake()
+
+    handshake = json.loads(connection.send.await_args.args[0])
+    assert FEATURE_NICK_AUTH not in json.loads(handshake["line"])["features"]
+    assert connection.receive.await_count == 1
+    assert client.directory_nick_authenticated is False
+
+
+@pytest.mark.asyncio
+async def test_nick_auth_require_verified_fails_accurately_without_expected_identity() -> None:
+    connection = AsyncMock()
+    client = DirectoryClient(
+        "directory.example", 5222, "regtest", nick_auth_mode=NickAuthMode.REQUIRE_VERIFIED
+    )
+    client.connection = connection
+
+    with pytest.raises(DirectoryClientError, match="No expected.*directory.example:5222"):
+        await client._handshake()
+
+    connection.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_nick_auth_valid_challenge_proof_and_result_use_exact_wire_envelopes() -> None:
     identity = NickIdentity(private_key_bytes=b"\x01" * 32)
-    directory_id = directory_id_for_endpoint("directory-a", 5222)
+    directory_id = TEST_DIRECTORY_ID
     challenge = NickAuthChallenge(challenge="22" * 32, directory_id=directory_id)
     result = NickAuthResult(code="ok", verified=True)
     connection = AsyncMock()
@@ -181,7 +218,13 @@ async def test_nick_auth_valid_challenge_proof_and_result_use_exact_wire_envelop
         json.dumps({"type": MessageType.NICK_AUTH.value, "line": challenge.to_json()}).encode(),
         json.dumps({"type": MessageType.NICK_AUTH_RESULT.value, "line": result.to_json()}).encode(),
     ]
-    client = DirectoryClient("directory-a", 5222, "regtest", nick_identity=identity)
+    client = DirectoryClient(
+        "directory-a",
+        5222,
+        "regtest",
+        nick_identity=identity,
+        nick_auth_directory_id=directory_id,
+    )
     client.connection = connection
 
     await client._handshake()
@@ -219,7 +262,7 @@ async def test_nick_auth_valid_challenge_proof_and_result_use_exact_wire_envelop
 
 @pytest.mark.asyncio
 async def test_nick_auth_malformed_result_fails_closed() -> None:
-    directory_id = directory_id_for_endpoint("directory-a", 5222)
+    directory_id = TEST_DIRECTORY_ID
     challenge = NickAuthChallenge(challenge="22" * 32, directory_id=directory_id)
     connection = AsyncMock()
     connection.receive.side_effect = [
@@ -232,7 +275,7 @@ async def test_nick_auth_malformed_result_fails_closed() -> None:
             }
         ).encode(),
     ]
-    client = DirectoryClient("directory-a", 5222, "regtest")
+    client = DirectoryClient("directory-a", 5222, "regtest", nick_auth_directory_id=directory_id)
     client.connection = connection
 
     with pytest.raises(DirectoryClientError, match="Invalid nick authentication response"):
@@ -254,13 +297,15 @@ async def test_nick_auth_malformed_challenge_is_redacted_from_exception_chain() 
                     {
                         "kind": "challenge",
                         "challenge": secret_challenge,
-                        "directory-id": directory_id_for_endpoint("directory-a", 5222),
+                        "directory-id": TEST_DIRECTORY_ID,
                     }
                 ),
             }
         ).encode(),
     ]
-    client = DirectoryClient("directory-a", 5222, "regtest")
+    client = DirectoryClient(
+        "directory-a", 5222, "regtest", nick_auth_directory_id=TEST_DIRECTORY_ID
+    )
     client.connection = connection
 
     with pytest.raises(DirectoryClientError) as exc_info:
@@ -281,13 +326,15 @@ async def test_nick_auth_rejects_duplicate_outer_envelope_keys() -> None:
             + json.dumps(
                 NickAuthChallenge(
                     challenge="22" * 32,
-                    directory_id=directory_id_for_endpoint("directory-a", 5222),
+                    directory_id=TEST_DIRECTORY_ID,
                 ).to_json()
             )
             + "}"
         ).encode(),
     ]
-    client = DirectoryClient("directory-a", 5222, "regtest")
+    client = DirectoryClient(
+        "directory-a", 5222, "regtest", nick_auth_directory_id=TEST_DIRECTORY_ID
+    )
     client.connection = connection
 
     with pytest.raises(DirectoryClientError, match="Invalid nick authentication response"):
@@ -320,7 +367,7 @@ async def test_nick_auth_mismatched_directory_id_fails_before_proof() -> None:
 
 
 @pytest.mark.asyncio
-async def test_nick_auth_accepts_stable_test_id_across_forwarded_endpoint() -> None:
+async def test_nick_auth_accepts_configured_test_id_across_forwarded_endpoint() -> None:
     challenge = NickAuthChallenge(
         challenge="22" * 32,
         directory_id="test:jm-directory-5222",
@@ -332,7 +379,12 @@ async def test_nick_auth_accepts_stable_test_id_across_forwarded_endpoint() -> N
         json.dumps({"type": MessageType.NICK_AUTH.value, "line": challenge.to_json()}).encode(),
         json.dumps({"type": MessageType.NICK_AUTH_RESULT.value, "line": result.to_json()}).encode(),
     ]
-    client = DirectoryClient("127.0.0.1", 20004, "regtest")
+    client = DirectoryClient(
+        "127.0.0.1",
+        20004,
+        "regtest",
+        nick_auth_directory_id="test:jm-directory-5222",
+    )
     client.connection = connection
 
     await client._handshake()
@@ -348,7 +400,13 @@ async def test_nick_auth_challenge_timeout_fails_closed() -> None:
         _handshake_response(nick_auth=True),
         TimeoutError(),
     ]
-    client = DirectoryClient("directory-a", 5222, "regtest", timeout=0.01)
+    client = DirectoryClient(
+        "directory-a",
+        5222,
+        "regtest",
+        timeout=0.01,
+        nick_auth_directory_id=TEST_DIRECTORY_ID,
+    )
     client.connection = connection
 
     with pytest.raises(DirectoryClientError, match="timed out"):
@@ -356,6 +414,48 @@ async def test_nick_auth_challenge_timeout_fails_closed() -> None:
 
     assert connection.send.await_count == 1
     assert client.directory_nick_authenticated is False
+
+
+@pytest.mark.asyncio
+async def test_nick_auth_challenge_and_result_waits_are_capped_at_30_seconds() -> None:
+    challenge = NickAuthChallenge(challenge="22" * 32, directory_id=TEST_DIRECTORY_ID)
+    result = NickAuthResult(code="ok", verified=True)
+    connection = AsyncMock()
+    connection.receive.side_effect = [
+        _handshake_response(nick_auth=True),
+        json.dumps({"type": MessageType.NICK_AUTH.value, "line": challenge.to_json()}).encode(),
+        json.dumps({"type": MessageType.NICK_AUTH_RESULT.value, "line": result.to_json()}).encode(),
+    ]
+    client = DirectoryClient(
+        "directory-a",
+        5222,
+        "regtest",
+        timeout=120.0,
+        nick_auth_directory_id=TEST_DIRECTORY_ID,
+    )
+    client.connection = connection
+
+    with patch("jmcore.directory_client.asyncio.wait_for", wraps=asyncio.wait_for) as wait_for:
+        await client._handshake()
+
+    assert [call.kwargs["timeout"] for call in wait_for.call_args_list] == [
+        120.0,
+        30.0,
+        30.0,
+        30.0,
+    ]
+
+
+def test_nick_auth_derives_expected_identity_only_for_v3_onion() -> None:
+    onion_host = "a" * 56 + ".onion"
+
+    onion_client = DirectoryClient(onion_host, 5222, "mainnet")
+    clearnet_client = DirectoryClient("directory.example", 5222, "mainnet")
+    local_client = DirectoryClient("127.0.0.1", 5222, "regtest")
+
+    assert onion_client.nick_auth_directory_id == f"{onion_host}:5222"
+    assert clearnet_client.nick_auth_directory_id is None
+    assert local_client.nick_auth_directory_id is None
 
 
 @pytest.mark.asyncio

--- a/jmcore/tests/test_directory_client.py
+++ b/jmcore/tests/test_directory_client.py
@@ -6,9 +6,36 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from jmcore.directory_client import DirectoryClient, MessageType, _fidelity_bond_claim_key
+from jmcore.crypto import NickIdentity
+from jmcore.directory_client import (
+    DirectoryClient,
+    DirectoryClientError,
+    MessageType,
+    _fidelity_bond_claim_key,
+)
 from jmcore.models import Offer, OfferType
-from jmcore.protocol import FEATURE_PEERLIST_FEATURES
+from jmcore.nick_auth import (
+    NickAuthChallenge,
+    NickAuthMode,
+    NickAuthResult,
+    create_nick_auth_proof,
+    directory_id_for_endpoint,
+)
+from jmcore.protocol import FEATURE_NICK_AUTH, FEATURE_PEERLIST_FEATURES
+
+
+def _handshake_response(*, nick_auth: bool = False) -> bytes:
+    features = {FEATURE_NICK_AUTH: True} if nick_auth else {}
+    line = json.dumps(
+        {
+            "accepted": True,
+            "proto-ver-min": 5,
+            "proto-ver-max": 5,
+            "features": features,
+            "nick": "directory",
+        }
+    )
+    return json.dumps({"type": MessageType.DN_HANDSHAKE.value, "line": line}).encode()
 
 
 def _bond_offer(counterparty: str, oid: int, bond_data: dict[str, Any] | None = None) -> Offer:
@@ -109,6 +136,241 @@ def test_offer_bond_rotation_removes_old_reverse_index() -> None:
     assert set(client.offers) == {maker_offer_key, ("Maker2", 0)}
     assert maker_offer_key not in client._bond_to_offers[first_key]
     assert maker_offer_key in client._bond_to_offers[second_key]
+
+
+@pytest.mark.asyncio
+async def test_nick_auth_prefer_verified_falls_back_to_legacy_directory() -> None:
+    connection = AsyncMock()
+    connection.receive.return_value = _handshake_response()
+    client = DirectoryClient("directory-a", 5222, "regtest")
+    client.connection = connection
+
+    await client._handshake()
+
+    assert client.directory_nick_authenticated is False
+    assert connection.send.await_count == 1
+    handshake = json.loads(connection.send.await_args.args[0])
+    assert json.loads(handshake["line"])["features"][FEATURE_NICK_AUTH] is True
+
+
+@pytest.mark.asyncio
+async def test_nick_auth_require_verified_rejects_legacy_directory() -> None:
+    connection = AsyncMock()
+    connection.receive.return_value = _handshake_response()
+    client = DirectoryClient(
+        "directory-a", 5222, "regtest", nick_auth_mode=NickAuthMode.REQUIRE_VERIFIED
+    )
+    client.connection = connection
+
+    with pytest.raises(DirectoryClientError, match="does not support"):
+        await client._handshake()
+
+    assert client.directory_nick_authenticated is False
+    assert connection.send.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_nick_auth_valid_challenge_proof_and_result_use_exact_wire_envelopes() -> None:
+    identity = NickIdentity(private_key_bytes=b"\x01" * 32)
+    directory_id = directory_id_for_endpoint("directory-a", 5222)
+    challenge = NickAuthChallenge(challenge="22" * 32, directory_id=directory_id)
+    result = NickAuthResult(code="ok", verified=True)
+    connection = AsyncMock()
+    connection.receive.side_effect = [
+        _handshake_response(nick_auth=True),
+        json.dumps({"type": MessageType.NICK_AUTH.value, "line": challenge.to_json()}).encode(),
+        json.dumps({"type": MessageType.NICK_AUTH_RESULT.value, "line": result.to_json()}).encode(),
+    ]
+    client = DirectoryClient("directory-a", 5222, "regtest", nick_identity=identity)
+    client.connection = connection
+
+    await client._handshake()
+
+    sent = connection.send.await_args_list
+    assert len(sent) == 2
+    expected_handshake_line = json.dumps(
+        {
+            "app-name": "joinmarket",
+            "directory": False,
+            "location-string": "NOT-SERVING-ONION",
+            "proto-ver": 5,
+            "features": {
+                "nick_auth": True,
+                "peerlist_features": True,
+                "ping": True,
+            },
+            "nick": identity.nick,
+            "network": "regtest",
+        }
+    )
+    expected_handshake = json.dumps(
+        {"type": MessageType.HANDSHAKE.value, "line": expected_handshake_line}
+    ).encode()
+    expected_proof = create_nick_auth_proof(
+        identity, challenge.challenge, directory_id, expected_handshake_line
+    )
+    expected_proof_envelope = json.dumps(
+        {"type": MessageType.NICK_AUTH.value, "line": expected_proof.to_json()}
+    ).encode()
+    assert sent[0].args[0] == expected_handshake
+    assert sent[1].args[0] == expected_proof_envelope
+    assert client.directory_nick_authenticated is True
+
+
+@pytest.mark.asyncio
+async def test_nick_auth_malformed_result_fails_closed() -> None:
+    directory_id = directory_id_for_endpoint("directory-a", 5222)
+    challenge = NickAuthChallenge(challenge="22" * 32, directory_id=directory_id)
+    connection = AsyncMock()
+    connection.receive.side_effect = [
+        _handshake_response(nick_auth=True),
+        json.dumps({"type": MessageType.NICK_AUTH.value, "line": challenge.to_json()}).encode(),
+        json.dumps(
+            {
+                "type": MessageType.NICK_AUTH_RESULT.value,
+                "line": '{"code":"ok","verified":false}',
+            }
+        ).encode(),
+    ]
+    client = DirectoryClient("directory-a", 5222, "regtest")
+    client.connection = connection
+
+    with pytest.raises(DirectoryClientError, match="Invalid nick authentication response"):
+        await client._handshake()
+
+    assert client.directory_nick_authenticated is False
+
+
+@pytest.mark.asyncio
+async def test_nick_auth_malformed_challenge_is_redacted_from_exception_chain() -> None:
+    secret_challenge = "AA" * 32
+    connection = AsyncMock()
+    connection.receive.side_effect = [
+        _handshake_response(nick_auth=True),
+        json.dumps(
+            {
+                "type": MessageType.NICK_AUTH.value,
+                "line": json.dumps(
+                    {
+                        "kind": "challenge",
+                        "challenge": secret_challenge,
+                        "directory-id": directory_id_for_endpoint("directory-a", 5222),
+                    }
+                ),
+            }
+        ).encode(),
+    ]
+    client = DirectoryClient("directory-a", 5222, "regtest")
+    client.connection = connection
+
+    with pytest.raises(DirectoryClientError) as exc_info:
+        await client._handshake()
+
+    assert str(exc_info.value) == "Invalid nick authentication response"
+    assert secret_challenge not in str(exc_info.value)
+    assert exc_info.value.__suppress_context__ is True
+
+
+@pytest.mark.asyncio
+async def test_nick_auth_rejects_duplicate_outer_envelope_keys() -> None:
+    connection = AsyncMock()
+    connection.receive.side_effect = [
+        _handshake_response(nick_auth=True),
+        (
+            '{"type":803,"type":803,"line":'
+            + json.dumps(
+                NickAuthChallenge(
+                    challenge="22" * 32,
+                    directory_id=directory_id_for_endpoint("directory-a", 5222),
+                ).to_json()
+            )
+            + "}"
+        ).encode(),
+    ]
+    client = DirectoryClient("directory-a", 5222, "regtest")
+    client.connection = connection
+
+    with pytest.raises(DirectoryClientError, match="Invalid nick authentication response"):
+        await client._handshake()
+
+    assert connection.send.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_nick_auth_mismatched_directory_id_fails_before_proof() -> None:
+    selected_host = "a" * 56 + ".onion"
+    other_host = "b" * 56 + ".onion"
+    challenge = NickAuthChallenge(
+        challenge="22" * 32,
+        directory_id=directory_id_for_endpoint(other_host, 5222),
+    )
+    connection = AsyncMock()
+    connection.receive.side_effect = [
+        _handshake_response(nick_auth=True),
+        json.dumps({"type": MessageType.NICK_AUTH.value, "line": challenge.to_json()}).encode(),
+    ]
+    client = DirectoryClient(selected_host, 5222, "regtest")
+    client.connection = connection
+
+    with pytest.raises(DirectoryClientError, match="directory-id mismatch"):
+        await client._handshake()
+
+    assert connection.send.await_count == 1
+    assert client.directory_nick_authenticated is False
+
+
+@pytest.mark.asyncio
+async def test_nick_auth_accepts_stable_test_id_across_forwarded_endpoint() -> None:
+    challenge = NickAuthChallenge(
+        challenge="22" * 32,
+        directory_id="test:jm-directory-5222",
+    )
+    result = NickAuthResult(code="ok", verified=True)
+    connection = AsyncMock()
+    connection.receive.side_effect = [
+        _handshake_response(nick_auth=True),
+        json.dumps({"type": MessageType.NICK_AUTH.value, "line": challenge.to_json()}).encode(),
+        json.dumps({"type": MessageType.NICK_AUTH_RESULT.value, "line": result.to_json()}).encode(),
+    ]
+    client = DirectoryClient("127.0.0.1", 20004, "regtest")
+    client.connection = connection
+
+    await client._handshake()
+
+    assert connection.send.await_count == 2
+    assert client.directory_nick_authenticated is True
+
+
+@pytest.mark.asyncio
+async def test_nick_auth_challenge_timeout_fails_closed() -> None:
+    connection = AsyncMock()
+    connection.receive.side_effect = [
+        _handshake_response(nick_auth=True),
+        TimeoutError(),
+    ]
+    client = DirectoryClient("directory-a", 5222, "regtest", timeout=0.01)
+    client.connection = connection
+
+    with pytest.raises(DirectoryClientError, match="timed out"):
+        await client._handshake()
+
+    assert connection.send.await_count == 1
+    assert client.directory_nick_authenticated is False
+
+
+@pytest.mark.asyncio
+async def test_nick_auth_disabled_uses_legacy_handshake_only() -> None:
+    connection = AsyncMock()
+    connection.receive.return_value = _handshake_response(nick_auth=True)
+    client = DirectoryClient("directory-a", 5222, "regtest", nick_auth_mode=NickAuthMode.DISABLED)
+    client.connection = connection
+
+    await client._handshake()
+
+    assert connection.send.await_count == 1
+    handshake = json.loads(connection.send.await_args.args[0])
+    assert FEATURE_NICK_AUTH not in json.loads(handshake["line"])["features"]
+    assert client.directory_nick_authenticated is False
 
 
 def test_directory_client_default_timeout():

--- a/jmcore/tests/test_directory_client.py
+++ b/jmcore/tests/test_directory_client.py
@@ -215,7 +215,9 @@ async def test_nick_auth_valid_challenge_proof_and_result_use_exact_wire_envelop
     connection = AsyncMock()
     connection.receive.side_effect = [
         _handshake_response(nick_auth=True),
-        json.dumps({"type": MessageType.NICK_AUTH.value, "line": challenge.to_json()}).encode(),
+        json.dumps(
+            {"type": MessageType.NICK_AUTH_CHALLENGE.value, "line": challenge.to_json()}
+        ).encode(),
         json.dumps({"type": MessageType.NICK_AUTH_RESULT.value, "line": result.to_json()}).encode(),
     ]
     client = DirectoryClient(
@@ -253,7 +255,7 @@ async def test_nick_auth_valid_challenge_proof_and_result_use_exact_wire_envelop
         identity, challenge.challenge, directory_id, expected_handshake_line
     )
     expected_proof_envelope = json.dumps(
-        {"type": MessageType.NICK_AUTH.value, "line": expected_proof.to_json()}
+        {"type": MessageType.NICK_AUTH_PROOF.value, "line": expected_proof.to_json()}
     ).encode()
     assert sent[0].args[0] == expected_handshake
     assert sent[1].args[0] == expected_proof_envelope
@@ -267,7 +269,9 @@ async def test_nick_auth_malformed_result_fails_closed() -> None:
     connection = AsyncMock()
     connection.receive.side_effect = [
         _handshake_response(nick_auth=True),
-        json.dumps({"type": MessageType.NICK_AUTH.value, "line": challenge.to_json()}).encode(),
+        json.dumps(
+            {"type": MessageType.NICK_AUTH_CHALLENGE.value, "line": challenge.to_json()}
+        ).encode(),
         json.dumps(
             {
                 "type": MessageType.NICK_AUTH_RESULT.value,
@@ -292,10 +296,9 @@ async def test_nick_auth_malformed_challenge_is_redacted_from_exception_chain() 
         _handshake_response(nick_auth=True),
         json.dumps(
             {
-                "type": MessageType.NICK_AUTH.value,
+                "type": MessageType.NICK_AUTH_CHALLENGE.value,
                 "line": json.dumps(
                     {
-                        "kind": "challenge",
                         "challenge": secret_challenge,
                         "directory-id": TEST_DIRECTORY_ID,
                     }
@@ -344,6 +347,33 @@ async def test_nick_auth_rejects_duplicate_outer_envelope_keys() -> None:
 
 
 @pytest.mark.asyncio
+async def test_nick_auth_rejects_proof_type_before_parsing_challenge_payload() -> None:
+    connection = AsyncMock()
+    connection.receive.side_effect = [
+        _handshake_response(nick_auth=True),
+        json.dumps(
+            {
+                "type": MessageType.NICK_AUTH_PROOF.value,
+                "line": "not a challenge payload",
+            }
+        ).encode(),
+    ]
+    client = DirectoryClient(
+        "directory-a", 5222, "regtest", nick_auth_directory_id=TEST_DIRECTORY_ID
+    )
+    client.connection = connection
+
+    with (
+        patch("jmcore.directory_client.NickAuthChallenge.parse") as parse_challenge,
+        pytest.raises(DirectoryClientError, match="Unexpected nick authentication challenge type"),
+    ):
+        await client._handshake()
+
+    parse_challenge.assert_not_called()
+    assert connection.send.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_nick_auth_mismatched_directory_id_fails_before_proof() -> None:
     selected_host = "a" * 56 + ".onion"
     other_host = "b" * 56 + ".onion"
@@ -354,7 +384,9 @@ async def test_nick_auth_mismatched_directory_id_fails_before_proof() -> None:
     connection = AsyncMock()
     connection.receive.side_effect = [
         _handshake_response(nick_auth=True),
-        json.dumps({"type": MessageType.NICK_AUTH.value, "line": challenge.to_json()}).encode(),
+        json.dumps(
+            {"type": MessageType.NICK_AUTH_CHALLENGE.value, "line": challenge.to_json()}
+        ).encode(),
     ]
     client = DirectoryClient(selected_host, 5222, "regtest")
     client.connection = connection
@@ -376,7 +408,9 @@ async def test_nick_auth_accepts_configured_test_id_across_forwarded_endpoint() 
     connection = AsyncMock()
     connection.receive.side_effect = [
         _handshake_response(nick_auth=True),
-        json.dumps({"type": MessageType.NICK_AUTH.value, "line": challenge.to_json()}).encode(),
+        json.dumps(
+            {"type": MessageType.NICK_AUTH_CHALLENGE.value, "line": challenge.to_json()}
+        ).encode(),
         json.dumps({"type": MessageType.NICK_AUTH_RESULT.value, "line": result.to_json()}).encode(),
     ]
     client = DirectoryClient(
@@ -423,7 +457,9 @@ async def test_nick_auth_challenge_and_result_waits_are_capped_at_30_seconds() -
     connection = AsyncMock()
     connection.receive.side_effect = [
         _handshake_response(nick_auth=True),
-        json.dumps({"type": MessageType.NICK_AUTH.value, "line": challenge.to_json()}).encode(),
+        json.dumps(
+            {"type": MessageType.NICK_AUTH_CHALLENGE.value, "line": challenge.to_json()}
+        ).encode(),
         json.dumps({"type": MessageType.NICK_AUTH_RESULT.value, "line": result.to_json()}).encode(),
     ]
     client = DirectoryClient(

--- a/jmcore/tests/test_directory_pool.py
+++ b/jmcore/tests/test_directory_pool.py
@@ -48,6 +48,7 @@ async def test_connect_to_directory_parses_address_and_connects():
     assert kwargs["socks_username"] is None
     assert kwargs["socks_password"] is None
     assert kwargs["nick_auth_mode"] is NickAuthMode.PREFER_VERIFIED
+    assert kwargs["nick_auth_directory_id"] is None
 
 
 @pytest.mark.asyncio
@@ -59,6 +60,20 @@ async def test_connect_to_directory_passes_configured_nick_auth_mode():
         await pool.connect_to_directory("onion.example:5222")
 
     assert ctor.call_args.kwargs["nick_auth_mode"] is NickAuthMode.REQUIRE_VERIFIED
+
+
+@pytest.mark.asyncio
+async def test_connect_to_directory_resolves_expected_identity_by_selected_endpoint():
+    pool = _make_pool(
+        ["directory.internal"],
+        nick_auth_directory_ids={"directory.internal:5222": "test:directory-a"},
+    )
+    fake_client = MagicMock(connect=AsyncMock(return_value=None))
+
+    with patch("jmcore.directory_pool.DirectoryClient", return_value=fake_client) as ctor:
+        await pool.connect_to_directory("directory.internal")
+
+    assert ctor.call_args.kwargs["nick_auth_directory_id"] == "test:directory-a"
 
 
 @pytest.mark.asyncio

--- a/jmcore/tests/test_directory_pool.py
+++ b/jmcore/tests/test_directory_pool.py
@@ -10,6 +10,7 @@ import pytest
 
 from jmcore.crypto import NickIdentity
 from jmcore.directory_pool import DirectoryClientPool
+from jmcore.nick_auth import NickAuthMode
 
 
 def _identity() -> NickIdentity:
@@ -46,6 +47,18 @@ async def test_connect_to_directory_parses_address_and_connects():
     kwargs = ctor.call_args.kwargs
     assert kwargs["socks_username"] is None
     assert kwargs["socks_password"] is None
+    assert kwargs["nick_auth_mode"] is NickAuthMode.PREFER_VERIFIED
+
+
+@pytest.mark.asyncio
+async def test_connect_to_directory_passes_configured_nick_auth_mode():
+    pool = _make_pool(["onion.example:5222"], nick_auth_mode=NickAuthMode.REQUIRE_VERIFIED)
+    fake_client = MagicMock(connect=AsyncMock(return_value=None))
+
+    with patch("jmcore.directory_pool.DirectoryClient", return_value=fake_client) as ctor:
+        await pool.connect_to_directory("onion.example:5222")
+
+    assert ctor.call_args.kwargs["nick_auth_mode"] is NickAuthMode.REQUIRE_VERIFIED
 
 
 @pytest.mark.asyncio

--- a/jmcore/tests/test_nick_auth.py
+++ b/jmcore/tests/test_nick_auth.py
@@ -143,7 +143,20 @@ def test_directory_ids_accept_spec_grammar(directory_id: str):
     assert validate_directory_id(directory_id) == directory_id
 
 
-@pytest.mark.parametrize("directory_id", ["", "UPPERCASE", "bad|id", "bad id", "non-ascii-\u00e9"])
+@pytest.mark.parametrize(
+    "directory_id",
+    [
+        "",
+        "UPPERCASE",
+        ".directory",
+        ":directory",
+        "_directory",
+        "-directory",
+        "bad|id",
+        "bad id",
+        "non-ascii-\u00e9",
+    ],
+)
 def test_directory_ids_reject_values_outside_spec_grammar(directory_id: str):
     with pytest.raises(ValueError, match="invalid directory-id"):
         validate_directory_id(directory_id)

--- a/jmcore/tests/test_nick_auth.py
+++ b/jmcore/tests/test_nick_auth.py
@@ -5,9 +5,10 @@ import hashlib
 import json
 
 import pytest
+from coincurve import verify_signature as coincurve_verify
 from pydantic import ValidationError
 
-from jmcore.crypto import NickIdentity
+from jmcore.crypto import NickIdentity, bitcoin_message_hash_bytes
 from jmcore.nick_auth import (
     NickAuthChallenge,
     NickAuthMode,
@@ -18,8 +19,10 @@ from jmcore.nick_auth import (
     directory_id_for_endpoint,
     handshake_line_sha256,
     parse_strict_json_object,
+    validate_directory_id,
     verify_nick_auth_proof,
 )
+from jmcore.protocol import JM_VERSION
 
 PRIVATE_KEY = bytes.fromhex("11" * 32)
 CHALLENGE = "22" * 32
@@ -142,9 +145,20 @@ def test_handshake_hashes_exact_decoded_line_utf8_bytes():
 
 def test_directory_endpoint_ids_are_canonical():
     assert directory_id_for_endpoint(DIRECTORY_HOST.upper(), 5222) == DIRECTORY_ID
-    assert directory_id_for_endpoint("LOCALHOST", 1234) == "test:localhost-1234"
-    assert directory_id_for_endpoint("127.0.0.1", 1234) == "test:127.0.0.1-1234"
-    assert directory_id_for_endpoint("directory-a", 5222) == "test:directory-a-5222"
+
+
+@pytest.mark.parametrize(
+    "directory_id",
+    [DIRECTORY_ID, "test:directory-a", "directory.example:5222", "vpn_directory-1"],
+)
+def test_directory_ids_accept_spec_grammar(directory_id: str):
+    assert validate_directory_id(directory_id) == directory_id
+
+
+@pytest.mark.parametrize("directory_id", ["", "UPPERCASE", "bad|id", "bad id", "non-ascii-\u00e9"])
+def test_directory_ids_reject_values_outside_spec_grammar(directory_id: str):
+    with pytest.raises(ValueError, match="invalid directory-id"):
+        validate_directory_id(directory_id)
 
 
 @pytest.mark.parametrize(
@@ -153,6 +167,9 @@ def test_directory_endpoint_ids_are_canonical():
         ("short.onion", 5222),
         ("a" * 56 + ".onion", 0),
         ("bad host", 5222),
+        ("localhost", 1234),
+        ("127.0.0.1", 1234),
+        ("directory-a", 5222),
         ("example.com", 5222),
         ("8.8.8.8", 5222),
     ],
@@ -177,7 +194,7 @@ def test_signed_message_is_exact_ascii_transcript(identity: NickIdentity):
             f"nick-auth|{CHALLENGE}|{DIRECTORY_ID}|{handshake_hash}|"
             f"{identity.nick}|{identity.public_key_hex}"
         ).encode("ascii")
-        + b"onion-network"
+        + b"nick-auth-v1"
     )
 
 
@@ -188,8 +205,8 @@ def test_create_and_verify_deterministic_proof(identity: NickIdentity, proof: Ni
     )
     assert proof.pubkey == "034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa"
     assert proof.signature == (
-        "MEUCIQCy/qOvvS9DrnU8eOp09bftEqTvFmuDay7kXQtJw03a"
-        "RAIgR+WY4/hlsW8gC+NmGJIqM6ijM0r5oXmrhOIVn1ZlHAQ="
+        "MEQCIDTAF2VwsN1hK3n+Hc2iGt2xkhURfTfCiJnM4myGM6T2"
+        "AiAbXU8Kl5f16SwddktRYcl+gLHt5zS1nY7eLSi61e1g6w=="
     )
     assert verify_nick_auth_proof(
         proof,
@@ -197,6 +214,26 @@ def test_create_and_verify_deterministic_proof(identity: NickIdentity, proof: Ni
         DIRECTORY_ID,
         HANDSHAKE_LINE,
         identity.nick,
+        JM_VERSION,
+    )
+
+
+def test_proof_does_not_verify_in_message_signature_domain(
+    identity: NickIdentity,
+    proof: NickAuthProof,
+):
+    handshake_hash = handshake_line_sha256(HANDSHAKE_LINE)
+    transcript = (
+        f"nick-auth|{CHALLENGE}|{DIRECTORY_ID}|{handshake_hash}|"
+        f"{identity.nick}|{identity.public_key_hex}"
+    ).encode("ascii")
+    message_hash = bitcoin_message_hash_bytes(transcript + b"onion-network")
+
+    assert not coincurve_verify(
+        base64.b64decode(proof.signature),
+        message_hash,
+        bytes.fromhex(proof.pubkey),
+        hasher=None,
     )
 
 
@@ -229,6 +266,7 @@ def test_verification_rejects_replay_binding_mismatches(
         directory_id,
         handshake_line,
         nick or identity.nick,
+        JM_VERSION,
     )
 
 
@@ -244,4 +282,16 @@ def test_verification_rejects_tampered_signature(proof: NickAuthProof, identity:
         DIRECTORY_ID,
         HANDSHAKE_LINE,
         identity.nick,
+        JM_VERSION,
+    )
+
+
+def test_verification_uses_negotiated_version(identity: NickIdentity, proof: NickAuthProof):
+    assert not verify_nick_auth_proof(
+        proof,
+        CHALLENGE,
+        DIRECTORY_ID,
+        HANDSHAKE_LINE,
+        identity.nick,
+        JM_VERSION + 1,
     )

--- a/jmcore/tests/test_nick_auth.py
+++ b/jmcore/tests/test_nick_auth.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from jmcore.crypto import NickIdentity
+from jmcore.nick_auth import (
+    NickAuthChallenge,
+    NickAuthMode,
+    NickAuthProof,
+    NickAuthResult,
+    build_nick_auth_signed_message,
+    create_nick_auth_proof,
+    directory_id_for_endpoint,
+    handshake_line_sha256,
+    parse_strict_json_object,
+    verify_nick_auth_proof,
+)
+
+PRIVATE_KEY = bytes.fromhex("11" * 32)
+CHALLENGE = "22" * 32
+DIRECTORY_HOST = "nakamotourflxwjnjpnrk7yc2nhkf6r62ed4gdfxmmn5f4saw5q5qoyd.onion"
+DIRECTORY_ID = f"{DIRECTORY_HOST}:5222"
+HANDSHAKE_LINE = '{"nick":"J5example","features":{"nick_auth":true}}'
+
+
+@pytest.fixture
+def identity() -> NickIdentity:
+    return NickIdentity(private_key_bytes=PRIVATE_KEY)
+
+
+@pytest.fixture
+def proof(identity: NickIdentity) -> NickAuthProof:
+    return create_nick_auth_proof(identity, CHALLENGE, DIRECTORY_ID, HANDSHAKE_LINE)
+
+
+def test_modes_are_stable_string_values():
+    assert {mode.value for mode in NickAuthMode} == {
+        "prefer_verified",
+        "require_verified",
+        "disabled",
+    }
+
+
+def test_payload_models_roundtrip_wire_aliases(proof: NickAuthProof):
+    challenge = NickAuthChallenge(kind="challenge", challenge=CHALLENGE, directory_id=DIRECTORY_ID)
+    assert challenge.to_payload() == {
+        "kind": "challenge",
+        "challenge": CHALLENGE,
+        "directory-id": DIRECTORY_ID,
+    }
+    assert NickAuthChallenge.parse(challenge.to_json()) == challenge
+
+    proof_payload = proof.to_payload()
+    assert "handshake-sha256" in proof_payload
+    assert "handshake_sha256" not in proof_payload
+    assert NickAuthProof.from_payload(json.dumps(proof_payload)) == proof
+
+    result = NickAuthResult(code="ok", verified=True)
+    assert NickAuthResult.from_payload(result.to_payload()) == result
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"kind":"challenge","challenge":"'
+        + CHALLENGE
+        + '","challenge":"'
+        + CHALLENGE
+        + '","directory-id":"test:directory-a"}',
+        '{"kind":"challenge","challenge":"'
+        + CHALLENGE
+        + '","directory-id":"test:directory-a","value":NaN}',
+        '{"kind":"challenge","challenge":"'
+        + CHALLENGE
+        + '","directory-id":"test:directory-a","value":Infinity}',
+        "[]",
+    ],
+)
+def test_strict_json_rejects_duplicates_non_finite_and_non_objects(payload: str):
+    with pytest.raises(ValueError):
+        parse_strict_json_object(payload)
+
+
+def test_payload_models_reject_extra_fields_and_type_coercion():
+    with pytest.raises(ValidationError):
+        NickAuthChallenge.from_payload(
+            {
+                "kind": "challenge",
+                "challenge": CHALLENGE,
+                "directory-id": "test:directory-a",
+                "extra": "rejected",
+            }
+        )
+    with pytest.raises(ValidationError):
+        NickAuthResult(code="ok", verified=1)
+    with pytest.raises(ValidationError):
+        NickAuthResult(code="invalid", verified=True)
+    with pytest.raises(ValidationError):
+        NickAuthResult(code="unknown", verified=False)
+
+    with pytest.raises(ValueError, match="missing required field"):
+        NickAuthChallenge.from_payload({"challenge": CHALLENGE, "directory-id": "test:directory-a"})
+    with pytest.raises(ValueError, match="wire name"):
+        NickAuthChallenge.from_payload(
+            {
+                "kind": "challenge",
+                "challenge": CHALLENGE,
+                "directory_id": "test:directory-a",
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("challenge", "AA" * 32),
+        ("handshake-sha256", "0" * 63),
+        ("pubkey", "02" + "AA" * 32),
+        ("pubkey", "04" + "11" * 32),
+        ("signature", "not base64"),
+        ("signature", base64.b64encode(b"\x30\x00").decode("ascii")),
+    ],
+)
+def test_proof_rejects_noncanonical_encodings(proof: NickAuthProof, field: str, value: str):
+    payload = proof.to_payload()
+    payload[field] = value
+    with pytest.raises(ValidationError):
+        NickAuthProof.from_payload(payload)
+
+
+def test_handshake_hashes_exact_decoded_line_utf8_bytes():
+    line = '{"motd":"caf\u00e9","escaped":"\\n"}'
+    assert handshake_line_sha256(line) == hashlib.sha256(line.encode("utf-8")).hexdigest()
+    assert handshake_line_sha256(line) != handshake_line_sha256(line + "\r\n")
+    assert handshake_line_sha256(line) != handshake_line_sha256(json.dumps(line))
+
+
+def test_directory_endpoint_ids_are_canonical():
+    assert directory_id_for_endpoint(DIRECTORY_HOST.upper(), 5222) == DIRECTORY_ID
+    assert directory_id_for_endpoint("LOCALHOST", 1234) == "test:localhost-1234"
+    assert directory_id_for_endpoint("127.0.0.1", 1234) == "test:127.0.0.1-1234"
+    assert directory_id_for_endpoint("directory-a", 5222) == "test:directory-a-5222"
+
+
+@pytest.mark.parametrize(
+    ("host", "port"),
+    [
+        ("short.onion", 5222),
+        ("a" * 56 + ".onion", 0),
+        ("bad host", 5222),
+        ("example.com", 5222),
+        ("8.8.8.8", 5222),
+    ],
+)
+def test_directory_endpoint_ids_reject_malformed_or_public_values(host: str, port: int):
+    with pytest.raises(ValueError):
+        directory_id_for_endpoint(host, port)
+
+
+def test_signed_message_is_exact_ascii_transcript(identity: NickIdentity):
+    handshake_hash = handshake_line_sha256(HANDSHAKE_LINE)
+    message = build_nick_auth_signed_message(
+        CHALLENGE,
+        DIRECTORY_ID,
+        handshake_hash,
+        identity.nick,
+        identity.public_key_hex,
+    )
+    assert (
+        message
+        == (
+            f"nick-auth|{CHALLENGE}|{DIRECTORY_ID}|{handshake_hash}|"
+            f"{identity.nick}|{identity.public_key_hex}"
+        ).encode("ascii")
+        + b"onion-network"
+    )
+
+
+def test_create_and_verify_deterministic_proof(identity: NickIdentity, proof: NickAuthProof):
+    assert proof.challenge == CHALLENGE
+    assert (
+        proof.handshake_sha256 == "ac72075bdc7009683bd8a563dfd09c5ad7ef8c42e8040db0717a5fb3c19b7666"
+    )
+    assert proof.pubkey == "034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa"
+    assert proof.signature == (
+        "MEUCIQCy/qOvvS9DrnU8eOp09bftEqTvFmuDay7kXQtJw03a"
+        "RAIgR+WY4/hlsW8gC+NmGJIqM6ijM0r5oXmrhOIVn1ZlHAQ="
+    )
+    assert verify_nick_auth_proof(
+        proof,
+        CHALLENGE,
+        DIRECTORY_ID,
+        HANDSHAKE_LINE,
+        identity.nick,
+    )
+
+
+def test_signature_is_deterministic(identity: NickIdentity):
+    first = create_nick_auth_proof(identity, CHALLENGE, DIRECTORY_ID, HANDSHAKE_LINE)
+    second = create_nick_auth_proof(identity, CHALLENGE, DIRECTORY_ID, HANDSHAKE_LINE)
+    assert first == second
+
+
+@pytest.mark.parametrize(
+    ("challenge", "directory_id", "handshake_line", "nick"),
+    [
+        ("33" * 32, DIRECTORY_ID, HANDSHAKE_LINE, None),
+        (CHALLENGE, "test:other-directory", HANDSHAKE_LINE, None),
+        (CHALLENGE, DIRECTORY_ID, HANDSHAKE_LINE + " ", None),
+        (CHALLENGE, DIRECTORY_ID, HANDSHAKE_LINE, "J5wrongnick"),
+    ],
+)
+def test_verification_rejects_replay_binding_mismatches(
+    identity: NickIdentity,
+    proof: NickAuthProof,
+    challenge: str,
+    directory_id: str,
+    handshake_line: str,
+    nick: str | None,
+):
+    assert not verify_nick_auth_proof(
+        proof,
+        challenge,
+        directory_id,
+        handshake_line,
+        nick or identity.nick,
+    )
+
+
+def test_verification_rejects_tampered_signature(proof: NickAuthProof, identity: NickIdentity):
+    signature = bytearray(base64.b64decode(proof.signature))
+    signature[-1] ^= 1
+    tampered = NickAuthProof.from_payload(
+        {**proof.to_payload(), "signature": base64.b64encode(signature).decode("ascii")}
+    )
+    assert not verify_nick_auth_proof(
+        tampered,
+        CHALLENGE,
+        DIRECTORY_ID,
+        HANDSHAKE_LINE,
+        identity.nick,
+    )

--- a/jmcore/tests/test_nick_auth.py
+++ b/jmcore/tests/test_nick_auth.py
@@ -50,17 +50,15 @@ def test_modes_are_stable_string_values():
 
 
 def test_payload_models_roundtrip_wire_aliases(proof: NickAuthProof):
-    challenge = NickAuthChallenge(kind="challenge", challenge=CHALLENGE, directory_id=DIRECTORY_ID)
+    challenge = NickAuthChallenge(challenge=CHALLENGE, directory_id=DIRECTORY_ID)
     assert challenge.to_payload() == {
-        "kind": "challenge",
         "challenge": CHALLENGE,
         "directory-id": DIRECTORY_ID,
     }
     assert NickAuthChallenge.parse(challenge.to_json()) == challenge
 
     proof_payload = proof.to_payload()
-    assert "handshake-sha256" in proof_payload
-    assert "handshake_sha256" not in proof_payload
+    assert set(proof_payload) == {"pubkey", "signature"}
     assert NickAuthProof.from_payload(json.dumps(proof_payload)) == proof
 
     result = NickAuthResult(code="ok", verified=True)
@@ -70,17 +68,13 @@ def test_payload_models_roundtrip_wire_aliases(proof: NickAuthProof):
 @pytest.mark.parametrize(
     "payload",
     [
-        '{"kind":"challenge","challenge":"'
+        '{"challenge":"'
         + CHALLENGE
         + '","challenge":"'
         + CHALLENGE
         + '","directory-id":"test:directory-a"}',
-        '{"kind":"challenge","challenge":"'
-        + CHALLENGE
-        + '","directory-id":"test:directory-a","value":NaN}',
-        '{"kind":"challenge","challenge":"'
-        + CHALLENGE
-        + '","directory-id":"test:directory-a","value":Infinity}',
+        '{"challenge":"' + CHALLENGE + '","directory-id":"test:directory-a","value":NaN}',
+        '{"challenge":"' + CHALLENGE + '","directory-id":"test:directory-a","value":Infinity}',
         "[]",
     ],
 )
@@ -93,7 +87,6 @@ def test_payload_models_reject_extra_fields_and_type_coercion():
     with pytest.raises(ValidationError):
         NickAuthChallenge.from_payload(
             {
-                "kind": "challenge",
                 "challenge": CHALLENGE,
                 "directory-id": "test:directory-a",
                 "extra": "rejected",
@@ -106,12 +99,9 @@ def test_payload_models_reject_extra_fields_and_type_coercion():
     with pytest.raises(ValidationError):
         NickAuthResult(code="unknown", verified=False)
 
-    with pytest.raises(ValueError, match="missing required field"):
-        NickAuthChallenge.from_payload({"challenge": CHALLENGE, "directory-id": "test:directory-a"})
     with pytest.raises(ValueError, match="wire name"):
         NickAuthChallenge.from_payload(
             {
-                "kind": "challenge",
                 "challenge": CHALLENGE,
                 "directory_id": "test:directory-a",
             }
@@ -121,8 +111,6 @@ def test_payload_models_reject_extra_fields_and_type_coercion():
 @pytest.mark.parametrize(
     ("field", "value"),
     [
-        ("challenge", "AA" * 32),
-        ("handshake-sha256", "0" * 63),
         ("pubkey", "02" + "AA" * 32),
         ("pubkey", "04" + "11" * 32),
         ("signature", "not base64"),
@@ -199,10 +187,13 @@ def test_signed_message_is_exact_ascii_transcript(identity: NickIdentity):
 
 
 def test_create_and_verify_deterministic_proof(identity: NickIdentity, proof: NickAuthProof):
-    assert proof.challenge == CHALLENGE
-    assert (
-        proof.handshake_sha256 == "ac72075bdc7009683bd8a563dfd09c5ad7ef8c42e8040db0717a5fb3c19b7666"
-    )
+    assert proof.to_payload() == {
+        "pubkey": "034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",
+        "signature": (
+            "MEQCIDTAF2VwsN1hK3n+Hc2iGt2xkhURfTfCiJnM4myGM6T2"
+            "AiAbXU8Kl5f16SwddktRYcl+gLHt5zS1nY7eLSi61e1g6w=="
+        ),
+    }
     assert proof.pubkey == "034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa"
     assert proof.signature == (
         "MEQCIDTAF2VwsN1hK3n+Hc2iGt2xkhURfTfCiJnM4myGM6T2"

--- a/jmcore/tests/test_protocol.py
+++ b/jmcore/tests/test_protocol.py
@@ -881,5 +881,5 @@ def test_nick_auth_protocol_allocations():
     assert FEATURE_NICK_AUTH in ALL_FEATURES
     assert FeatureSet(features={FEATURE_NICK_AUTH}).supports_nick_auth()
     assert MessageType.NICK_AUTH_CHALLENGE == 803
-    assert MessageType.NICK_AUTH_PROOF == 804
-    assert MessageType.NICK_AUTH_RESULT == 805
+    assert MessageType.NICK_AUTH_PROOF == 805
+    assert MessageType.NICK_AUTH_RESULT == 807

--- a/jmcore/tests/test_protocol.py
+++ b/jmcore/tests/test_protocol.py
@@ -7,6 +7,7 @@ import pytest
 from jmcore.protocol import (
     ALL_FEATURES,
     FEATURE_NEUTRINO_COMPAT,
+    FEATURE_NICK_AUTH,
     FEATURE_PEERLIST_FEATURES,
     FEATURE_PING,
     FEATURE_PUSH_ENCRYPTED,
@@ -873,3 +874,11 @@ class TestPingFeature:
         """FeatureSet.from_handshake() with ping=False should not include it."""
         fs = FeatureSet.from_handshake({"features": {"ping": False}})
         assert fs.supports_ping() is False
+
+
+def test_nick_auth_protocol_allocations():
+    assert FEATURE_NICK_AUTH == "nick_auth"
+    assert FEATURE_NICK_AUTH in ALL_FEATURES
+    assert FeatureSet(features={FEATURE_NICK_AUTH}).supports_nick_auth()
+    assert MessageType.NICK_AUTH == 803
+    assert MessageType.NICK_AUTH_RESULT == 805

--- a/jmcore/tests/test_protocol.py
+++ b/jmcore/tests/test_protocol.py
@@ -880,5 +880,6 @@ def test_nick_auth_protocol_allocations():
     assert FEATURE_NICK_AUTH == "nick_auth"
     assert FEATURE_NICK_AUTH in ALL_FEATURES
     assert FeatureSet(features={FEATURE_NICK_AUTH}).supports_nick_auth()
-    assert MessageType.NICK_AUTH == 803
+    assert MessageType.NICK_AUTH_CHALLENGE == 803
+    assert MessageType.NICK_AUTH_PROOF == 804
     assert MessageType.NICK_AUTH_RESULT == 805

--- a/jmcore/tests/test_settings.py
+++ b/jmcore/tests/test_settings.py
@@ -186,6 +186,7 @@ class TestSettingsDefaults:
         assert settings.network_config.bitcoin_network is None
         assert settings.network_config.directory_servers == []
         assert settings.network_config.nick_auth_mode is NickAuthMode.PREFER_VERIFIED
+        assert settings.network_config.nick_auth_directory_ids == {}
 
     def test_default_directory_server_nick_auth_settings(self) -> None:
         settings = JoinMarketSettings()
@@ -195,8 +196,8 @@ class TestSettingsDefaults:
         assert settings.directory_server.nick_auth_timeout == 30.0
 
     def test_directory_server_validates_nick_auth_identity_and_required_mode(self) -> None:
-        with pytest.raises(ValueError, match="invalid onion directory-id"):
-            DirectoryServerSettings(nick_auth_directory_id="not-an-endpoint")
+        with pytest.raises(ValueError, match="invalid directory-id"):
+            DirectoryServerSettings(nick_auth_directory_id="bad|identity")
         with pytest.raises(ValueError, match="needs nick_auth_directory_id"):
             DirectoryServerSettings(nick_auth_mode=NickAuthMode.REQUIRE_VERIFIED)
 
@@ -805,6 +806,19 @@ class TestParseDirectoryServers:
         settings = NetworkSettings(nick_auth_mode="require_verified")
         assert settings.nick_auth_mode is NickAuthMode.REQUIRE_VERIFIED
 
+    def test_nick_auth_directory_ids_validate_values(self) -> None:
+        settings = NetworkSettings(
+            nick_auth_directory_ids={"directory.internal:5222": "directory-identity-a"}
+        )
+
+        assert settings.nick_auth_directory_ids == {
+            "directory.internal:5222": "directory-identity-a"
+        }
+        with pytest.raises(ValueError, match="invalid directory-id"):
+            NetworkSettings(nick_auth_directory_ids={"directory.internal:5222": "bad|identity"})
+        with pytest.raises(ValueError, match="host:port"):
+            NetworkSettings(nick_auth_directory_ids={"directory.internal": "test:directory-a"})
+
 
 class TestJoinMarketSettingsHelpers:
     """Tests for JoinMarketSettings helper methods."""
@@ -928,6 +942,18 @@ class TestCommaListEnvSettingsSource:
         settings = JoinMarketSettings()
         servers = settings.network_config.directory_servers
         assert servers == ["host1.onion:5222", "host2.onion:5222"]
+
+    def test_json_nick_auth_directory_ids(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS",
+            '{"directory.internal:5222":"test:directory-a"}',
+        )
+
+        settings = JoinMarketSettings()
+
+        assert settings.network_config.nick_auth_directory_ids == {
+            "directory.internal:5222": "test:directory-a"
+        }
 
 
 class TestNeutrinoAuthTokenFile:

--- a/jmcore/tests/test_settings.py
+++ b/jmcore/tests/test_settings.py
@@ -11,8 +11,10 @@ import pytest
 from pydantic import BaseModel, ValidationError
 
 from jmcore.models import NetworkType
+from jmcore.nick_auth import NickAuthMode
 from jmcore.settings import (
     BitcoinSettings,
+    DirectoryServerSettings,
     JoinMarketSettings,
     MakerSettings,
     NetworkSettings,
@@ -183,6 +185,26 @@ class TestSettingsDefaults:
         assert settings.network_config.network == NetworkType.MAINNET
         assert settings.network_config.bitcoin_network is None
         assert settings.network_config.directory_servers == []
+        assert settings.network_config.nick_auth_mode is NickAuthMode.PREFER_VERIFIED
+
+    def test_default_directory_server_nick_auth_settings(self) -> None:
+        settings = JoinMarketSettings()
+
+        assert settings.directory_server.nick_auth_mode is NickAuthMode.PREFER_VERIFIED
+        assert settings.directory_server.nick_auth_directory_id is None
+        assert settings.directory_server.nick_auth_timeout == 30.0
+
+    def test_directory_server_validates_nick_auth_identity_and_required_mode(self) -> None:
+        with pytest.raises(ValueError, match="invalid onion directory-id"):
+            DirectoryServerSettings(nick_auth_directory_id="not-an-endpoint")
+        with pytest.raises(ValueError, match="needs nick_auth_directory_id"):
+            DirectoryServerSettings(nick_auth_mode=NickAuthMode.REQUIRE_VERIFIED)
+
+        settings = DirectoryServerSettings(
+            nick_auth_mode=NickAuthMode.REQUIRE_VERIFIED,
+            nick_auth_directory_id="test:directory-a",
+        )
+        assert settings.nick_auth_directory_id == "test:directory-a"
 
     def test_default_wallet_settings(self) -> None:
         """Test default wallet settings."""
@@ -775,6 +797,13 @@ class TestParseDirectoryServers:
         """JSON empty string should produce empty list."""
         settings = NetworkSettings(directory_servers='""')
         assert settings.directory_servers == []
+
+    def test_nick_auth_mode_defaults_to_prefer_verified(self) -> None:
+        assert NetworkSettings().nick_auth_mode is NickAuthMode.PREFER_VERIFIED
+
+    def test_nick_auth_mode_parses_config_value(self) -> None:
+        settings = NetworkSettings(nick_auth_mode="require_verified")
+        assert settings.nick_auth_mode is NickAuthMode.REQUIRE_VERIFIED
 
 
 class TestJoinMarketSettingsHelpers:

--- a/jmwalletd/src/jmwalletd/routers/coinjoin.py
+++ b/jmwalletd/src/jmwalletd/routers/coinjoin.py
@@ -311,6 +311,7 @@ async def start_maker(
                     network=jm_settings.network_config.network,
                     directory_servers=jm_settings.get_directory_servers(),
                     nick_auth_mode=jm_settings.network_config.nick_auth_mode,
+                    nick_auth_directory_ids=jm_settings.network_config.nick_auth_directory_ids,
                     socks_host=jm_settings.tor.socks_host,
                     socks_port=jm_settings.tor.socks_port,
                     stream_isolation=jm_settings.tor.stream_isolation,

--- a/jmwalletd/src/jmwalletd/routers/coinjoin.py
+++ b/jmwalletd/src/jmwalletd/routers/coinjoin.py
@@ -310,6 +310,7 @@ async def start_maker(
                     tx_fee_contribution=txfee,
                     network=jm_settings.network_config.network,
                     directory_servers=jm_settings.get_directory_servers(),
+                    nick_auth_mode=jm_settings.network_config.nick_auth_mode,
                     socks_host=jm_settings.tor.socks_host,
                     socks_port=jm_settings.tor.socks_port,
                     stream_isolation=jm_settings.tor.stream_isolation,

--- a/jmwalletd/src/jmwalletd/routers/tumbler.py
+++ b/jmwalletd/src/jmwalletd/routers/tumbler.py
@@ -432,6 +432,8 @@ async def start_plan(
             mnemonic=state.wallet_mnemonic,
             network=jm_settings.network_config.network,
             directory_servers=jm_settings.get_directory_servers(),
+            nick_auth_mode=jm_settings.network_config.nick_auth_mode,
+            nick_auth_directory_ids=jm_settings.network_config.nick_auth_directory_ids,
             socks_host=jm_settings.tor.socks_host,
             socks_port=jm_settings.tor.socks_port,
             stream_isolation=jm_settings.tor.stream_isolation,

--- a/jmwalletd/tests/test_coinjoin_router.py
+++ b/jmwalletd/tests/test_coinjoin_router.py
@@ -537,6 +537,7 @@ class TestStartMaker:
         mock_settings = Mock()
         mock_settings.get_directory_servers.return_value = expected_dirs
         mock_settings.network_config.network = NetworkType.SIGNET
+        mock_settings.network_config.nick_auth_mode = "require_verified"
         mock_settings.tor.socks_host = "127.0.0.1"
         mock_settings.tor.socks_port = 9050
         mock_settings.tor.stream_isolation = False
@@ -559,6 +560,7 @@ class TestStartMaker:
         assert kwargs["mnemonic"] == state.wallet_mnemonic
         assert kwargs["network"] == NetworkType.SIGNET
         assert kwargs["directory_servers"] == expected_dirs
+        assert kwargs["nick_auth_mode"] == "require_verified"
         assert kwargs["socks_host"] == "127.0.0.1"
         assert kwargs["socks_port"] == 9050
         assert kwargs["stream_isolation"] is False

--- a/jmwalletd/tests/test_coinjoin_router.py
+++ b/jmwalletd/tests/test_coinjoin_router.py
@@ -538,6 +538,8 @@ class TestStartMaker:
         mock_settings.get_directory_servers.return_value = expected_dirs
         mock_settings.network_config.network = NetworkType.SIGNET
         mock_settings.network_config.nick_auth_mode = "require_verified"
+        expected_ids = {expected_dirs[0]: "test:walletd-directory"}
+        mock_settings.network_config.nick_auth_directory_ids = expected_ids
         mock_settings.tor.socks_host = "127.0.0.1"
         mock_settings.tor.socks_port = 9050
         mock_settings.tor.stream_isolation = False
@@ -561,6 +563,7 @@ class TestStartMaker:
         assert kwargs["network"] == NetworkType.SIGNET
         assert kwargs["directory_servers"] == expected_dirs
         assert kwargs["nick_auth_mode"] == "require_verified"
+        assert kwargs["nick_auth_directory_ids"] == expected_ids
         assert kwargs["socks_host"] == "127.0.0.1"
         assert kwargs["socks_port"] == 9050
         assert kwargs["stream_isolation"] is False

--- a/jmwalletd/tests/test_tumbler_router.py
+++ b/jmwalletd/tests/test_tumbler_router.py
@@ -640,6 +640,9 @@ class TestBuildTumblerTakerConfig:
         settings.data_dir = Path("/tmp/jm-test")
         settings.network_config.network = NetworkType.REGTEST
         settings.network_config.directory_servers = []
+        settings.network_config.nick_auth_directory_ids = {
+            "directory.internal:5222": "test:tumbler-directory"
+        }
         settings.bitcoin.backend_type = "descriptor_wallet"
         settings.tor.socks_host = "127.0.0.1"
         settings.tor.socks_port = 9050
@@ -755,6 +758,9 @@ class TestBuildTumblerTakerConfig:
         assert captured["order_wait_time"] == 60.0
         assert captured["orderbook_min_wait"] == 45.0
         assert captured["orderbook_quiet_period"] == 20.0
+        assert captured["nick_auth_directory_ids"] == {
+            "directory.internal:5222": "test:tumbler-directory"
+        }
         # The runner resolves destinations itself; the placeholder stays empty.
         assert captured["destination_address"].get_secret_value() == ""
 

--- a/maker/src/maker/cli.py
+++ b/maker/src/maker/cli.py
@@ -339,6 +339,7 @@ def build_maker_config(
         backend_type=effective_backend_type,
         backend_config=backend_config,
         directory_servers=dir_servers,
+        nick_auth_mode=settings.network_config.nick_auth_mode,
         socks_host=effective_socks_host,
         socks_port=effective_socks_port,
         stream_isolation=settings.tor.stream_isolation,

--- a/maker/src/maker/cli.py
+++ b/maker/src/maker/cli.py
@@ -340,6 +340,7 @@ def build_maker_config(
         backend_config=backend_config,
         directory_servers=dir_servers,
         nick_auth_mode=settings.network_config.nick_auth_mode,
+        nick_auth_directory_ids=settings.network_config.nick_auth_directory_ids,
         socks_host=effective_socks_host,
         socks_port=effective_socks_port,
         stream_isolation=settings.tor.stream_isolation,

--- a/maker/src/maker/directory_pool.py
+++ b/maker/src/maker/directory_pool.py
@@ -62,6 +62,7 @@ class MakerDirectoryPool(DirectoryClientPool):
             connection_timeout=config.connection_timeout,
             stream_isolation=config.stream_isolation,
             nick_auth_mode=config.nick_auth_mode,
+            nick_auth_directory_ids=config.nick_auth_directory_ids,
         )
 
     def _build_client_kwargs(self, host: str, port: int) -> dict[str, Any]:

--- a/maker/src/maker/directory_pool.py
+++ b/maker/src/maker/directory_pool.py
@@ -61,6 +61,7 @@ class MakerDirectoryPool(DirectoryClientPool):
             socks_port=config.socks_port,
             connection_timeout=config.connection_timeout,
             stream_isolation=config.stream_isolation,
+            nick_auth_mode=config.nick_auth_mode,
         )
 
     def _build_client_kwargs(self, host: str, port: int) -> dict[str, Any]:

--- a/maker/src/maker/protocol_handlers.py
+++ b/maker/src/maker/protocol_handlers.py
@@ -1048,6 +1048,9 @@ class ProtocolHandlersMixin:
                         socks_port=self.config.socks_port,
                         timeout=30.0,
                         nick_auth_mode=self.config.nick_auth_mode,
+                        nick_auth_directory_id=self.config.nick_auth_directory_ids.get(
+                            f"{host}:{port}"
+                        ),
                         socks_username=socks_username,
                         socks_password=socks_password,
                     )

--- a/maker/src/maker/protocol_handlers.py
+++ b/maker/src/maker/protocol_handlers.py
@@ -1047,6 +1047,7 @@ class ProtocolHandlersMixin:
                         socks_host=self.config.socks_host,
                         socks_port=self.config.socks_port,
                         timeout=30.0,
+                        nick_auth_mode=self.config.nick_auth_mode,
                         socks_username=socks_username,
                         socks_password=socks_password,
                     )

--- a/maker/tests/test_commitment_broadcast.py
+++ b/maker/tests/test_commitment_broadcast.py
@@ -31,6 +31,10 @@ def config() -> MakerConfig:
     return MakerConfig(
         mnemonic="abandon " * 11 + "about",
         directory_servers=["dir1.onion:5222", "dir2.onion:5222"],
+        nick_auth_directory_ids={
+            "dir1.onion:5222": "test:directory-1",
+            "dir2.onion:5222": "test:directory-2",
+        },
         network=NetworkType.REGTEST,
     )
 
@@ -53,6 +57,12 @@ def mock_directory_client() -> MagicMock:
     client.send_private_message = AsyncMock()
     client.get_active_nicks = MagicMock(return_value={"PeerA", "PeerB"})
     return client
+
+
+def test_maker_pool_resolves_configured_directory_identity(maker_bot: MakerBot) -> None:
+    kwargs = maker_bot._directory_pool._build_client_kwargs("dir1.onion", 5222)
+
+    assert kwargs["nick_auth_directory_id"] == "test:directory-1"
 
 
 @pytest.mark.asyncio
@@ -171,6 +181,23 @@ class TestBroadcastCommitmentEphemeral:
         # Password should be random (non-empty)
         assert kwargs1["socks_password"]
         assert len(kwargs1["socks_password"]) == 32  # hex(16 bytes)
+
+    async def test_resolves_expected_identity_for_each_ephemeral_client(
+        self, maker_bot: MakerBot
+    ) -> None:
+        mock_client = MagicMock(
+            connect=AsyncMock(),
+            send_public_message=AsyncMock(),
+            close=AsyncMock(),
+        )
+
+        with patch("maker.protocol_handlers.DirectoryClient", return_value=mock_client) as mock_cls:
+            await maker_bot._broadcast_commitment_ephemeral(COMMITMENT)
+
+        assert [call.kwargs["nick_auth_directory_id"] for call in mock_cls.call_args_list] == [
+            "test:directory-1",
+            "test:directory-2",
+        ]
 
     async def test_different_broadcasts_get_different_credentials(
         self, maker_bot: MakerBot

--- a/maker/tests/test_config.py
+++ b/maker/tests/test_config.py
@@ -874,6 +874,17 @@ class TestNewSettingsWiring:
         config = build_maker_config(settings=settings, mnemonic=TEST_MNEMONIC, passphrase="")
         assert config.nick_auth_mode is NickAuthMode.REQUIRE_VERIFIED
 
+    def test_nick_auth_directory_ids_passed_from_settings(self) -> None:
+        from jmcore.settings import JoinMarketSettings
+
+        from maker.cli import build_maker_config
+
+        expected = {"directory.internal:5222": "test:directory-a"}
+        settings = JoinMarketSettings(network_config={"nick_auth_directory_ids": expected})
+        config = build_maker_config(settings=settings, mnemonic=TEST_MNEMONIC, passphrase="")
+
+        assert config.nick_auth_directory_ids == expected
+
     def test_directory_reconnect_interval_passed_from_settings(self) -> None:
         """maker.directory_reconnect_interval in config.toml must reach MakerConfig."""
         from jmcore.settings import JoinMarketSettings

--- a/maker/tests/test_config.py
+++ b/maker/tests/test_config.py
@@ -862,6 +862,18 @@ class TestNewSettingsWiring:
         config = build_maker_config(settings=settings, mnemonic=TEST_MNEMONIC, passphrase="")
         assert config.min_confirmations == 2
 
+    def test_nick_auth_mode_passed_from_settings(self) -> None:
+        from jmcore.nick_auth import NickAuthMode
+        from jmcore.settings import JoinMarketSettings
+
+        from maker.cli import build_maker_config
+
+        settings = JoinMarketSettings(
+            network_config={"nick_auth_mode": NickAuthMode.REQUIRE_VERIFIED}
+        )
+        config = build_maker_config(settings=settings, mnemonic=TEST_MNEMONIC, passphrase="")
+        assert config.nick_auth_mode is NickAuthMode.REQUIRE_VERIFIED
+
     def test_directory_reconnect_interval_passed_from_settings(self) -> None:
         """maker.directory_reconnect_interval in config.toml must reach MakerConfig."""
         from jmcore.settings import JoinMarketSettings

--- a/orderbook_watcher/src/orderbook_watcher/aggregator.py
+++ b/orderbook_watcher/src/orderbook_watcher/aggregator.py
@@ -155,6 +155,7 @@ class OrderbookAggregator:
         blockchain_backend: BlockchainBackend | None = None,
         nick_identity: NickIdentity | None = None,
         nick_auth_mode: NickAuthMode = NickAuthMode.PREFER_VERIFIED,
+        nick_auth_directory_ids: dict[str, str] | None = None,
     ) -> None:
         self.directory_nodes = directory_nodes
         self.network = network
@@ -171,6 +172,7 @@ class OrderbookAggregator:
         self.blockchain_backend = blockchain_backend
         self.nick_identity = nick_identity or NickIdentity(JM_VERSION)
         self.nick_auth_mode = nick_auth_mode
+        self.nick_auth_directory_ids = nick_auth_directory_ids or {}
 
         # Build the optional mempool proxy URL and pre-compute isolation credentials.
         self._dir_username: str | None = None
@@ -278,6 +280,7 @@ class OrderbookAggregator:
             timeout=self.timeout,
             max_message_size=self.max_message_size,
             nick_auth_mode=self.nick_auth_mode,
+            nick_auth_directory_id=self.nick_auth_directory_ids.get(node_id),
             socks_username=self._dir_username,
             socks_password=self._dir_password,
         )
@@ -677,6 +680,7 @@ class OrderbookAggregator:
             max_message_size=self.max_message_size,
             on_disconnect=on_disconnect,
             nick_auth_mode=self.nick_auth_mode,
+            nick_auth_directory_id=self.nick_auth_directory_ids.get(node_id),
             socks_username=self._dir_username,
             socks_password=self._dir_password,
         )

--- a/orderbook_watcher/src/orderbook_watcher/aggregator.py
+++ b/orderbook_watcher/src/orderbook_watcher/aggregator.py
@@ -12,8 +12,11 @@ from typing import TYPE_CHECKING, Any
 
 from jmcore.bond_calc import calculate_timelocked_fidelity_bond_value
 from jmcore.btc_script import derive_bond_address
+from jmcore.crypto import NickIdentity
 from jmcore.mempool_api import MempoolAPI, TxOut
 from jmcore.models import FidelityBond, Offer, OrderBook
+from jmcore.nick_auth import NickAuthMode
+from jmcore.protocol import JM_VERSION
 from loguru import logger
 
 if TYPE_CHECKING:
@@ -150,6 +153,8 @@ class OrderbookAggregator:
         uptime_grace_period: int = 60,
         stream_isolation: bool = False,
         blockchain_backend: BlockchainBackend | None = None,
+        nick_identity: NickIdentity | None = None,
+        nick_auth_mode: NickAuthMode = NickAuthMode.PREFER_VERIFIED,
     ) -> None:
         self.directory_nodes = directory_nodes
         self.network = network
@@ -164,6 +169,8 @@ class OrderbookAggregator:
         self.max_message_size = max_message_size
         self.uptime_grace_period = uptime_grace_period
         self.blockchain_backend = blockchain_backend
+        self.nick_identity = nick_identity or NickIdentity(JM_VERSION)
+        self.nick_auth_mode = nick_auth_mode
 
         # Build the optional mempool proxy URL and pre-compute isolation credentials.
         self._dir_username: str | None = None
@@ -265,10 +272,12 @@ class OrderbookAggregator:
             onion_address,
             port,
             self.network,
+            nick_identity=self.nick_identity,
             socks_host=self.socks_host,
             socks_port=self.socks_port,
             timeout=self.timeout,
             max_message_size=self.max_message_size,
+            nick_auth_mode=self.nick_auth_mode,
             socks_username=self._dir_username,
             socks_password=self._dir_password,
         )
@@ -661,11 +670,13 @@ class OrderbookAggregator:
             onion_address,
             port,
             self.network,
+            nick_identity=self.nick_identity,
             socks_host=self.socks_host,
             socks_port=self.socks_port,
             timeout=self.timeout,
             max_message_size=self.max_message_size,
             on_disconnect=on_disconnect,
+            nick_auth_mode=self.nick_auth_mode,
             socks_username=self._dir_username,
             socks_password=self._dir_password,
         )

--- a/orderbook_watcher/src/orderbook_watcher/main.py
+++ b/orderbook_watcher/src/orderbook_watcher/main.py
@@ -161,6 +161,7 @@ async def run_watcher(log_level: str | None = None) -> None:
         blockchain_backend=blockchain_backend,
         nick_identity=nick_identity,
         nick_auth_mode=settings.network_config.nick_auth_mode,
+        nick_auth_directory_ids=settings.network_config.nick_auth_directory_ids,
     )
 
     server = OrderbookServer(watcher_settings, aggregator)

--- a/orderbook_watcher/src/orderbook_watcher/main.py
+++ b/orderbook_watcher/src/orderbook_watcher/main.py
@@ -159,6 +159,8 @@ async def run_watcher(log_level: str | None = None) -> None:
         uptime_grace_period=watcher_settings.uptime_grace_period,
         stream_isolation=settings.tor.stream_isolation,
         blockchain_backend=blockchain_backend,
+        nick_identity=nick_identity,
+        nick_auth_mode=settings.network_config.nick_auth_mode,
     )
 
     server = OrderbookServer(watcher_settings, aggregator)

--- a/orderbook_watcher/tests/test_directory_identity.py
+++ b/orderbook_watcher/tests/test_directory_identity.py
@@ -26,6 +26,7 @@ async def test_aggregator_reuses_identity_and_auth_mode_for_all_directory_client
         mempool_api_url="",
         nick_identity=identity,
         nick_auth_mode=NickAuthMode.REQUIRE_VERIFIED,
+        nick_auth_directory_ids={"directory.example:5222": "test:directory-a"},
     )
     clients = [_mock_client(), _mock_client(), _mock_client()]
 
@@ -38,3 +39,4 @@ async def test_aggregator_reuses_identity_and_auth_mode_for_all_directory_client
     for call in client_cls.call_args_list:
         assert call.kwargs["nick_identity"] is identity
         assert call.kwargs["nick_auth_mode"] is NickAuthMode.REQUIRE_VERIFIED
+        assert call.kwargs["nick_auth_directory_id"] == "test:directory-a"

--- a/orderbook_watcher/tests/test_directory_identity.py
+++ b/orderbook_watcher/tests/test_directory_identity.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from jmcore.crypto import NickIdentity
+from jmcore.nick_auth import NickAuthMode
+
+from orderbook_watcher.aggregator import OrderbookAggregator
+
+
+def _mock_client() -> MagicMock:
+    client = MagicMock()
+    client.connect = AsyncMock(return_value=None)
+    client.fetch_orderbooks = AsyncMock(return_value=([], []))
+    client.close = AsyncMock(return_value=None)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_aggregator_reuses_identity_and_auth_mode_for_all_directory_clients() -> None:
+    identity = NickIdentity(private_key_bytes=b"\x01" * 32)
+    aggregator = OrderbookAggregator(
+        directory_nodes=[("directory.example", 5222)],
+        network="regtest",
+        mempool_api_url="",
+        nick_identity=identity,
+        nick_auth_mode=NickAuthMode.REQUIRE_VERIFIED,
+    )
+    clients = [_mock_client(), _mock_client(), _mock_client()]
+
+    with patch("orderbook_watcher.aggregator.DirectoryClient", side_effect=clients) as client_cls:
+        await aggregator.fetch_from_directory("directory.example", 5222)
+        await aggregator._connect_to_node("directory.example", 5222)
+        await aggregator._connect_to_node("directory.example", 5222)
+
+    assert client_cls.call_count == 3
+    for call in client_cls.call_args_list:
+        assert call.kwargs["nick_identity"] is identity
+        assert call.kwargs["nick_auth_mode"] is NickAuthMode.REQUIRE_VERIFIED

--- a/orderbook_watcher/tests/test_mempool_routing.py
+++ b/orderbook_watcher/tests/test_mempool_routing.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from jmcore.nick_auth import NickAuthMode
 
 from orderbook_watcher.aggregator import OrderbookAggregator
 from orderbook_watcher.main import run_watcher
@@ -68,6 +69,7 @@ async def test_run_watcher_passes_mempool_transport_setting(tmp_path: Path) -> N
     settings.logging.level = "INFO"
     settings.network_config.network.value = "regtest"
     settings.network_config.directory_servers = []
+    settings.network_config.nick_auth_mode = NickAuthMode.REQUIRE_VERIFIED
     settings.get_directory_servers.return_value = ["directory.onion:5222"]
     settings.get_data_dir.return_value = tmp_path
     settings.tor.socks_host = "127.0.0.1"
@@ -105,3 +107,5 @@ async def test_run_watcher_passes_mempool_transport_setting(tmp_path: Path) -> N
         await run_watcher()
 
     assert aggregator_cls.call_args.kwargs["mempool_api_use_tor"] is False
+    assert aggregator_cls.call_args.kwargs["nick_identity"] is nick_identity
+    assert aggregator_cls.call_args.kwargs["nick_auth_mode"] is NickAuthMode.REQUIRE_VERIFIED

--- a/orderbook_watcher/tests/test_mempool_routing.py
+++ b/orderbook_watcher/tests/test_mempool_routing.py
@@ -70,6 +70,7 @@ async def test_run_watcher_passes_mempool_transport_setting(tmp_path: Path) -> N
     settings.network_config.network.value = "regtest"
     settings.network_config.directory_servers = []
     settings.network_config.nick_auth_mode = NickAuthMode.REQUIRE_VERIFIED
+    settings.network_config.nick_auth_directory_ids = {"directory.onion:5222": "test:directory-a"}
     settings.get_directory_servers.return_value = ["directory.onion:5222"]
     settings.get_data_dir.return_value = tmp_path
     settings.tor.socks_host = "127.0.0.1"
@@ -109,3 +110,6 @@ async def test_run_watcher_passes_mempool_transport_setting(tmp_path: Path) -> N
     assert aggregator_cls.call_args.kwargs["mempool_api_use_tor"] is False
     assert aggregator_cls.call_args.kwargs["nick_identity"] is nick_identity
     assert aggregator_cls.call_args.kwargs["nick_auth_mode"] is NickAuthMode.REQUIRE_VERIFIED
+    assert aggregator_cls.call_args.kwargs["nick_auth_directory_ids"] == {
+        "directory.onion:5222": "test:directory-a"
+    }

--- a/scripts/test_feature_detection.py
+++ b/scripts/test_feature_detection.py
@@ -67,6 +67,8 @@ async def run(args: argparse.Namespace) -> None:
         network=settings.network_config.network,
         socks_host=settings.tor.socks_host,
         socks_port=settings.tor.socks_port,
+        nick_auth_mode=settings.network_config.nick_auth_mode,
+        nick_auth_directory_ids=settings.network_config.nick_auth_directory_ids,
     )
 
     await aggregator.start_continuous_listening()

--- a/taker/src/taker/config_builder.py
+++ b/taker/src/taker/config_builder.py
@@ -226,6 +226,7 @@ def build_taker_config_kwargs(
         "backend_type": effective_backend_type,
         "backend_config": backend_config,
         "directory_servers": dir_servers,
+        "nick_auth_mode": settings.network_config.nick_auth_mode,
         "socks_host": effective_socks_host,
         "socks_port": effective_socks_port,
         "stream_isolation": settings.tor.stream_isolation,

--- a/taker/src/taker/config_builder.py
+++ b/taker/src/taker/config_builder.py
@@ -227,6 +227,7 @@ def build_taker_config_kwargs(
         "backend_config": backend_config,
         "directory_servers": dir_servers,
         "nick_auth_mode": settings.network_config.nick_auth_mode,
+        "nick_auth_directory_ids": settings.network_config.nick_auth_directory_ids,
         "socks_host": effective_socks_host,
         "socks_port": effective_socks_port,
         "stream_isolation": settings.tor.stream_isolation,

--- a/taker/src/taker/multi_directory.py
+++ b/taker/src/taker/multi_directory.py
@@ -98,6 +98,7 @@ class MultiDirectoryClient(DirectoryClientPool):
         our_location: str = "NOT-SERVING-ONION",
         stream_isolation: bool = False,
         nick_auth_mode: NickAuthMode = NickAuthMode.PREFER_VERIFIED,
+        nick_auth_directory_ids: dict[str, str] | None = None,
     ):
         # Connection / SOCKS / credential setup is delegated to the
         # DirectoryClientPool base; it handles directory_servers, network,
@@ -112,6 +113,7 @@ class MultiDirectoryClient(DirectoryClientPool):
             connection_timeout=connection_timeout,
             stream_isolation=stream_isolation,
             nick_auth_mode=nick_auth_mode,
+            nick_auth_directory_ids=nick_auth_directory_ids,
         )
 
         # Taker-specific state below.

--- a/taker/src/taker/multi_directory.py
+++ b/taker/src/taker/multi_directory.py
@@ -19,6 +19,7 @@ from jmcore.directory_client import DirectoryClient
 from jmcore.directory_pool import DirectoryClientPool
 from jmcore.models import Offer
 from jmcore.network import ONION_HOSTID, OnionPeer
+from jmcore.nick_auth import NickAuthMode
 from jmcore.protocol import NOT_SERVING_ONION_HOSTNAME, parse_jm_message
 from jmcore.randomness import secure_random
 from loguru import logger
@@ -96,6 +97,7 @@ class MultiDirectoryClient(DirectoryClientPool):
         prefer_direct_connections: bool = True,
         our_location: str = "NOT-SERVING-ONION",
         stream_isolation: bool = False,
+        nick_auth_mode: NickAuthMode = NickAuthMode.PREFER_VERIFIED,
     ):
         # Connection / SOCKS / credential setup is delegated to the
         # DirectoryClientPool base; it handles directory_servers, network,
@@ -109,6 +111,7 @@ class MultiDirectoryClient(DirectoryClientPool):
             socks_port=socks_port,
             connection_timeout=connection_timeout,
             stream_isolation=stream_isolation,
+            nick_auth_mode=nick_auth_mode,
         )
 
         # Taker-specific state below.

--- a/taker/src/taker/taker.py
+++ b/taker/src/taker/taker.py
@@ -154,6 +154,7 @@ class Taker(TakerMonitoringMixin):
             socks_host=config.socks_host,
             socks_port=config.socks_port,
             connection_timeout=config.connection_timeout,
+            nick_auth_mode=config.nick_auth_mode,
             neutrino_compat=neutrino_compat,
             stream_isolation=config.stream_isolation,
         )

--- a/taker/src/taker/taker.py
+++ b/taker/src/taker/taker.py
@@ -155,6 +155,7 @@ class Taker(TakerMonitoringMixin):
             socks_port=config.socks_port,
             connection_timeout=config.connection_timeout,
             nick_auth_mode=config.nick_auth_mode,
+            nick_auth_directory_ids=config.nick_auth_directory_ids,
             neutrino_compat=neutrino_compat,
             stream_isolation=config.stream_isolation,
         )

--- a/taker/tests/_taker_test_helpers.py
+++ b/taker/tests/_taker_test_helpers.py
@@ -25,6 +25,7 @@ SAMPLE_MNEMONIC = (
 )
 TEST_SCRIPTPUBKEY = "001400" * 10
 TEST_DIRECTORY_SERVERS = ["localhost:5222"]
+TEST_NICK_AUTH_DIRECTORY_IDS = {"localhost:5222": "test:taker-directory"}
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +75,7 @@ def make_taker_config(**overrides: object) -> TakerConfig:
         "mnemonic": SAMPLE_MNEMONIC,
         "network": NetworkType.REGTEST,
         "directory_servers": TEST_DIRECTORY_SERVERS,
+        "nick_auth_directory_ids": TEST_NICK_AUTH_DIRECTORY_IDS,
     }
     defaults.update(overrides)
     return TakerConfig(**defaults)  # type: ignore[arg-type]
@@ -84,6 +86,7 @@ def make_directory_client(**overrides: object) -> MultiDirectoryClient:
     nick_identity = NickIdentity(5)
     defaults: dict[str, object] = {
         "directory_servers": TEST_DIRECTORY_SERVERS,
+        "nick_auth_directory_ids": TEST_NICK_AUTH_DIRECTORY_IDS,
         "network": "regtest",
         "nick_identity": nick_identity,
     }

--- a/taker/tests/test_cli.py
+++ b/taker/tests/test_cli.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import click
 import pytest
 from jmcore.models import NetworkType
+from jmcore.nick_auth import NickAuthMode
 from typer.testing import CliRunner
 
 from taker.cli import app, build_taker_config, create_backend
@@ -45,6 +46,7 @@ class TestBuildTakerConfig:
         settings.network_config.network = NetworkType.SIGNET
         settings.network_config.bitcoin_network = None
         settings.network_config.directory_servers = ["dir1.onion:5222"]
+        settings.network_config.nick_auth_mode = NickAuthMode.PREFER_VERIFIED
 
         # Data dir
         settings.get_data_dir.return_value = "/tmp/jm-test"
@@ -638,3 +640,19 @@ class TestBuildTakerConfig:
         )
 
         assert config.gap_limit == 50
+
+    def test_nick_auth_mode_flows_into_config(
+        self, sample_mnemonic: str, mock_settings: MagicMock
+    ) -> None:
+        mock_settings.network_config.nick_auth_mode = NickAuthMode.REQUIRE_VERIFIED
+
+        config = build_taker_config(
+            settings=mock_settings,
+            mnemonic=sample_mnemonic,
+            passphrase="",
+            destination="bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            amount=100000,
+            mixdepth=0,
+        )
+
+        assert config.nick_auth_mode is NickAuthMode.REQUIRE_VERIFIED

--- a/taker/tests/test_cli.py
+++ b/taker/tests/test_cli.py
@@ -47,6 +47,7 @@ class TestBuildTakerConfig:
         settings.network_config.bitcoin_network = None
         settings.network_config.directory_servers = ["dir1.onion:5222"]
         settings.network_config.nick_auth_mode = NickAuthMode.PREFER_VERIFIED
+        settings.network_config.nick_auth_directory_ids = {}
 
         # Data dir
         settings.get_data_dir.return_value = "/tmp/jm-test"
@@ -656,3 +657,20 @@ class TestBuildTakerConfig:
         )
 
         assert config.nick_auth_mode is NickAuthMode.REQUIRE_VERIFIED
+
+    def test_nick_auth_directory_ids_flow_into_config(
+        self, sample_mnemonic: str, mock_settings: MagicMock
+    ) -> None:
+        expected = {"directory.internal:5222": "test:directory-a"}
+        mock_settings.network_config.nick_auth_directory_ids = expected
+
+        config = build_taker_config(
+            settings=mock_settings,
+            mnemonic=sample_mnemonic,
+            passphrase="",
+            destination="bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            amount=100000,
+            mixdepth=0,
+        )
+
+        assert config.nick_auth_directory_ids == expected

--- a/taker/tests/test_taker_protocol.py
+++ b/taker/tests/test_taker_protocol.py
@@ -552,6 +552,13 @@ class TestMultiDirectoryClientDirectConnections:
         assert client.our_location == "NOT-SERVING-ONION"
         assert client._peer_connections == {}
 
+    def test_resolves_configured_directory_identity(self):
+        client = make_directory_client()
+
+        kwargs = client._build_client_kwargs("localhost", 5222)
+
+        assert kwargs["nick_auth_directory_id"] == "test:taker-directory"
+
     def test_direct_connections_can_be_disabled(self):
         """Test that direct connections can be disabled."""
         client = make_directory_client(prefer_direct_connections=False)

--- a/tests/e2e/test_fidelity_bonds_e2e.py
+++ b/tests/e2e/test_fidelity_bonds_e2e.py
@@ -38,6 +38,7 @@ async def test_orderbook_watcher_receives_bonds(wait_for_directory_server):
         host="127.0.0.1",
         port=get_directory_port(),
         network="testnet",
+        nick_auth_directory_id="test:jm-directory-5222",
     )
     await watcher.connect()
 
@@ -84,6 +85,7 @@ async def test_new_peer_triggers_orderbook_request(wait_for_directory_server):
         host="127.0.0.1",
         port=get_directory_port(),
         network="testnet",
+        nick_auth_directory_id="test:jm-directory-5222",
     )
     await watcher.connect()
 
@@ -152,6 +154,7 @@ async def test_bond_appears_in_privmsg_not_public(wait_for_directory_server):
         host="127.0.0.1",
         port=get_directory_port(),
         network="testnet",
+        nick_auth_directory_id="test:jm-directory-5222",
     )
     await watcher.connect()
 

--- a/tests/test_jmwalletd_dockerfile.py
+++ b/tests/test_jmwalletd_dockerfile.py
@@ -61,6 +61,10 @@ def test_playwright_uses_jam_docker_standalone_ng() -> None:
         "NETWORK_CONFIG__NETWORK=testnet",
         "NETWORK_CONFIG__BITCOIN_NETWORK=regtest",
         "NETWORK_CONFIG__DIRECTORY_SERVERS=jm-directory:5222,jm-directory2:5223",
+        (
+            'NETWORK_CONFIG__NICK_AUTH_DIRECTORY_IDS={"jm-directory:5222":'
+            '"test:jm-directory-5222","jm-directory2:5223":"test:jm-directory2-5223"}'
+        ),
         "LOGGING__LEVEL=DEBUG",
         "DIRECTORY_NODES=jm-directory:5222",
     ]


### PR DESCRIPTION
Bind directory registrations to nick signing keys while retaining an explicit legacy migration path. Track routing state by connection generation so displaced or stale peers cannot remove or receive traffic for the active owner.

Fixes #577