### PR TITLE
fix(jmwalletd): record direct sends in history file at broadcast time

### DIFF
--- a/jmwallet/src/jmwallet/history.py
+++ b/jmwallet/src/jmwallet/history.py
@@ -1499,8 +1499,8 @@ def update_send_awaiting_broadcast(
     or failure) the same row is updated in place with the final outcome.
 
     Args:
-        pending_entry: The in-memory entry that was just appended. Its
-            ``timestamp`` and ``destination_address`` identify the row.
+        pending_entry: The in-memory entry that was just appended. Its wallet,
+            timestamp, addresses, and selected UTXOs identify the row.
         txid: Final transaction ID (empty string if broadcast failed).
         success: True if the transaction was broadcast successfully.
         failure_reason: Final failure reason (empty string on success).
@@ -1518,8 +1518,11 @@ def update_send_awaiting_broadcast(
     for entry in entries:
         if (
             entry.role == "send"
+            and entry.wallet_fingerprint == pending_entry.wallet_fingerprint
             and entry.timestamp == pending_entry.timestamp
             and entry.destination_address == pending_entry.destination_address
+            and entry.change_address == pending_entry.change_address
+            and entry.utxos_used == pending_entry.utxos_used
             and entry.failure_reason == "awaiting broadcast"
             and not entry.txid
         ):

--- a/jmwallet/src/jmwallet/wallet/__init__.py
+++ b/jmwallet/src/jmwallet/wallet/__init__.py
@@ -13,7 +13,12 @@ from jmwallet.wallet.bond_registry import (
 )
 from jmwallet.wallet.models import CoinSelection, UTXOInfo
 from jmwallet.wallet.service import WalletService
-from jmwallet.wallet.spend import DirectSendResult, direct_send
+from jmwallet.wallet.spend import (
+    DirectSendResult,
+    SignedDirectTx,
+    direct_send,
+    prepare_direct_send,
+)
 from jmwallet.wallet.utxo_metadata import UTXOMetadataStore, load_metadata_store
 
 __all__ = [
@@ -30,5 +35,7 @@ __all__ = [
     "UTXOMetadataStore",
     "load_metadata_store",
     "DirectSendResult",
+    "SignedDirectTx",
     "direct_send",
+    "prepare_direct_send",
 ]

--- a/jmwallet/src/jmwallet/wallet/spend.py
+++ b/jmwallet/src/jmwallet/wallet/spend.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from hashlib import sha256
 from typing import TYPE_CHECKING
 
-from jmcore.bitcoin import estimate_vsize, get_address_type
+from jmcore.bitcoin import estimate_vsize, get_address_type, get_txid
 from jmcore.btc_script import mk_freeze_script
 from jmcore.randomness import secure_random
 from loguru import logger
@@ -108,8 +108,9 @@ class DirectSendResult:
 
 @dataclass
 class SignedDirectTx:
-    """Intermediate result from :func:`_prepare_direct_send`."""
+    """Intermediate result from :func:`prepare_direct_send`."""
 
+    txid: str
     tx_hex: str
     fee: int
     fee_rate: float
@@ -119,6 +120,7 @@ class SignedDirectTx:
     num_outputs: int
     destination: str
     change_address: str = ""
+    selected_utxos: list[tuple[str, int]] = field(default_factory=list)
     source_addresses: list[str] = field(default_factory=list)
     inputs: list[dict[str, object]] = field(default_factory=list)
     outputs: list[dict[str, object]] = field(default_factory=list)
@@ -366,7 +368,7 @@ def _assemble_signed_tx(
     return bytes(signed)
 
 
-async def _prepare_direct_send(
+async def prepare_direct_send(
     *,
     wallet: WalletService,
     backend: BlockchainBackend,
@@ -521,6 +523,7 @@ async def _prepare_direct_send(
         )
 
     return SignedDirectTx(
+        txid=get_txid(tx_hex),
         tx_hex=tx_hex,
         fee=fee,
         fee_rate=fee_rate,
@@ -530,6 +533,7 @@ async def _prepare_direct_send(
         num_outputs=num_outputs,
         destination=destination,
         change_address=change_addr if change_amount > 0 else "",
+        selected_utxos=[(u.txid, u.vout) for u in utxos],
         source_addresses=[u.address for u in utxos],
         inputs=[
             {
@@ -592,7 +596,7 @@ async def direct_send(
     -------
     DirectSendResult
     """
-    prepared = await _prepare_direct_send(
+    prepared = await prepare_direct_send(
         wallet=wallet,
         backend=backend,
         mixdepth=mixdepth,
@@ -607,7 +611,7 @@ async def direct_send(
     tx_bytes_len = len(bytes.fromhex(prepared.tx_hex))
     logger.info("Broadcasting direct-send transaction ({} bytes)", tx_bytes_len)
     broadcast_txid = await backend.broadcast_transaction(prepared.tx_hex)
-    txid = broadcast_txid or ""
+    txid = broadcast_txid or prepared.txid
 
     logger.info("Broadcast OK: {}", txid)
     return DirectSendResult(

--- a/jmwallet/src/jmwallet/wallet/spend.py
+++ b/jmwallet/src/jmwallet/wallet/spend.py
@@ -106,6 +106,24 @@ class DirectSendResult:
     outputs: list[dict[str, object]] = field(default_factory=list)
 
 
+@dataclass
+class SignedDirectTx:
+    """Intermediate result from :func:`_prepare_direct_send`."""
+
+    tx_hex: str
+    fee: int
+    fee_rate: float
+    send_amount: int
+    change_amount: int
+    num_inputs: int
+    num_outputs: int
+    destination: str
+    change_address: str = ""
+    source_addresses: list[str] = field(default_factory=list)
+    inputs: list[dict[str, object]] = field(default_factory=list)
+    outputs: list[dict[str, object]] = field(default_factory=list)
+
+
 # Map of wallet networks to python-bitcointx chain parameter names. Used so
 # CCoinAddress can both verify the bech32/base58 checksum AND reject
 # addresses from a different network than the wallet is configured for.
@@ -348,7 +366,7 @@ def _assemble_signed_tx(
     return bytes(signed)
 
 
-async def direct_send(
+async def _prepare_direct_send(
     *,
     wallet: WalletService,
     backend: BlockchainBackend,
@@ -359,40 +377,12 @@ async def direct_send(
     fee_target_blocks: int = 6,
     tx_fee_factor: float = 0.0,
     max_fee_rate_sat_vb: float = DEFAULT_MAX_FEE_RATE_SAT_VB,
-) -> DirectSendResult:
-    """Build, sign, and broadcast a direct (non-CoinJoin) transaction.
+) -> SignedDirectTx:
+    """Build and sign a direct-send transaction WITHOUT broadcasting.
 
-    Parameters
-    ----------
-    wallet:
-        An initialised and synced :class:`WalletService`.
-    backend:
-        The blockchain backend for fee estimation and broadcasting.
-    mixdepth:
-        The mixdepth (account) to spend from.
-    amount_sats:
-        Amount in satoshis to send.  ``0`` means sweep the entire mixdepth.
-    destination:
-        Destination Bitcoin address (bech32 only).
-    fee_rate:
-        Explicit fee rate in sat/vB.  When *None*, the rate is estimated
-        from the backend using *fee_target_blocks*.
-    fee_target_blocks:
-        Number of blocks for fee estimation (ignored when *fee_rate* is set).
-    tx_fee_factor:
-        Privacy randomization factor. The final rate is selected between the
-        resolved rate and that rate multiplied by ``1 + tx_fee_factor``, with
-        the upper end limited by *max_fee_rate_sat_vb*.
-    max_fee_rate_sat_vb:
-        Safety cap on the fee rate (sat/vB).  The resolved rate (manual or
-        from backend estimation) is rejected with
-        :class:`ExcessiveFeeRateError` when it exceeds this value.  Defaults
-        to :data:`DEFAULT_MAX_FEE_RATE_SAT_VB`; daemon and CLI callers wire
-        this from ``settings.wallet.max_fee_rate_sat_vb``.
-
-    Returns
-    -------
-    DirectSendResult
+    Returns a :class:`SignedDirectTx` containing the signed hex and all
+    metadata needed to broadcast and record a history entry. Callers that want
+    the full build+sign+broadcast flow should use :func:`direct_send` instead.
     """
     if not destination.startswith(("bc1", "tb1", "bcrt1")):
         msg = "Only bech32 addresses are currently supported"
@@ -486,6 +476,7 @@ async def direct_send(
 
     # --- Change output ---
     change_script: bytes | None = None
+    change_addr: str = ""
     if change_amount > 0:
         change_index = wallet.get_next_address_index(mixdepth, 1)
         change_addr = wallet.get_change_address(mixdepth, change_index)
@@ -517,14 +508,19 @@ async def direct_send(
     )
     tx_hex = signed_tx.hex()
 
-    # --- Broadcast ---
-    logger.info("Broadcasting direct-send transaction ({} bytes)", len(signed_tx))
-    broadcast_txid = await backend.broadcast_transaction(tx_hex)
-    txid = broadcast_txid or ""
+    outputs_list: list[dict[str, object]] = [
+        {"value_sats": send_amount, "scriptPubKey": dest_script.hex(), "address": destination},
+    ]
+    if change_amount > 0 and change_script is not None:
+        outputs_list.append(
+            {
+                "value_sats": change_amount,
+                "scriptPubKey": change_script.hex(),
+                "address": change_addr,
+            }
+        )
 
-    logger.info("Broadcast OK: {}", txid)
-    return DirectSendResult(
-        txid=txid,
+    return SignedDirectTx(
         tx_hex=tx_hex,
         fee=fee,
         fee_rate=fee_rate,
@@ -532,6 +528,9 @@ async def direct_send(
         change_amount=change_amount,
         num_inputs=len(utxos),
         num_outputs=num_outputs,
+        destination=destination,
+        change_address=change_addr if change_amount > 0 else "",
+        source_addresses=[u.address for u in utxos],
         inputs=[
             {
                 "outpoint": f"{u.txid}:{u.vout}",
@@ -543,7 +542,83 @@ async def direct_send(
             }
             for u in utxos
         ],
-        outputs=[
-            {"value_sats": send_amount, "scriptPubKey": dest_script.hex(), "address": destination},
-        ],
+        outputs=outputs_list,
+    )
+
+
+async def direct_send(
+    *,
+    wallet: WalletService,
+    backend: BlockchainBackend,
+    mixdepth: int,
+    amount_sats: int,
+    destination: str,
+    fee_rate: float | None = None,
+    fee_target_blocks: int = 6,
+    tx_fee_factor: float = 0.0,
+    max_fee_rate_sat_vb: float = DEFAULT_MAX_FEE_RATE_SAT_VB,
+) -> DirectSendResult:
+    """Build, sign, and broadcast a direct (non-CoinJoin) transaction.
+
+    Parameters
+    ----------
+    wallet:
+        An initialised and synced :class:`WalletService`.
+    backend:
+        The blockchain backend for fee estimation and broadcasting.
+    mixdepth:
+        The mixdepth (account) to spend from.
+    amount_sats:
+        Amount in satoshis to send.  ``0`` means sweep the entire mixdepth.
+    destination:
+        Destination Bitcoin address (bech32 only).
+    fee_rate:
+        Explicit fee rate in sat/vB.  When *None*, the rate is estimated
+        from the backend using *fee_target_blocks*.
+    fee_target_blocks:
+        Number of blocks for fee estimation (ignored when *fee_rate* is set).
+    tx_fee_factor:
+        Privacy randomization factor. The final rate is selected between the
+        resolved rate and that rate multiplied by ``1 + tx_fee_factor``, with
+        the upper end limited by *max_fee_rate_sat_vb*.
+    max_fee_rate_sat_vb:
+        Safety cap on the fee rate (sat/vB).  The resolved rate (manual or
+        from backend estimation) is rejected with
+        :class:`ExcessiveFeeRateError` when it exceeds this value.  Defaults
+        to :data:`DEFAULT_MAX_FEE_RATE_SAT_VB`; daemon and CLI callers wire
+        this from ``settings.wallet.max_fee_rate_sat_vb``.
+
+    Returns
+    -------
+    DirectSendResult
+    """
+    prepared = await _prepare_direct_send(
+        wallet=wallet,
+        backend=backend,
+        mixdepth=mixdepth,
+        amount_sats=amount_sats,
+        destination=destination,
+        fee_rate=fee_rate,
+        fee_target_blocks=fee_target_blocks,
+        tx_fee_factor=tx_fee_factor,
+        max_fee_rate_sat_vb=max_fee_rate_sat_vb,
+    )
+
+    tx_bytes_len = len(bytes.fromhex(prepared.tx_hex))
+    logger.info("Broadcasting direct-send transaction ({} bytes)", tx_bytes_len)
+    broadcast_txid = await backend.broadcast_transaction(prepared.tx_hex)
+    txid = broadcast_txid or ""
+
+    logger.info("Broadcast OK: {}", txid)
+    return DirectSendResult(
+        txid=txid,
+        tx_hex=prepared.tx_hex,
+        fee=prepared.fee,
+        fee_rate=prepared.fee_rate,
+        send_amount=prepared.send_amount,
+        change_amount=prepared.change_amount,
+        num_inputs=prepared.num_inputs,
+        num_outputs=prepared.num_outputs,
+        inputs=prepared.inputs,
+        outputs=prepared.outputs,
     )

--- a/jmwallet/tests/test_history.py
+++ b/jmwallet/tests/test_history.py
@@ -3460,6 +3460,71 @@ class TestSendHistoryEntry:
         used = get_used_addresses(temp_data_dir)
         assert pending.destination_address in used
 
+    def test_update_send_awaiting_broadcast_is_scoped_to_exact_send(
+        self, temp_data_dir: Path
+    ) -> None:
+        destination = "bc1qdest1234567890abcdef1234567890abcdef1234"
+        change = "bc1qchg1234567890abcdef1234567890abcdef1234"
+        shared_args = {
+            "destination": destination,
+            "change_address": change,
+            "amount": 666,
+            "mining_fee": 178,
+            "source_mixdepth": 4,
+            "selected_utxos": [("aa" * 32, 0)],
+            "txid": "",
+            "success": False,
+            "failure_reason": "awaiting broadcast",
+        }
+        other_wallet = create_send_history_entry(
+            **shared_args,
+            wallet_fingerprint="11111111",
+        )
+        target_wallet = create_send_history_entry(
+            **shared_args,
+            wallet_fingerprint="22222222",
+        )
+        same_wallet_other_send = create_send_history_entry(
+            **{
+                **shared_args,
+                "change_address": "bc1qother1234567890abcdef1234567890abcdef123",
+                "selected_utxos": [("bb" * 32, 1)],
+            },
+            wallet_fingerprint="22222222",
+        )
+        target_wallet.timestamp = other_wallet.timestamp
+        same_wallet_other_send.timestamp = other_wallet.timestamp
+        append_history_entry(other_wallet, temp_data_dir)
+        append_history_entry(same_wallet_other_send, temp_data_dir)
+        append_history_entry(target_wallet, temp_data_dir)
+
+        ok = update_send_awaiting_broadcast(
+            target_wallet,
+            txid="dd" * 32,
+            success=True,
+            failure_reason="",
+            data_dir=temp_data_dir,
+        )
+
+        assert ok is True
+        rows = read_history(temp_data_dir)
+        other_wallet_row = next(row for row in rows if row.wallet_fingerprint == "11111111")
+        same_wallet_other_row = next(
+            row for row in rows if row.change_address == same_wallet_other_send.change_address
+        )
+        target_row = next(
+            row
+            for row in rows
+            if row.wallet_fingerprint == "22222222"
+            and row.change_address == target_wallet.change_address
+        )
+        assert other_wallet_row.failure_reason == "awaiting broadcast"
+        assert other_wallet_row.txid == ""
+        assert same_wallet_other_row.failure_reason == "awaiting broadcast"
+        assert same_wallet_other_row.txid == ""
+        assert target_row.success is True
+        assert target_row.txid == "dd" * 32
+
     def test_send_addresses_not_classified_as_coinjoin(self, temp_data_dir: Path) -> None:
         """Regression for issue #517.
 

--- a/jmwallet/tests/test_spend.py
+++ b/jmwallet/tests/test_spend.py
@@ -8,6 +8,7 @@ from hashlib import sha256
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from jmcore.bitcoin import get_txid
 from jmcore.btc_script import mk_freeze_script
 
 from jmwallet.backends.base import BlockchainBackend
@@ -16,11 +17,13 @@ from jmwallet.wallet.spend import (
     DUST_THRESHOLD,
     DirectSendResult,
     ExcessiveFeeRateError,
+    SignedDirectTx,
     _build_unsigned_tx,
     _decode_bech32_scriptpubkey,
     direct_send,
     enforce_fee_rate_cap,
     estimate_fee,
+    prepare_direct_send,
     select_spendable_utxos,
 )
 
@@ -919,18 +922,17 @@ class TestDirectSendFeeRateCap:
 
 
 class TestPrepareDirectSend:
-    """Unit tests for _prepare_direct_send."""
+    """Unit tests for prepare_direct_send."""
 
     @pytest.mark.anyio
     async def test_prepare_returns_signed_tx_without_broadcasting(self) -> None:
-        """_prepare_direct_send builds and signs but does NOT call broadcast_transaction."""
-        from jmwallet.wallet.spend import SignedDirectTx, _prepare_direct_send
+        """prepare_direct_send builds and signs but does not broadcast."""
 
         utxos = [_make_utxo(value=200_000, address="bcrt1qinput")]
         wallet = _make_mock_wallet(utxos, change_addr=REGTEST_P2WPKH_ADDR)
         backend = _make_mock_backend()
 
-        result = await _prepare_direct_send(
+        result = await prepare_direct_send(
             wallet=wallet,
             backend=backend,
             mixdepth=0,
@@ -941,7 +943,9 @@ class TestPrepareDirectSend:
 
         assert isinstance(result, SignedDirectTx)
         assert result.tx_hex
+        assert result.txid == get_txid(result.tx_hex)
         assert result.change_address == REGTEST_P2WPKH_ADDR
+        assert result.selected_utxos == [(utxos[0].txid, utxos[0].vout)]
         assert result.source_addresses == ["bcrt1qinput"]
         assert len(result.outputs) == 2
         backend.broadcast_transaction.assert_not_awaited()
@@ -949,13 +953,11 @@ class TestPrepareDirectSend:
     @pytest.mark.anyio
     async def test_prepare_sweep_has_empty_change_address(self) -> None:
         """Sweep (amount_sats=0) produces no change output; change_address must be empty."""
-        from jmwallet.wallet.spend import _prepare_direct_send
-
         utxos = [_make_utxo(value=100_000, address="bcrt1qinput")]
         wallet = _make_mock_wallet(utxos)
         backend = _make_mock_backend()
 
-        result = await _prepare_direct_send(
+        result = await prepare_direct_send(
             wallet=wallet,
             backend=backend,
             mixdepth=0,

--- a/jmwallet/tests/test_spend.py
+++ b/jmwallet/tests/test_spend.py
@@ -728,7 +728,7 @@ class TestDirectSend:
         assert result.num_inputs == 1
         assert result.num_outputs == 2  # send + change
         assert len(result.inputs) == 1
-        assert len(result.outputs) >= 1
+        assert len(result.outputs) == 2
         assert result.inputs[0]["outpoint"] == f"{'aa' * 32}:0"
 
     @pytest.mark.anyio
@@ -916,3 +916,54 @@ class TestDirectSendFeeRateCap:
             )
 
         assert result.fee_rate == 1_000.0
+
+
+class TestPrepareDirectSend:
+    """Unit tests for _prepare_direct_send."""
+
+    @pytest.mark.anyio
+    async def test_prepare_returns_signed_tx_without_broadcasting(self) -> None:
+        """_prepare_direct_send builds and signs but does NOT call broadcast_transaction."""
+        from jmwallet.wallet.spend import SignedDirectTx, _prepare_direct_send
+
+        utxos = [_make_utxo(value=200_000, address="bcrt1qinput")]
+        wallet = _make_mock_wallet(utxos, change_addr=REGTEST_P2WPKH_ADDR)
+        backend = _make_mock_backend()
+
+        result = await _prepare_direct_send(
+            wallet=wallet,
+            backend=backend,
+            mixdepth=0,
+            amount_sats=50_000,
+            destination=REGTEST_P2WPKH_ADDR,
+            fee_rate=1.0,
+        )
+
+        assert isinstance(result, SignedDirectTx)
+        assert result.tx_hex
+        assert result.change_address == REGTEST_P2WPKH_ADDR
+        assert result.source_addresses == ["bcrt1qinput"]
+        assert len(result.outputs) == 2
+        backend.broadcast_transaction.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_prepare_sweep_has_empty_change_address(self) -> None:
+        """Sweep (amount_sats=0) produces no change output; change_address must be empty."""
+        from jmwallet.wallet.spend import _prepare_direct_send
+
+        utxos = [_make_utxo(value=100_000, address="bcrt1qinput")]
+        wallet = _make_mock_wallet(utxos)
+        backend = _make_mock_backend()
+
+        result = await _prepare_direct_send(
+            wallet=wallet,
+            backend=backend,
+            mixdepth=0,
+            amount_sats=0,
+            destination=REGTEST_P2WPKH_ADDR,
+            fee_rate=1.0,
+        )
+
+        assert result.change_address == ""
+        assert result.source_addresses == ["bcrt1qinput"]
+        backend.broadcast_transaction.assert_not_awaited()

--- a/jmwalletd/src/jmwalletd/send.py
+++ b/jmwalletd/src/jmwalletd/send.py
@@ -1,7 +1,7 @@
 """Direct-send helper for jmwalletd.
 
-Thin wrapper around :func:`jmwallet.wallet.spend.direct_send` that adapts the
-result for the jmwalletd HTTP API response format.
+Builds, signs, broadcasts, and records direct (non-coinjoin) transactions
+in history.csv following the two-phase history persistence pattern.
 """
 
 from __future__ import annotations
@@ -11,10 +11,15 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from jmwallet.history import (
+    append_history_entry,
+    create_send_history_entry,
+    update_send_awaiting_broadcast,
+)
 from jmwallet.wallet.spend import (
     DEFAULT_MAX_FEE_RATE_SAT_VB,
     DirectSendResult,
-    direct_send,
+    _prepare_direct_send,
 )
 
 if TYPE_CHECKING:
@@ -32,13 +37,24 @@ async def do_direct_send(
     tx_fee_factor: float = 0.0,
     max_fee_rate_sat_vb: float = DEFAULT_MAX_FEE_RATE_SAT_VB,
 ) -> DirectSendResult:
-    """Build and broadcast a direct (non-coinjoin) transaction.
+    """Build, sign, broadcast, and record a direct (non-coinjoin) transaction.
 
-    Delegates entirely to :func:`jmwallet.wallet.spend.direct_send`.
     ``fee_rate`` (sat/vB) takes priority; otherwise ``fee_target_blocks``
     drives backend estimation (``None`` keeps the spend module's default
     target). ``tx_fee_factor`` applies the reference fee-rate randomization,
     and ``max_fee_rate_sat_vb`` applies the operator's configured hard cap.
+
+    Follows the same two-phase history-write pattern as the CLI send command:
+
+    1. A ``role="send"`` row is written to ``history.csv`` with
+       ``failure_reason="awaiting broadcast"`` **before** the broadcast call.
+       This permanently marks destination and change addresses as used,
+       even if broadcast fails — the signed bytes are already outside
+       the wallet's control.
+    2. After broadcast resolves (success or failure) the row is patched
+       in-place via :func:`~jmwallet.history.update_send_awaiting_broadcast`.
+
+    Persistence failures are logged as warnings and never block the broadcast.
     """
     from jmcore.paths import get_default_data_dir
     from jmwalletd._backend import get_backend
@@ -63,7 +79,8 @@ async def do_direct_send(
     if fee_target_blocks is not None:
         extra_kwargs["fee_target_blocks"] = fee_target_blocks
 
-    return await direct_send(
+    # --- Phase 1: build + sign (no broadcast yet) ---
+    prepared = await _prepare_direct_send(
         wallet=wallet_service,
         backend=backend,
         mixdepth=mixdepth,
@@ -73,4 +90,74 @@ async def do_direct_send(
         tx_fee_factor=tx_fee_factor,
         max_fee_rate_sat_vb=max_fee_rate_sat_vb,
         **extra_kwargs,
+    )
+
+    # --- Phase 1b: persist pending history row BEFORE broadcast ---
+    network: str = getattr(wallet_service, "network", "mainnet")
+    wallet_fingerprint: str = getattr(wallet_service, "wallet_fingerprint", "") or getattr(
+        wallet_service, "fingerprint", ""
+    )
+    selected_utxos = [
+        (str(inp["outpoint"]).split(":")[0], int(str(inp["outpoint"]).split(":")[1]))
+        for inp in prepared.inputs
+    ]
+    send_entry = create_send_history_entry(
+        destination=destination,
+        change_address=prepared.change_address,
+        amount=prepared.send_amount,
+        mining_fee=prepared.fee,
+        source_mixdepth=mixdepth,
+        selected_utxos=selected_utxos,
+        txid="",
+        success=False,
+        failure_reason="awaiting broadcast",
+        network=network,
+        wallet_fingerprint=wallet_fingerprint,
+        source_addresses=prepared.source_addresses,
+    )
+    try:
+        append_history_entry(send_entry, data_dir=data_dir)
+    except Exception as exc:
+        logger.warning("Failed to persist pre-broadcast send history entry: {}", exc)
+
+    # --- Phase 2: broadcast ---
+    txid = ""
+    broadcast_exc: Exception | None = None
+    try:
+        logger.info(
+            "Broadcasting direct-send transaction ({} bytes)",
+            len(bytes.fromhex(prepared.tx_hex)),
+        )
+        txid = (await backend.broadcast_transaction(prepared.tx_hex)) or ""
+        logger.info("Broadcast OK: {}", txid)
+    except Exception as exc:
+        broadcast_exc = exc
+        logger.error("Broadcast failed: {}", exc)
+
+    # --- Phase 3: finalize history row (success or failure) ---
+    try:
+        update_send_awaiting_broadcast(
+            send_entry,
+            txid=txid,
+            success=broadcast_exc is None,
+            failure_reason="" if broadcast_exc is None else f"broadcast failed: {broadcast_exc}",
+            data_dir=data_dir,
+        )
+    except Exception as exc:
+        logger.warning("Failed to finalize send history entry: {}", exc)
+
+    if broadcast_exc is not None:
+        raise broadcast_exc
+
+    return DirectSendResult(
+        txid=txid,
+        tx_hex=prepared.tx_hex,
+        fee=prepared.fee,
+        fee_rate=prepared.fee_rate,
+        send_amount=prepared.send_amount,
+        change_amount=prepared.change_amount,
+        num_inputs=prepared.num_inputs,
+        num_outputs=prepared.num_outputs,
+        inputs=prepared.inputs,
+        outputs=prepared.outputs,
     )

--- a/jmwalletd/src/jmwalletd/send.py
+++ b/jmwalletd/src/jmwalletd/send.py
@@ -19,7 +19,7 @@ from jmwallet.history import (
 from jmwallet.wallet.spend import (
     DEFAULT_MAX_FEE_RATE_SAT_VB,
     DirectSendResult,
-    _prepare_direct_send,
+    prepare_direct_send,
 )
 
 if TYPE_CHECKING:
@@ -80,7 +80,7 @@ async def do_direct_send(
         extra_kwargs["fee_target_blocks"] = fee_target_blocks
 
     # --- Phase 1: build + sign (no broadcast yet) ---
-    prepared = await _prepare_direct_send(
+    prepared = await prepare_direct_send(
         wallet=wallet_service,
         backend=backend,
         mixdepth=mixdepth,
@@ -97,17 +97,13 @@ async def do_direct_send(
     wallet_fingerprint: str = getattr(wallet_service, "wallet_fingerprint", "") or getattr(
         wallet_service, "fingerprint", ""
     )
-    selected_utxos = [
-        (str(inp["outpoint"]).split(":")[0], int(str(inp["outpoint"]).split(":")[1]))
-        for inp in prepared.inputs
-    ]
     send_entry = create_send_history_entry(
         destination=destination,
         change_address=prepared.change_address,
         amount=prepared.send_amount,
         mining_fee=prepared.fee,
         source_mixdepth=mixdepth,
-        selected_utxos=selected_utxos,
+        selected_utxos=prepared.selected_utxos,
         txid="",
         success=False,
         failure_reason="awaiting broadcast",
@@ -115,8 +111,10 @@ async def do_direct_send(
         wallet_fingerprint=wallet_fingerprint,
         source_addresses=prepared.source_addresses,
     )
+    history_persisted = False
     try:
         append_history_entry(send_entry, data_dir=data_dir)
+        history_persisted = True
     except Exception as exc:
         logger.warning("Failed to persist pre-broadcast send history entry: {}", exc)
 
@@ -128,23 +126,28 @@ async def do_direct_send(
             "Broadcasting direct-send transaction ({} bytes)",
             len(bytes.fromhex(prepared.tx_hex)),
         )
-        txid = (await backend.broadcast_transaction(prepared.tx_hex)) or ""
+        txid = (await backend.broadcast_transaction(prepared.tx_hex)) or prepared.txid
         logger.info("Broadcast OK: {}", txid)
     except Exception as exc:
         broadcast_exc = exc
         logger.error("Broadcast failed: {}", exc)
 
     # --- Phase 3: finalize history row (success or failure) ---
-    try:
-        update_send_awaiting_broadcast(
-            send_entry,
-            txid=txid,
-            success=broadcast_exc is None,
-            failure_reason="" if broadcast_exc is None else f"broadcast failed: {broadcast_exc}",
-            data_dir=data_dir,
-        )
-    except Exception as exc:
-        logger.warning("Failed to finalize send history entry: {}", exc)
+    if history_persisted:
+        try:
+            updated = update_send_awaiting_broadcast(
+                send_entry,
+                txid=txid,
+                success=broadcast_exc is None,
+                failure_reason=""
+                if broadcast_exc is None
+                else f"broadcast failed: {broadcast_exc}",
+                data_dir=data_dir,
+            )
+            if not updated:
+                logger.warning("Could not find pre-broadcast send history entry to finalize")
+        except Exception as exc:
+            logger.warning("Failed to finalize send history entry: {}", exc)
 
     if broadcast_exc is not None:
         raise broadcast_exc

--- a/jmwalletd/tests/test_send.py
+++ b/jmwalletd/tests/test_send.py
@@ -12,6 +12,7 @@ from jmwalletd.send import do_direct_send
 
 def _make_prepared_tx() -> SignedDirectTx:
     return SignedDirectTx(
+        txid="bb" * 32,
         tx_hex="deadbeef",
         fee=150,
         fee_rate=1.0,
@@ -21,6 +22,7 @@ def _make_prepared_tx() -> SignedDirectTx:
         num_outputs=2,
         destination="bcrt1qdestination",
         change_address="bcrt1qchange",
+        selected_utxos=[("aa" * 32, 0)],
         source_addresses=["bcrt1qinput"],
         inputs=[{"outpoint": "aa" * 32 + ":0"}],
         outputs=[{"value_sats": 50_000, "scriptPubKey": "0014...", "address": "bcrt1qdestination"}],
@@ -31,7 +33,7 @@ def _make_prepared_tx() -> SignedDirectTx:
 @patch("jmwalletd.send.update_send_awaiting_broadcast")
 @patch("jmwalletd.send.append_history_entry")
 @patch("jmwalletd.send.create_send_history_entry")
-@patch("jmwalletd.send._prepare_direct_send", new_callable=AsyncMock)
+@patch("jmwalletd.send.prepare_direct_send", new_callable=AsyncMock)
 @patch("jmwalletd._backend.get_backend", new_callable=AsyncMock)
 async def test_direct_send_refreshes_registered_bonds_and_writes_history(
     mock_get_backend: AsyncMock,
@@ -56,6 +58,7 @@ async def test_direct_send_refreshes_registered_bonds_and_writes_history(
 
     fake_entry = MagicMock()
     mock_create_entry.return_value = fake_entry
+    mock_update_entry.return_value = True
 
     call_order: list[str] = []
 
@@ -111,7 +114,7 @@ async def test_direct_send_refreshes_registered_bonds_and_writes_history(
 @patch("jmwalletd.send.update_send_awaiting_broadcast")
 @patch("jmwalletd.send.append_history_entry")
 @patch("jmwalletd.send.create_send_history_entry")
-@patch("jmwalletd.send._prepare_direct_send", new_callable=AsyncMock)
+@patch("jmwalletd.send.prepare_direct_send", new_callable=AsyncMock)
 @patch("jmwalletd._backend.get_backend", new_callable=AsyncMock)
 async def test_direct_send_records_broadcast_failure(
     mock_get_backend: AsyncMock,
@@ -135,6 +138,7 @@ async def test_direct_send_records_broadcast_failure(
 
     fake_entry = MagicMock()
     mock_create_entry.return_value = fake_entry
+    mock_update_entry.return_value = True
 
     with pytest.raises(RuntimeError, match="node connection refused"):
         await do_direct_send(
@@ -161,7 +165,7 @@ async def test_direct_send_records_broadcast_failure(
 @patch("jmwalletd.send.update_send_awaiting_broadcast")
 @patch("jmwalletd.send.append_history_entry")
 @patch("jmwalletd.send.create_send_history_entry")
-@patch("jmwalletd.send._prepare_direct_send", new_callable=AsyncMock)
+@patch("jmwalletd.send.prepare_direct_send", new_callable=AsyncMock)
 @patch("jmwalletd._backend.get_backend", new_callable=AsyncMock)
 async def test_direct_send_forwards_fee_overrides(
     mock_get_backend: AsyncMock,
@@ -170,7 +174,7 @@ async def test_direct_send_forwards_fee_overrides(
     mock_append_entry: MagicMock,
     mock_update_entry: MagicMock,
 ) -> None:
-    """Fee overrides (configset [POLICY] tx_fees, issue #566) reach _prepare_direct_send."""
+    """Fee overrides (configset [POLICY] tx_fees, issue #566) reach prepare_direct_send."""
     wallet = MagicMock()
     wallet.data_dir = None
     wallet.sync_with_registered_bonds = AsyncMock()
@@ -200,3 +204,122 @@ async def test_direct_send_forwards_fee_overrides(
     )
     assert mock_prepare_direct_send.call_args.kwargs["fee_rate"] is None
     assert mock_prepare_direct_send.call_args.kwargs["fee_target_blocks"] == 6
+
+
+@pytest.mark.asyncio
+@patch("jmwalletd.send.update_send_awaiting_broadcast")
+@patch("jmwalletd.send.append_history_entry")
+@patch("jmwalletd.send.create_send_history_entry")
+@patch("jmwalletd.send.prepare_direct_send", new_callable=AsyncMock)
+@patch("jmwalletd._backend.get_backend", new_callable=AsyncMock)
+async def test_direct_send_uses_local_txid_when_backend_omits_it(
+    mock_get_backend: AsyncMock,
+    mock_prepare_direct_send: AsyncMock,
+    mock_create_entry: MagicMock,
+    mock_append_entry: MagicMock,
+    mock_update_entry: MagicMock,
+) -> None:
+    wallet = MagicMock(data_dir=None, network="regtest", wallet_fingerprint="aabbccdd")
+    wallet.sync_with_registered_bonds = AsyncMock()
+    prepared = _make_prepared_tx()
+    mock_prepare_direct_send.return_value = prepared
+    mock_create_entry.return_value = MagicMock()
+    mock_update_entry.return_value = True
+
+    backend = MagicMock()
+    backend.broadcast_transaction = AsyncMock(side_effect=["", None])
+    mock_get_backend.return_value = backend
+
+    results = [
+        await do_direct_send(
+            wallet_service=wallet,
+            mixdepth=0,
+            amount_sats=50_000,
+            destination="bcrt1qdestination",
+        )
+        for _ in range(2)
+    ]
+
+    assert [result.txid for result in results] == [prepared.txid, prepared.txid]
+    assert [call.kwargs["txid"] for call in mock_update_entry.call_args_list] == [
+        prepared.txid,
+        prepared.txid,
+    ]
+
+
+@pytest.mark.asyncio
+@patch("jmwalletd.send.update_send_awaiting_broadcast")
+@patch("jmwalletd.send.append_history_entry")
+@patch("jmwalletd.send.create_send_history_entry")
+@patch("jmwalletd.send.prepare_direct_send", new_callable=AsyncMock)
+@patch("jmwalletd._backend.get_backend", new_callable=AsyncMock)
+async def test_direct_send_skips_finalization_when_history_append_fails(
+    mock_get_backend: AsyncMock,
+    mock_prepare_direct_send: AsyncMock,
+    mock_create_entry: MagicMock,
+    mock_append_entry: MagicMock,
+    mock_update_entry: MagicMock,
+) -> None:
+    wallet = MagicMock(data_dir=None, network="regtest", wallet_fingerprint="aabbccdd")
+    wallet.sync_with_registered_bonds = AsyncMock()
+    prepared = _make_prepared_tx()
+    mock_prepare_direct_send.return_value = prepared
+    mock_create_entry.return_value = MagicMock()
+    mock_append_entry.side_effect = OSError("disk full")
+
+    backend = MagicMock()
+    backend.broadcast_transaction = AsyncMock(return_value=prepared.txid)
+    mock_get_backend.return_value = backend
+
+    with patch("jmwalletd.send.logger.warning") as mock_warning:
+        result = await do_direct_send(
+            wallet_service=wallet,
+            mixdepth=0,
+            amount_sats=50_000,
+            destination="bcrt1qdestination",
+        )
+
+    assert result.txid == prepared.txid
+    backend.broadcast_transaction.assert_awaited_once_with(prepared.tx_hex)
+    mock_update_entry.assert_not_called()
+    mock_warning.assert_called_once_with(
+        "Failed to persist pre-broadcast send history entry: {}", mock_append_entry.side_effect
+    )
+
+
+@pytest.mark.asyncio
+@patch("jmwalletd.send.update_send_awaiting_broadcast", return_value=False)
+@patch("jmwalletd.send.append_history_entry")
+@patch("jmwalletd.send.create_send_history_entry")
+@patch("jmwalletd.send.prepare_direct_send", new_callable=AsyncMock)
+@patch("jmwalletd._backend.get_backend", new_callable=AsyncMock)
+async def test_direct_send_warns_when_history_row_cannot_be_finalized(
+    mock_get_backend: AsyncMock,
+    mock_prepare_direct_send: AsyncMock,
+    mock_create_entry: MagicMock,
+    mock_append_entry: MagicMock,
+    mock_update_entry: MagicMock,
+) -> None:
+    wallet = MagicMock(data_dir=None, network="regtest", wallet_fingerprint="aabbccdd")
+    wallet.sync_with_registered_bonds = AsyncMock()
+    prepared = _make_prepared_tx()
+    mock_prepare_direct_send.return_value = prepared
+    mock_create_entry.return_value = MagicMock()
+
+    backend = MagicMock()
+    backend.broadcast_transaction = AsyncMock(return_value=prepared.txid)
+    mock_get_backend.return_value = backend
+
+    with patch("jmwalletd.send.logger.warning") as mock_warning:
+        result = await do_direct_send(
+            wallet_service=wallet,
+            mixdepth=0,
+            amount_sats=50_000,
+            destination="bcrt1qdestination",
+        )
+
+    assert result.txid == prepared.txid
+    mock_update_entry.assert_called_once()
+    mock_warning.assert_called_once_with(
+        "Could not find pre-broadcast send history entry to finalize"
+    )

--- a/jmwalletd/tests/test_send.py
+++ b/jmwalletd/tests/test_send.py
@@ -2,64 +2,182 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
+from jmwallet.wallet.spend import SignedDirectTx
 from jmwalletd.send import do_direct_send
 
 
+def _make_prepared_tx() -> SignedDirectTx:
+    return SignedDirectTx(
+        tx_hex="deadbeef",
+        fee=150,
+        fee_rate=1.0,
+        send_amount=50_000,
+        change_amount=49_850,
+        num_inputs=1,
+        num_outputs=2,
+        destination="bcrt1qdestination",
+        change_address="bcrt1qchange",
+        source_addresses=["bcrt1qinput"],
+        inputs=[{"outpoint": "aa" * 32 + ":0"}],
+        outputs=[{"value_sats": 50_000, "scriptPubKey": "0014...", "address": "bcrt1qdestination"}],
+    )
+
+
 @pytest.mark.asyncio
-@patch("jmwalletd.send.direct_send", new_callable=AsyncMock)
+@patch("jmwalletd.send.update_send_awaiting_broadcast")
+@patch("jmwalletd.send.append_history_entry")
+@patch("jmwalletd.send.create_send_history_entry")
+@patch("jmwalletd.send._prepare_direct_send", new_callable=AsyncMock)
 @patch("jmwalletd._backend.get_backend", new_callable=AsyncMock)
-async def test_direct_send_refreshes_registered_bonds(
+async def test_direct_send_refreshes_registered_bonds_and_writes_history(
     mock_get_backend: AsyncMock,
-    mock_direct_send: AsyncMock,
+    mock_prepare_direct_send: AsyncMock,
+    mock_create_entry: MagicMock,
+    mock_append_entry: MagicMock,
+    mock_update_entry: MagicMock,
 ) -> None:
     wallet = MagicMock()
     wallet.data_dir = None
+    wallet.network = "regtest"
+    wallet.wallet_fingerprint = "aabbccdd"
     wallet.sync = AsyncMock()
     wallet.sync_with_registered_bonds = AsyncMock()
+
+    prepared = _make_prepared_tx()
+    mock_prepare_direct_send.return_value = prepared
+
     backend = MagicMock()
-    result = MagicMock()
+    backend.broadcast_transaction = AsyncMock(return_value="txid_123")
     mock_get_backend.return_value = backend
-    mock_direct_send.return_value = result
+
+    fake_entry = MagicMock()
+    mock_create_entry.return_value = fake_entry
+
+    call_order: list[str] = []
+
+    def _on_append(*a: object, **kw: object) -> None:
+        call_order.append("append")
+
+    def _on_broadcast(*a: object, **kw: object) -> str:
+        call_order.append("broadcast")
+        return "txid_123"
+
+    mock_append_entry.side_effect = _on_append
+    backend.broadcast_transaction.side_effect = _on_broadcast
 
     actual = await do_direct_send(
         wallet_service=wallet,
         mixdepth=0,
-        amount_sats=0,
+        amount_sats=50_000,
         destination="bcrt1qdestination",
     )
 
-    assert actual is result
+    assert actual.txid == "txid_123"
     wallet.sync_with_registered_bonds.assert_awaited_once_with()
     wallet.sync.assert_not_awaited()
-    mock_direct_send.assert_awaited_once_with(
-        wallet=wallet,
-        backend=backend,
-        mixdepth=0,
-        amount_sats=0,
+
+    # Verify append was called BEFORE broadcast
+    assert call_order == ["append", "broadcast"]
+
+    mock_create_entry.assert_called_once_with(
         destination="bcrt1qdestination",
-        fee_rate=None,
-        tx_fee_factor=0.0,
-        max_fee_rate_sat_vb=1_000.0,
+        change_address="bcrt1qchange",
+        amount=50_000,
+        mining_fee=150,
+        source_mixdepth=0,
+        selected_utxos=[("aa" * 32, 0)],
+        txid="",
+        success=False,
+        failure_reason="awaiting broadcast",
+        network="regtest",
+        wallet_fingerprint="aabbccdd",
+        source_addresses=["bcrt1qinput"],
+    )
+    mock_append_entry.assert_called_once_with(fake_entry, data_dir=ANY)
+    mock_update_entry.assert_called_once_with(
+        fake_entry,
+        txid="txid_123",
+        success=True,
+        failure_reason="",
+        data_dir=ANY,
     )
 
 
 @pytest.mark.asyncio
-@patch("jmwalletd.send.direct_send", new_callable=AsyncMock)
+@patch("jmwalletd.send.update_send_awaiting_broadcast")
+@patch("jmwalletd.send.append_history_entry")
+@patch("jmwalletd.send.create_send_history_entry")
+@patch("jmwalletd.send._prepare_direct_send", new_callable=AsyncMock)
+@patch("jmwalletd._backend.get_backend", new_callable=AsyncMock)
+async def test_direct_send_records_broadcast_failure(
+    mock_get_backend: AsyncMock,
+    mock_prepare_direct_send: AsyncMock,
+    mock_create_entry: MagicMock,
+    mock_append_entry: MagicMock,
+    mock_update_entry: MagicMock,
+) -> None:
+    wallet = MagicMock()
+    wallet.data_dir = None
+    wallet.network = "regtest"
+    wallet.wallet_fingerprint = "aabbccdd"
+    wallet.sync_with_registered_bonds = AsyncMock()
+
+    prepared = _make_prepared_tx()
+    mock_prepare_direct_send.return_value = prepared
+
+    backend = MagicMock()
+    backend.broadcast_transaction = AsyncMock(side_effect=RuntimeError("node connection refused"))
+    mock_get_backend.return_value = backend
+
+    fake_entry = MagicMock()
+    mock_create_entry.return_value = fake_entry
+
+    with pytest.raises(RuntimeError, match="node connection refused"):
+        await do_direct_send(
+            wallet_service=wallet,
+            mixdepth=0,
+            amount_sats=50_000,
+            destination="bcrt1qdestination",
+        )
+
+    # Pre-broadcast append happened
+    mock_append_entry.assert_called_once()
+
+    # Post-broadcast update recorded failure
+    mock_update_entry.assert_called_once_with(
+        fake_entry,
+        txid="",
+        success=False,
+        failure_reason="broadcast failed: node connection refused",
+        data_dir=ANY,
+    )
+
+
+@pytest.mark.asyncio
+@patch("jmwalletd.send.update_send_awaiting_broadcast")
+@patch("jmwalletd.send.append_history_entry")
+@patch("jmwalletd.send.create_send_history_entry")
+@patch("jmwalletd.send._prepare_direct_send", new_callable=AsyncMock)
 @patch("jmwalletd._backend.get_backend", new_callable=AsyncMock)
 async def test_direct_send_forwards_fee_overrides(
     mock_get_backend: AsyncMock,
-    mock_direct_send: AsyncMock,
+    mock_prepare_direct_send: AsyncMock,
+    mock_create_entry: MagicMock,
+    mock_append_entry: MagicMock,
+    mock_update_entry: MagicMock,
 ) -> None:
-    """Fee overrides (configset [POLICY] tx_fees, issue #566) reach direct_send."""
+    """Fee overrides (configset [POLICY] tx_fees, issue #566) reach _prepare_direct_send."""
     wallet = MagicMock()
     wallet.data_dir = None
     wallet.sync_with_registered_bonds = AsyncMock()
-    mock_get_backend.return_value = MagicMock()
-    mock_direct_send.return_value = MagicMock()
+    backend = MagicMock()
+    backend.broadcast_transaction = AsyncMock(return_value="txid_123")
+    mock_get_backend.return_value = backend
+    mock_prepare_direct_send.return_value = _make_prepared_tx()
 
     await do_direct_send(
         wallet_service=wallet,
@@ -69,9 +187,9 @@ async def test_direct_send_forwards_fee_overrides(
         fee_rate=2.5,
         tx_fee_factor=0.4,
     )
-    assert mock_direct_send.call_args.kwargs["fee_rate"] == 2.5
-    assert mock_direct_send.call_args.kwargs["tx_fee_factor"] == 0.4
-    assert "fee_target_blocks" not in mock_direct_send.call_args.kwargs
+    assert mock_prepare_direct_send.call_args.kwargs["fee_rate"] == 2.5
+    assert mock_prepare_direct_send.call_args.kwargs["tx_fee_factor"] == 0.4
+    assert "fee_target_blocks" not in mock_prepare_direct_send.call_args.kwargs
 
     await do_direct_send(
         wallet_service=wallet,
@@ -80,5 +198,5 @@ async def test_direct_send_forwards_fee_overrides(
         destination="bcrt1qdestination",
         fee_target_blocks=6,
     )
-    assert mock_direct_send.call_args.kwargs["fee_rate"] is None
-    assert mock_direct_send.call_args.kwargs["fee_target_blocks"] == 6
+    assert mock_prepare_direct_send.call_args.kwargs["fee_rate"] is None
+    assert mock_prepare_direct_send.call_args.kwargs["fee_target_blocks"] == 6


### PR DESCRIPTION
### Summary
Resolves #583 by recording direct (non-collaborative) transactions in `history.csv` immediately upon broadcast when initiated via the daemon API (`POST /api/v1/wallet/{walletname}/taker/direct-send`).

### Changes
- **`jmwallet/src/jmwallet/wallet/spend.py`**:
  - Extracted `_prepare_direct_send()` to build and sign transactions without broadcasting, returning a `SignedDirectTx` intermediate dataclass.
  - Retained `direct_send()` as a public wrapper
  - Included change output in `outputs` metadata list when change is present.
- **`jmwalletd/src/jmwalletd/send.py`**:
  - Implemented the three-phase history write pattern in `do_direct_send()` matching the CLI (`jmwallet.cli.send`):
    1. **Pre-broadcast write**: Append pending history row (`success=False`, `failure_reason="awaiting broadcast"`).
    2. **Broadcast**: Transmit raw transaction hex via backend.
    3. **Post-broadcast update**: Reconcile row in `history.csv` with `txid` and `success=True/False`.
  - Fixed wallet fingerprint resolution to check `wallet.wallet_fingerprint`.
- **Tests**:
  - Added unit tests for `_prepare_direct_send()` in `jmwallet/tests/test_spend.py`.
  - Added coverage for 3-phase history persistence, broadcast failure recovery, and fee parameter forwarding in `jmwalletd/tests/test_send.py`.