### PR TITLE
fix(jmwallet): add neutral amount field and nullify coinjoin fields on non-collaborative transactions

### DIFF
--- a/jmwallet/src/jmwallet/cli/history_cmd.py
+++ b/jmwallet/src/jmwallet/cli/history_cmd.py
@@ -197,6 +197,7 @@ def history(
             "net_fee",
             "success",
             "source",
+            "amount",
         ]
         writer = csv_module.DictWriter(sys.stdout, fieldnames=fieldnames)
         writer.writeheader()
@@ -211,6 +212,7 @@ def history(
                     "net_fee": entry.net_fee,
                     "success": entry.success,
                     "source": entry.source,
+                    "amount": entry.transfer_amount,
                 }
             )
     else:
@@ -244,7 +246,7 @@ def history(
             role_str = f"{entry.role}*" if entry.source == "onchain" else entry.role
 
             print(
-                f"{entry.timestamp[:19]:<20} {role_str:<8} {entry.cj_amount:>12,} "
+                f"{entry.timestamp[:19]:<20} {role_str:<8} {entry.transfer_amount:>12,} "
                 f"{peer_str:>6} {fee_str:>12} {txid_full:<64}{status}"
             )
 

--- a/jmwallet/src/jmwallet/history.py
+++ b/jmwallet/src/jmwallet/history.py
@@ -154,6 +154,10 @@ class TransactionHistoryEntry:
     # Neutrino needs the exact vout to verify a confirmed output by address.
     destination_vout: int = -1
 
+    # Neutral transfer amount (in satoshis) across all roles (maker/taker CJ denomination,
+    # send output amount, deposit input amount). Appended last for legacy CSV migration.
+    amount: int = 0
+
 
 HISTORY_FILENAME = "history.csv"
 LEGACY_HISTORY_FILENAME = "coinjoin_history.csv"
@@ -503,6 +507,11 @@ def _row_to_entry(row: Mapping[str, str | None]) -> TransactionHistoryEntry | No
             ),
             input_value=int(_get("input_value", "0") or 0),
             destination_vout=destination_vout,
+            amount=(
+                int(_get("amount"))
+                if _get("amount") and _get("amount") not in ("", "None")
+                else int(_get("cj_amount", "0") or 0)
+            ),
         )
     except (ValueError, KeyError) as e:
         logger.warning(f"Skipping malformed history row: {e}")
@@ -1105,6 +1114,7 @@ def create_maker_history_entry(
         wallet_fingerprint=wallet_fingerprint,
         input_value=input_value,
         destination_vout=destination_vout,
+        amount=cj_amount,
     )
 
 
@@ -1798,6 +1808,7 @@ def create_taker_history_entry(
         network=network,
         wallet_fingerprint=wallet_fingerprint,
         destination_vout=destination_vout,
+        amount=cj_amount,
     )
 
 
@@ -1860,7 +1871,8 @@ def create_send_history_entry(
         confirmations=0,
         confirmed_at="",
         txid=txid,
-        cj_amount=amount,
+        cj_amount=0,
+        amount=amount,
         peer_count=None,
         counterparty_nicks="",
         mining_fee_paid=mining_fee,

--- a/jmwallet/src/jmwallet/history.py
+++ b/jmwallet/src/jmwallet/history.py
@@ -158,6 +158,11 @@ class TransactionHistoryEntry:
     # send output amount, deposit input amount). Appended last for legacy CSV migration.
     amount: int = 0
 
+    @property
+    def transfer_amount(self) -> int:
+        """Return the neutral amount, including rows written before it existed."""
+        return self.amount if self.amount != 0 else self.cj_amount
+
 
 HISTORY_FILENAME = "history.csv"
 LEGACY_HISTORY_FILENAME = "coinjoin_history.csv"

--- a/jmwallet/src/jmwallet/history_reconstruction.py
+++ b/jmwallet/src/jmwallet/history_reconstruction.py
@@ -87,7 +87,8 @@ class ClassifiedTransaction:
     """Result of classifying a single wallet transaction from chain data."""
 
     role: HistoryRole
-    cj_amount: int
+    amount: int
+    cj_amount: int | None
     peer_count: int | None
     fee_received: int
     total_maker_fees_paid: int
@@ -155,7 +156,8 @@ def classify_wallet_transaction(
         )
         return ClassifiedTransaction(
             role="deposit",
-            cj_amount=our_output_value,
+            amount=our_output_value,
+            cj_amount=None,
             peer_count=analysis.cj_count if analysis.is_coinjoin else None,
             fee_received=0,
             total_maker_fees_paid=0,
@@ -178,6 +180,7 @@ def classify_wallet_transaction(
             # is net of our mining-fee contribution (inseparable on-chain).
             return ClassifiedTransaction(
                 role="maker",
+                amount=analysis.cj_amount,
                 cj_amount=analysis.cj_amount,
                 # Matches the equal-output count that the maker confirmation
                 # monitor backfills via ``detect_coinjoin_peer_count``.
@@ -206,6 +209,7 @@ def classify_wallet_transaction(
             cost = max(0, cost - analysis.cj_amount)
         return ClassifiedTransaction(
             role="taker",
+            amount=analysis.cj_amount,
             cj_amount=analysis.cj_amount,
             # Protocol taker rows record the number of *makers*; one of the
             # equal outputs is our own, so exclude it from the count.
@@ -264,7 +268,8 @@ def classify_wallet_transaction(
         )
     return ClassifiedTransaction(
         role="send",
-        cj_amount=amount,
+        amount=amount,
+        cj_amount=None,
         peer_count=None,
         fee_received=0,
         total_maker_fees_paid=0,
@@ -472,7 +477,7 @@ async def reconstruct_history_from_chain(
             confirmations=entry.confirmations,
             confirmed_at=timestamp,
             txid=entry.txid,
-            cj_amount=classified.cj_amount,
+            cj_amount=classified.cj_amount or 0,
             peer_count=classified.peer_count,
             counterparty_nicks="",
             fee_received=classified.fee_received,
@@ -489,6 +494,7 @@ async def reconstruct_history_from_chain(
             network=network,
             wallet_fingerprint=wallet_fingerprint,
             source="onchain",
+            amount=classified.amount,
         )
         append_history_entry(history_entry, data_dir)
         result.created += 1

--- a/jmwallet/tests/test_history.py
+++ b/jmwallet/tests/test_history.py
@@ -162,6 +162,23 @@ class TestTransactionHistoryEntry:
         assert entry.total_maker_fees_paid == 1000
         assert entry.net_fee == -1500
 
+    def test_transfer_amount_prefers_neutral_amount_with_legacy_fallback(self) -> None:
+        current = TransactionHistoryEntry(
+            timestamp="2024-01-01T00:00:00",
+            role="send",
+            amount=600_000,
+            cj_amount=0,
+        )
+        legacy = TransactionHistoryEntry(
+            timestamp="2024-01-01T00:00:00",
+            role="send",
+            amount=0,
+            cj_amount=500_000,
+        )
+
+        assert current.transfer_amount == 600_000
+        assert legacy.transfer_amount == 500_000
+
 
 class TestAppendAndReadHistory:
     """Tests for appending and reading history."""

--- a/jmwallet/tests/test_history_reconstruction.py
+++ b/jmwallet/tests/test_history_reconstruction.py
@@ -259,7 +259,8 @@ class TestClassifyWalletTransaction:
         result = classify_wallet_transaction(parsed, owned_inputs, owned_outputs, True, NETWORK)
         assert result is not None
         assert result.role == "send"
-        assert result.cj_amount == 50_000
+        assert result.amount == 50_000
+        assert result.cj_amount is None
         assert result.mining_fee_paid == 500
         assert result.net_fee == -500
         assert result.destination_address == _addr(FOREIGN_A)
@@ -287,7 +288,8 @@ class TestClassifyWalletTransaction:
         result = classify_wallet_transaction(parsed, owned_inputs, owned_outputs, True, NETWORK)
         assert result is not None
         assert result.role == "send"
-        assert result.cj_amount == 40_000
+        assert result.amount == 40_000
+        assert result.cj_amount is None
         assert result.destination_address == _addr(OUR_DEPOSIT)
         assert result.mining_fee_paid == 500
 
@@ -304,7 +306,8 @@ class TestClassifyWalletTransaction:
         result = classify_wallet_transaction(parsed, owned_inputs, owned_outputs, True, NETWORK)
         assert result is not None
         assert result.role == "send"
-        assert result.cj_amount == 24_890
+        assert result.amount == 24_890
+        assert result.cj_amount is None
         assert result.destination_address == _addr(OUR_M1_INTERNAL)
         assert result.change_address == ""
         assert result.mining_fee_paid == 110
@@ -325,7 +328,8 @@ class TestClassifyWalletTransaction:
         result = classify_wallet_transaction(parsed, owned_inputs, owned_outputs, True, NETWORK)
         assert result is not None
         assert result.role == "send"
-        assert result.cj_amount == 20_000
+        assert result.amount == 20_000
+        assert result.cj_amount is None
         assert result.destination_address == _addr(OUR_M1_INTERNAL)
         assert result.change_address == _addr(OUR_CHANGE)
         assert result.mining_fee_paid == 459
@@ -337,7 +341,8 @@ class TestClassifyWalletTransaction:
         result = classify_wallet_transaction(parsed, [], owned_outputs, False, NETWORK)
         assert result is not None
         assert result.role == "deposit"
-        assert result.cj_amount == 100_000
+        assert result.amount == 100_000
+        assert result.cj_amount is None
         assert result.destination_address == _addr(OUR_DEPOSIT)
         assert result.net_fee == 0
 
@@ -348,7 +353,8 @@ class TestClassifyWalletTransaction:
         result = classify_wallet_transaction(parsed, [], owned_outputs, False, NETWORK)
         assert result is not None
         assert result.role == "deposit"
-        assert result.cj_amount == CJ_AMOUNT
+        assert result.amount == CJ_AMOUNT
+        assert result.cj_amount is None
         assert result.peer_count == 3
 
     def test_unrelated_transaction_is_ignored(self) -> None:
@@ -370,12 +376,14 @@ class TestReconstructHistoryFromChain:
 
         deposit = entries[txids["fund"]]
         assert deposit.role == "deposit"
-        assert deposit.cj_amount == 100_000
+        assert deposit.amount == 100_000
+        assert deposit.cj_amount == 0
         assert deposit.source == "onchain"
         assert deposit.success is True
 
         cj = entries[txids["cj"]]
         assert cj.role == "taker"
+        assert cj.amount == CJ_AMOUNT
         assert cj.cj_amount == CJ_AMOUNT
         # 3 equal outputs, one ours -> 2 makers (protocol taker convention).
         assert cj.peer_count == 2
@@ -390,7 +398,8 @@ class TestReconstructHistoryFromChain:
 
         send = entries[txids["send"]]
         assert send.role == "send"
-        assert send.cj_amount == 50_000
+        assert send.amount == 50_000
+        assert send.cj_amount == 0
         assert send.mining_fee_paid == 500
         assert send.destination_address == _addr(FOREIGN_A)
         assert send.change_address == _addr(OUR_CHANGE_2)

--- a/jmwallet/tests/test_wallet_cli.py
+++ b/jmwallet/tests/test_wallet_cli.py
@@ -4,6 +4,8 @@ E2E tests for jm-wallet CLI commands.
 
 from __future__ import annotations
 
+import csv
+import io
 import os
 import tempfile
 from collections.abc import Iterator
@@ -1221,6 +1223,41 @@ def test_history_command_renders_in_chronological_order(monkeypatch):
             f" got positions oldest={idx_oldest}, middle={idx_middle},"
             f" newest={idx_newest}"
         )
+
+
+def test_history_command_uses_neutral_amount_for_send() -> None:
+    from jmwallet.history import append_history_entry, create_send_history_entry
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data_dir = Path(tmpdir)
+        entry = create_send_history_entry(
+            destination="bcrt1qdestination",
+            change_address="bcrt1qchange",
+            amount=666,
+            mining_fee=12,
+            source_mixdepth=0,
+            selected_utxos=[("ab" * 32, 0)],
+            txid="cd" * 32,
+        )
+        append_history_entry(entry, data_dir)
+
+        table = runner.invoke(
+            app,
+            ["history", "--all-wallets", "--data-dir", str(data_dir)],
+        )
+        assert table.exit_code == 0, table.stdout
+        send_line = next(line for line in table.stdout.splitlines() if entry.txid in line)
+        assert "666" in send_line
+
+        csv_result = runner.invoke(
+            app,
+            ["history", "--csv", "--all-wallets", "--data-dir", str(data_dir)],
+        )
+        assert csv_result.exit_code == 0, csv_result.stdout
+        rows = list(csv.DictReader(io.StringIO(csv_result.stdout)))
+        assert len(rows) == 1
+        assert rows[0]["amount"] == "666"
+        assert rows[0]["cj_amount"] == "0"
 
 
 def test_generate_with_output_auto_saves():

--- a/jmwalletd/src/jmwalletd/models.py
+++ b/jmwalletd/src/jmwalletd/models.py
@@ -265,7 +265,8 @@ class HistoryEntry(BaseModel):
     failure_reason: str = ""
     confirmations: int = 0
     txid: str = ""
-    cj_amount: int = 0
+    amount: int = 0
+    cj_amount: int | None = None
     peer_count: int | None = None
     counterparty_nicks: str = ""
     fee_received: int = 0
@@ -273,7 +274,7 @@ class HistoryEntry(BaseModel):
     total_maker_fees_paid: int = 0
     mining_fee_paid: int = 0
     net_fee: int = 0
-    source_mixdepth: int = 0
+    source_mixdepth: int | None = None
     destination_address: str = ""
     change_address: str = ""
     utxos_used: str = ""

--- a/jmwalletd/src/jmwalletd/routers/wallet_data.py
+++ b/jmwalletd/src/jmwalletd/routers/wallet_data.py
@@ -230,7 +230,7 @@ async def wallet_history(
             failure_reason=e.failure_reason,
             confirmations=e.confirmations,
             txid=e.txid,
-            amount=e.amount if e.amount != 0 else e.cj_amount,
+            amount=e.transfer_amount,
             cj_amount=e.cj_amount if (e.role in _cj_roles and e.cj_amount > 0) else None,
             peer_count=e.peer_count if e.role in _cj_roles else None,
             counterparty_nicks=e.counterparty_nicks if e.role in _cj_roles else "",

--- a/jmwalletd/src/jmwalletd/routers/wallet_data.py
+++ b/jmwalletd/src/jmwalletd/routers/wallet_data.py
@@ -219,6 +219,7 @@ async def wallet_history(
         wallet_fingerprint=ws.wallet_fingerprint,
     )
 
+    _cj_roles = {"maker", "taker"}
     history = [
         HistoryEntry(
             timestamp=e.timestamp,
@@ -229,15 +230,16 @@ async def wallet_history(
             failure_reason=e.failure_reason,
             confirmations=e.confirmations,
             txid=e.txid,
-            cj_amount=e.cj_amount,
-            peer_count=e.peer_count,
-            counterparty_nicks=e.counterparty_nicks,
+            amount=e.amount if e.amount != 0 else e.cj_amount,
+            cj_amount=e.cj_amount if (e.role in _cj_roles and e.cj_amount > 0) else None,
+            peer_count=e.peer_count if e.role in _cj_roles else None,
+            counterparty_nicks=e.counterparty_nicks if e.role in _cj_roles else "",
             fee_received=e.fee_received,
             txfee_contribution=e.txfee_contribution,
             total_maker_fees_paid=e.total_maker_fees_paid,
             mining_fee_paid=e.mining_fee_paid,
             net_fee=e.net_fee,
-            source_mixdepth=e.source_mixdepth,
+            source_mixdepth=e.source_mixdepth if e.role != "deposit" else None,
             destination_address=e.destination_address,
             change_address=e.change_address,
             utxos_used=e.utxos_used,

--- a/jmwalletd/tests/test_models.py
+++ b/jmwalletd/tests/test_models.py
@@ -420,3 +420,57 @@ class TestMiscModels:
     def test_wallet_history_response_defaults_empty(self) -> None:
         resp = WalletHistoryResponse()
         assert resp.history == []
+
+
+class TestHistoryEntryFields:
+    def test_deposit_entry_omits_cj_fields(self) -> None:
+        entry = HistoryEntry(
+            timestamp="2026-08-08T10:00:00",
+            role="deposit",
+            amount=500_000,
+            cj_amount=None,
+            source_mixdepth=None,
+            txid="ab" * 32,
+        )
+        data = entry.model_dump()
+        assert data["role"] == "deposit"
+        assert data["amount"] == 500_000
+        assert data["cj_amount"] is None
+        assert data["source_mixdepth"] is None
+
+    def test_send_entry_has_amount_and_mixdepth_but_no_cj_amount(self) -> None:
+        entry = HistoryEntry(
+            timestamp="2026-08-08T10:00:00",
+            role="send",
+            amount=100_000,
+            cj_amount=None,
+            source_mixdepth=0,
+            txid="cd" * 32,
+        )
+        data = entry.model_dump()
+        assert data["role"] == "send"
+        assert data["amount"] == 100_000
+        assert data["cj_amount"] is None
+        assert data["source_mixdepth"] == 0
+
+    def test_coinjoin_roles_include_cj_amount(self) -> None:
+        maker = HistoryEntry(
+            timestamp="2026-08-08T10:00:00",
+            role="maker",
+            amount=100_000,
+            cj_amount=100_000,
+            source_mixdepth=0,
+            txid="ef" * 32,
+        )
+        taker = HistoryEntry(
+            timestamp="2026-08-08T10:00:00",
+            role="taker",
+            amount=100_000,
+            cj_amount=100_000,
+            source_mixdepth=1,
+            txid="fe" * 32,
+        )
+        assert maker.amount == 100_000
+        assert maker.cj_amount == 100_000
+        assert taker.amount == 100_000
+        assert taker.cj_amount == 100_000

--- a/jmwalletd/tests/test_wallet_data_router.py
+++ b/jmwalletd/tests/test_wallet_data_router.py
@@ -1117,3 +1117,62 @@ class TestWalletHistory:
         client, token = authed_client
         resp = client.get("/api/v1/wallet/other_wallet.jmdat/history", headers=_auth_headers(token))
         assert resp.status_code in (401, 404)
+
+    def test_deposit_and_send_history_omits_coinjoin_fields(
+        self, authed_client: tuple[TestClient, str], data_dir: Path
+    ) -> None:
+        """Regression test for deposit/send history rows must surface neutral
+        transfer `amount` and omit CoinJoin fields (`cj_amount`, `source_mixdepth`) for deposit.
+        """
+        client, token = authed_client
+        get_daemon_state().wallet_service.wallet_fingerprint = "deadbeef"
+        from jmwallet.history import TransactionHistoryEntry, append_history_entry
+
+        deposit = TransactionHistoryEntry(
+            timestamp="2026-07-29T00:09:13",
+            completed_at="2026-07-29T00:09:13",
+            confirmed_at="2026-07-29T00:09:13",
+            role="deposit",
+            success=True,
+            confirmations=310,
+            txid="9a74a1b0a651ed48fb92e0f31323191f1c46b235eb2d706750335be2e2d63691",
+            amount=5_000_000_000,
+            cj_amount=0,
+            source_mixdepth=0,
+            destination_address="bcrt1qt8nd5dwmagnyppf3u5n9tah5xe9phqrxl5cs8x",
+            wallet_fingerprint="deadbeef",
+            source="onchain",
+        )
+        send = TransactionHistoryEntry(
+            timestamp="2026-07-29T01:00:00",
+            completed_at="2026-07-29T01:00:00",
+            role="send",
+            success=True,
+            txid="11223344556677889900aabbccddeeff11223344556677889900aabbccddeeff",
+            amount=500_000,
+            cj_amount=0,
+            source_mixdepth=1,
+            destination_address="bcrt1qexternaldest",
+            wallet_fingerprint="deadbeef",
+            source="protocol",
+        )
+        append_history_entry(deposit, data_dir=data_dir)
+        append_history_entry(send, data_dir=data_dir)
+
+        resp = client.get("/api/v1/wallet/test_wallet.jmdat/history", headers=_auth_headers(token))
+        assert resp.status_code == 200
+        history = {h["role"]: h for h in resp.json()["history"]}
+
+        dep_entry = history["deposit"]
+        assert dep_entry["amount"] == 5_000_000_000
+        assert dep_entry["cj_amount"] is None
+        assert dep_entry["source_mixdepth"] is None
+        assert dep_entry["peer_count"] is None
+        assert dep_entry["counterparty_nicks"] == ""
+
+        snd_entry = history["send"]
+        assert snd_entry["amount"] == 500_000
+        assert snd_entry["cj_amount"] is None
+        assert snd_entry["source_mixdepth"] == 1
+        assert snd_entry["peer_count"] is None
+        assert snd_entry["counterparty_nicks"] == ""

--- a/scripts/coinjoin_notifier.py
+++ b/scripts/coinjoin_notifier.py
@@ -156,7 +156,9 @@ def create_notification_message(entry: dict[str, str]) -> tuple[str, str, int]:
     role = entry.get("role", "unknown")
     success = entry.get("success", "True").lower() == "true"
     confirmations = int(entry.get("confirmations", 0) or 0)
-    cj_amount = int(entry.get("cj_amount", 0) or 0)
+    amount = int(entry.get("amount", 0) or 0)
+    if amount == 0:
+        amount = int(entry.get("cj_amount", 0) or 0)
     peer_count_str = entry.get("peer_count", "")
     peer_count = (
         int(peer_count_str)
@@ -195,7 +197,7 @@ def create_notification_message(entry: dict[str, str]) -> tuple[str, str, int]:
     # Build message - exclude sensitive information (txid, network, peer nicks)
     message_parts = [
         f"{role_emoji} Role: {role.capitalize()}",
-        f"💰 Amount: {format_satoshis(cj_amount)}",
+        f"💰 Amount: {format_satoshis(amount)}",
     ]
 
     # Only show peer count if known (takers know, makers don't)

--- a/tests/test_coinjoin_notifier.py
+++ b/tests/test_coinjoin_notifier.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_notifier() -> ModuleType:
+    script_path = Path(__file__).parents[1] / "scripts" / "coinjoin_notifier.py"
+    spec = importlib.util.spec_from_file_location("coinjoin_notifier", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_notification_uses_neutral_amount() -> None:
+    notifier = _load_notifier()
+
+    _title, message, _priority = notifier.create_notification_message(
+        {
+            "role": "send",
+            "success": "True",
+            "confirmations": "0",
+            "amount": "666",
+            "cj_amount": "0",
+        }
+    )
+
+    assert "(666 sats)" in message
+
+
+def test_notification_falls_back_to_legacy_cj_amount() -> None:
+    notifier = _load_notifier()
+
+    _title, message, _priority = notifier.create_notification_message(
+        {
+            "role": "maker",
+            "success": "True",
+            "confirmations": "1",
+            "cj_amount": "777",
+        }
+    )
+
+    assert "(777 sats)" in message


### PR DESCRIPTION
### Summary
Fixes #582 by introducing a generic `amount` field for all trans history roles while nullifying CoinJoin-specific fields (`cj_amount`, `source_mixdepth`) on non-collaborative history entries (`deposit` and `send`).

### Changes
- **Internal Models (`jmwallet`)**: Added `amount: int` to `TransactionHistoryEntry` and `ClassifiedTransaction`. Maintained positional CSV compatibility on disk by appending `amount` as the trailing column.
- **Reconstruction (`history_reconstruction.py`)**: Updated `classify_wallet_transaction` and `reconstruct_history_from_chain` to populate transfer values into `amount`, setting `cj_amount` to `None`/`0` for deposit and send roles.
- **API Models & Router (`jmwalletd`)**: Updated `HistoryEntry` schema with `amount`, making `cj_amount` and `source_mixdepth` optional (`int | None`). Filtered outgoing json history responses so non-collaborative roles return `null` for CoinJoin-only fields (`"cj_amount": null`, `"source_mixdepth": null`).
- **Tests**: Added regression unit tests for model schema serialization and api history endpoint responses.
