### PR TITLE
feat(direct-send): allow specifying explicit input UTXOs

### DIFF
--- a/jmwallet/src/jmwallet/wallet/spend.py
+++ b/jmwallet/src/jmwallet/wallet/spend.py
@@ -206,6 +206,119 @@ def select_spendable_utxos(
     return result
 
 
+def parse_outpoint(raw: str) -> tuple[str, int]:
+    """Parse a ``txid:vout`` outpoint string into ``(txid, vout)``.
+
+    The txid is lowercased so callers can compare it against
+    :attr:`UTXOInfo.txid` without worrying about the case the client used.
+
+    Raises:
+        ValueError: If the string is not a well-formed outpoint.
+    """
+    text = raw.strip()
+    txid, separator, vout_text = text.rpartition(":")
+    if not separator:
+        msg = f"Invalid input UTXO {raw!r}: expected format 'txid:vout'"
+        raise ValueError(msg)
+    if len(txid) != 64 or any(c not in "0123456789abcdefABCDEF" for c in txid):
+        msg = f"Invalid input UTXO {raw!r}: {txid!r} is not a 64-character hex txid"
+        raise ValueError(msg)
+    if not (vout_text.isascii() and vout_text.isdigit()):
+        msg = f"Invalid input UTXO {raw!r}: vout {vout_text!r} is not a non-negative integer"
+        raise ValueError(msg)
+    return txid.lower(), int(vout_text)
+
+
+def _find_owning_mixdepth(wallet: WalletService, txid: str, vout: int) -> int | None:
+    """Look for an outpoint in already-synced mixdepths other than the requested one.
+
+    Reads only :attr:`WalletService.utxo_cache` so an error path never triggers
+    a fresh sync. Returns ``None`` when the outpoint is not in the cache, which
+    just means we cannot say more than "not found".
+    """
+    for other_mixdepth, cached in wallet.utxo_cache.items():
+        for utxo in cached:
+            if utxo.txid == txid and utxo.vout == vout:
+                return other_mixdepth
+    return None
+
+
+async def resolve_input_utxos(
+    *,
+    wallet: WalletService,
+    backend: BlockchainBackend,
+    mixdepth: int,
+    input_utxos: list[str],
+) -> tuple[list[UTXOInfo], int | None]:
+    """Resolve explicit ``txid:vout`` strings into spendable :class:`UTXOInfo`.
+
+    Every listed outpoint must exist in *mixdepth*, be unfrozen, and be
+    signable by this wallet. Fidelity bonds are admitted only when their
+    timelock has already expired against chain median-time-past, since the
+    caller selected them deliberately. There is no fallback to automatic
+    selection: anything unusable raises :class:`ValueError` naming the reason.
+
+    Returns ``(utxos, locktime_cutoff)`` with the UTXOs in the order given.
+    ``locktime_cutoff`` is the median-time-past that was fetched to validate
+    fidelity bonds, or *None* when no bond was selected.
+    """
+    if not input_utxos:
+        msg = "input_utxos must not be empty; omit it to use automatic coin selection"
+        raise ValueError(msg)
+
+    outpoints: list[tuple[str, int]] = []
+    seen: set[tuple[str, int]] = set()
+    for raw in input_utxos:
+        outpoint = parse_outpoint(raw)
+        if outpoint in seen:
+            msg = f"Duplicate input UTXO {outpoint[0]}:{outpoint[1]}"
+            raise ValueError(msg)
+        seen.add(outpoint)
+        outpoints.append(outpoint)
+
+    available = {(u.txid, u.vout): u for u in await wallet.get_utxos(mixdepth)}
+
+    utxos: list[UTXOInfo] = []
+    for txid, vout in outpoints:
+        utxo = available.get((txid, vout))
+        if utxo is None:
+            owner = _find_owning_mixdepth(wallet, txid, vout)
+            if owner is not None:
+                msg = (
+                    f"Input UTXO {txid}:{vout} is in mixdepth {owner}, "
+                    f"not the requested mixdepth {mixdepth}"
+                )
+            else:
+                msg = f"Input UTXO {txid}:{vout} not found in mixdepth {mixdepth}"
+            raise ValueError(msg)
+        if utxo.frozen:
+            msg = f"Input UTXO {txid}:{vout} is frozen; unfreeze it before spending"
+            raise ValueError(msg)
+        utxos.append(utxo)
+
+    # Fidelity bonds need chain time to check expiry, so only pay for the
+    # median-time-past round trip when one was actually selected.
+    locktime_cutoff: int | None = None
+    if any(u.is_fidelity_bond for u in utxos):
+        locktime_cutoff = await backend.get_median_time_past()
+        for utxo in utxos:
+            if not utxo.is_fidelity_bond:
+                continue
+            if utxo.locktime is None or utxo.locktime >= locktime_cutoff:
+                msg = (
+                    f"Input UTXO {utxo.txid}:{utxo.vout} is a fidelity bond whose "
+                    f"timelock {utxo.locktime} has not passed chain time {locktime_cutoff}"
+                )
+                raise ValueError(msg)
+            if not _is_signable_fidelity_bond(wallet, utxo):
+                msg = (
+                    f"Input UTXO {utxo.txid}:{utxo.vout} is a fidelity bond this wallet cannot sign"
+                )
+                raise ValueError(msg)
+
+    return utxos, locktime_cutoff
+
+
 def _is_signable_fidelity_bond(wallet: WalletService, utxo: UTXOInfo) -> bool:
     """Return whether this wallet derives the script key for a bond UTXO."""
     if not utxo.is_fidelity_bond or utxo.locktime is None or not utxo.is_p2wsh:
@@ -379,8 +492,14 @@ async def prepare_direct_send(
     fee_target_blocks: int = 6,
     tx_fee_factor: float = 0.0,
     max_fee_rate_sat_vb: float = DEFAULT_MAX_FEE_RATE_SAT_VB,
+    input_utxos: list[str] | None = None,
 ) -> SignedDirectTx:
     """Build and sign a direct-send transaction WITHOUT broadcasting.
+
+    When *input_utxos* is given as a list of ``txid:vout`` strings, exactly
+    those UTXOs are spent and automatic coin selection is skipped entirely;
+    anything unusable raises :class:`ValueError` rather than falling back. An
+    empty list is an error — omit the argument for automatic selection.
 
     Returns a :class:`SignedDirectTx` containing the signed hex and all
     metadata needed to broadcast and record a history entry. Callers that want
@@ -416,7 +535,16 @@ async def prepare_direct_send(
     # --- UTXO selection ---
     utxos: list[UTXOInfo]
     locktime_cutoff: int | None = None
-    if amount_sats == 0:
+    if input_utxos is not None:
+        # Explicit coin control (issue #587): spend exactly what was listed,
+        # including for sweeps, with no fallback to automatic selection.
+        utxos, locktime_cutoff = await resolve_input_utxos(
+            wallet=wallet,
+            backend=backend,
+            mixdepth=mixdepth,
+            input_utxos=input_utxos,
+        )
+    elif amount_sats == 0:
         # Sweep regular coins by default. If there are none, admit expired
         # hot-wallet bonds. This supports explicit bond-redemption flows that
         # freeze every other coin without making bonds part of normal
@@ -561,6 +689,7 @@ async def direct_send(
     fee_target_blocks: int = 6,
     tx_fee_factor: float = 0.0,
     max_fee_rate_sat_vb: float = DEFAULT_MAX_FEE_RATE_SAT_VB,
+    input_utxos: list[str] | None = None,
 ) -> DirectSendResult:
     """Build, sign, and broadcast a direct (non-CoinJoin) transaction.
 
@@ -591,6 +720,12 @@ async def direct_send(
         :class:`ExcessiveFeeRateError` when it exceeds this value.  Defaults
         to :data:`DEFAULT_MAX_FEE_RATE_SAT_VB`; daemon and CLI callers wire
         this from ``settings.wallet.max_fee_rate_sat_vb``.
+    input_utxos:
+        Optional explicit list of ``txid:vout`` outpoints to spend.  When
+        given, coin selection is skipped and exactly these UTXOs are used
+        (also for sweeps); they must all be unfrozen and in *mixdepth*, or
+        :class:`ValueError` is raised naming the reason.  An empty list is an
+        error; pass *None* for automatic selection.
 
     Returns
     -------
@@ -606,6 +741,7 @@ async def direct_send(
         fee_target_blocks=fee_target_blocks,
         tx_fee_factor=tx_fee_factor,
         max_fee_rate_sat_vb=max_fee_rate_sat_vb,
+        input_utxos=input_utxos,
     )
 
     tx_bytes_len = len(bytes.fromhex(prepared.tx_hex))

--- a/jmwallet/tests/test_spend.py
+++ b/jmwallet/tests/test_spend.py
@@ -23,6 +23,7 @@ from jmwallet.wallet.spend import (
     direct_send,
     enforce_fee_rate_cap,
     estimate_fee,
+    parse_outpoint,
     prepare_direct_send,
     select_spendable_utxos,
 )
@@ -386,6 +387,9 @@ def _make_mock_wallet(utxos: list[UTXOInfo], change_addr: str = REGTEST_P2WPKH_A
     wallet = MagicMock()
     wallet.network = "regtest"
     wallet.get_utxos = AsyncMock(return_value=utxos)
+    # Real WalletService always exposes a dict here; explicit-input resolution
+    # reads it to tell "wrong mixdepth" apart from "not found".
+    wallet.utxo_cache = {0: utxos}
     # Raise ValueError so direct_send falls back to get_utxos for coin selection
     wallet.select_utxos = MagicMock(side_effect=ValueError("no coin selection in tests"))
     wallet.get_key_for_address = MagicMock(return_value=_make_mock_key())
@@ -969,3 +973,350 @@ class TestPrepareDirectSend:
         assert result.change_address == ""
         assert result.source_addresses == ["bcrt1qinput"]
         backend.broadcast_transaction.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# parse_outpoint
+# ---------------------------------------------------------------------------
+
+
+class TestParseOutpoint:
+    """Unit tests for txid:vout parsing (issue #587)."""
+
+    def test_valid(self) -> None:
+        assert parse_outpoint(f"{'aa' * 32}:3") == ("aa" * 32, 3)
+
+    def test_uppercase_txid_is_normalized(self) -> None:
+        assert parse_outpoint(f"{'AB' * 32}:0") == ("ab" * 32, 0)
+
+    def test_surrounding_whitespace_is_tolerated(self) -> None:
+        assert parse_outpoint(f"  {'aa' * 32}:1  ") == ("aa" * 32, 1)
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "aa" * 32,  # no separator
+            f"{'aa' * 31}:0",  # txid too short
+            f"{'aa' * 33}:0",  # txid too long
+            f"{'zz' * 32}:0",  # not hex
+            f"{'aa' * 32}:",  # missing vout
+            f"{'aa' * 32}:-1",  # negative vout
+            f"{'aa' * 32}:x",  # non-numeric vout
+            f"{'aa' * 32}:1.0",  # non-integer vout
+            "",
+        ],
+    )
+    def test_malformed_raises(self, raw: str) -> None:
+        with pytest.raises(ValueError, match="Invalid input UTXO"):
+            parse_outpoint(raw)
+
+
+# ---------------------------------------------------------------------------
+# prepare_direct_send with explicit input_utxos (issue #587)
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareDirectSendExplicitInputs:
+    """Explicit coin control: spend exactly the listed UTXOs, or fail loudly."""
+
+    @pytest.mark.anyio
+    async def test_spends_only_the_listed_utxos(self) -> None:
+        chosen = _make_utxo(txid="aa" * 32, vout=0, value=200_000)
+        other = _make_utxo(txid="bb" * 32, vout=1, value=500_000)
+        wallet = _make_mock_wallet([chosen, other])
+        backend = _make_mock_backend()
+
+        result = await prepare_direct_send(
+            wallet=wallet,
+            backend=backend,
+            mixdepth=0,
+            amount_sats=50_000,
+            destination=REGTEST_P2WPKH_ADDR,
+            fee_rate=1.0,
+            input_utxos=[f"{'aa' * 32}:0"],
+        )
+
+        assert result.selected_utxos == [("aa" * 32, 0)]
+        assert result.num_inputs == 1
+        # Automatic coin selection must not run at all.
+        wallet.select_utxos.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_input_order_is_preserved(self) -> None:
+        first = _make_utxo(txid="aa" * 32, vout=0, value=200_000)
+        second = _make_utxo(txid="bb" * 32, vout=1, value=200_000)
+        wallet = _make_mock_wallet([first, second])
+        backend = _make_mock_backend()
+
+        result = await prepare_direct_send(
+            wallet=wallet,
+            backend=backend,
+            mixdepth=0,
+            amount_sats=50_000,
+            destination=REGTEST_P2WPKH_ADDR,
+            fee_rate=1.0,
+            input_utxos=[f"{'bb' * 32}:1", f"{'aa' * 32}:0"],
+        )
+
+        assert result.selected_utxos == [("bb" * 32, 1), ("aa" * 32, 0)]
+
+    @pytest.mark.anyio
+    async def test_sweep_spends_exactly_the_listed_utxos(self) -> None:
+        """amount_sats=0 + explicit inputs sweeps those inputs, not the mixdepth."""
+        chosen = _make_utxo(txid="aa" * 32, vout=0, value=200_000)
+        untouched = _make_utxo(txid="bb" * 32, vout=1, value=500_000)
+        wallet = _make_mock_wallet([chosen, untouched])
+        backend = _make_mock_backend()
+
+        result = await prepare_direct_send(
+            wallet=wallet,
+            backend=backend,
+            mixdepth=0,
+            amount_sats=0,
+            destination=REGTEST_P2WPKH_ADDR,
+            fee_rate=1.0,
+            input_utxos=[f"{'aa' * 32}:0"],
+        )
+
+        assert result.selected_utxos == [("aa" * 32, 0)]
+        assert result.change_amount == 0
+        assert result.send_amount == 200_000 - result.fee
+
+    @pytest.mark.anyio
+    async def test_empty_list_is_an_error(self) -> None:
+        wallet = _make_mock_wallet([_make_utxo(value=200_000)])
+        backend = _make_mock_backend()
+
+        with pytest.raises(ValueError, match="must not be empty"):
+            await prepare_direct_send(
+                wallet=wallet,
+                backend=backend,
+                mixdepth=0,
+                amount_sats=50_000,
+                destination=REGTEST_P2WPKH_ADDR,
+                fee_rate=1.0,
+                input_utxos=[],
+            )
+
+    @pytest.mark.anyio
+    async def test_frozen_utxo_is_rejected(self) -> None:
+        frozen = _make_utxo(txid="aa" * 32, vout=0, value=200_000, frozen=True)
+        wallet = _make_mock_wallet([frozen])
+        backend = _make_mock_backend()
+
+        with pytest.raises(ValueError, match="is frozen"):
+            await prepare_direct_send(
+                wallet=wallet,
+                backend=backend,
+                mixdepth=0,
+                amount_sats=50_000,
+                destination=REGTEST_P2WPKH_ADDR,
+                fee_rate=1.0,
+                input_utxos=[f"{'aa' * 32}:0"],
+            )
+
+    @pytest.mark.anyio
+    async def test_unknown_utxo_is_rejected(self) -> None:
+        wallet = _make_mock_wallet([_make_utxo(txid="aa" * 32, vout=0, value=200_000)])
+        backend = _make_mock_backend()
+
+        with pytest.raises(ValueError, match="not found in mixdepth 0"):
+            await prepare_direct_send(
+                wallet=wallet,
+                backend=backend,
+                mixdepth=0,
+                amount_sats=50_000,
+                destination=REGTEST_P2WPKH_ADDR,
+                fee_rate=1.0,
+                input_utxos=[f"{'cc' * 32}:0"],
+            )
+
+    @pytest.mark.anyio
+    async def test_utxo_from_another_mixdepth_names_that_mixdepth(self) -> None:
+        in_md0 = _make_utxo(txid="aa" * 32, vout=0, value=200_000)
+        in_md2 = _make_utxo(txid="bb" * 32, vout=0, value=200_000, mixdepth=2)
+        wallet = _make_mock_wallet([in_md0])
+        wallet.utxo_cache = {0: [in_md0], 2: [in_md2]}
+        backend = _make_mock_backend()
+
+        with pytest.raises(ValueError, match="is in mixdepth 2, not the requested mixdepth 0"):
+            await prepare_direct_send(
+                wallet=wallet,
+                backend=backend,
+                mixdepth=0,
+                amount_sats=50_000,
+                destination=REGTEST_P2WPKH_ADDR,
+                fee_rate=1.0,
+                input_utxos=[f"{'bb' * 32}:0"],
+            )
+
+    @pytest.mark.anyio
+    async def test_duplicate_outpoint_is_rejected(self) -> None:
+        wallet = _make_mock_wallet([_make_utxo(txid="aa" * 32, vout=0, value=200_000)])
+        backend = _make_mock_backend()
+
+        with pytest.raises(ValueError, match="Duplicate input UTXO"):
+            await prepare_direct_send(
+                wallet=wallet,
+                backend=backend,
+                mixdepth=0,
+                amount_sats=50_000,
+                destination=REGTEST_P2WPKH_ADDR,
+                fee_rate=1.0,
+                input_utxos=[f"{'aa' * 32}:0", f"{'AA' * 32}:0"],
+            )
+
+    @pytest.mark.anyio
+    async def test_insufficient_value_is_rejected_without_fallback(self) -> None:
+        """A too-small explicit input must error, not silently pull in the big one."""
+        small = _make_utxo(txid="aa" * 32, vout=0, value=10_000)
+        big = _make_utxo(txid="bb" * 32, vout=1, value=5_000_000)
+        wallet = _make_mock_wallet([small, big])
+        backend = _make_mock_backend()
+
+        with pytest.raises(ValueError, match="Insufficient funds"):
+            await prepare_direct_send(
+                wallet=wallet,
+                backend=backend,
+                mixdepth=0,
+                amount_sats=1_000_000,
+                destination=REGTEST_P2WPKH_ADDR,
+                fee_rate=1.0,
+                input_utxos=[f"{'aa' * 32}:0"],
+            )
+
+    @pytest.mark.anyio
+    async def test_expired_fidelity_bond_can_be_selected_explicitly(self) -> None:
+        past_locktime = int(time.time()) - 100_000
+        bond = _make_utxo(
+            txid="aa" * 32,
+            vout=0,
+            value=500_000,
+            scriptpubkey=_bond_scriptpubkey(past_locktime),
+            locktime=past_locktime,
+        )
+        wallet = _make_mock_wallet([bond, _make_utxo(txid="bb" * 32, vout=1, value=100_000)])
+        backend = _make_mock_backend()
+
+        result = await prepare_direct_send(
+            wallet=wallet,
+            backend=backend,
+            mixdepth=0,
+            amount_sats=0,
+            destination=REGTEST_P2WPKH_ADDR,
+            fee_rate=1.0,
+            input_utxos=[f"{'aa' * 32}:0"],
+        )
+
+        assert result.selected_utxos == [("aa" * 32, 0)]
+        assert int.from_bytes(bytes.fromhex(result.tx_hex)[-4:], "little") == past_locktime
+
+    @pytest.mark.anyio
+    async def test_unexpired_fidelity_bond_is_rejected(self) -> None:
+        future_locktime = int(time.time()) + 100_000
+        bond = _make_utxo(
+            txid="aa" * 32,
+            vout=0,
+            value=500_000,
+            scriptpubkey=_bond_scriptpubkey(future_locktime),
+            locktime=future_locktime,
+        )
+        wallet = _make_mock_wallet([bond])
+        backend = _make_mock_backend()
+
+        with pytest.raises(ValueError, match="timelock .* has not passed chain time"):
+            await prepare_direct_send(
+                wallet=wallet,
+                backend=backend,
+                mixdepth=0,
+                amount_sats=0,
+                destination=REGTEST_P2WPKH_ADDR,
+                fee_rate=1.0,
+                input_utxos=[f"{'aa' * 32}:0"],
+            )
+
+    @pytest.mark.anyio
+    async def test_unsignable_fidelity_bond_is_rejected(self) -> None:
+        """An expired bond whose script this wallet does not derive is refused."""
+        past_locktime = int(time.time()) - 100_000
+        bond = _make_utxo(
+            txid="aa" * 32,
+            vout=0,
+            value=500_000,
+            scriptpubkey="0020" + "cd" * 32,  # does not match mk_freeze_script
+            locktime=past_locktime,
+        )
+        wallet = _make_mock_wallet([bond])
+        backend = _make_mock_backend()
+
+        with pytest.raises(ValueError, match="cannot sign"):
+            await prepare_direct_send(
+                wallet=wallet,
+                backend=backend,
+                mixdepth=0,
+                amount_sats=0,
+                destination=REGTEST_P2WPKH_ADDR,
+                fee_rate=1.0,
+                input_utxos=[f"{'aa' * 32}:0"],
+            )
+
+    @pytest.mark.anyio
+    async def test_no_median_time_past_lookup_without_bonds(self) -> None:
+        wallet = _make_mock_wallet([_make_utxo(txid="aa" * 32, vout=0, value=200_000)])
+        backend = _make_mock_backend()
+
+        await prepare_direct_send(
+            wallet=wallet,
+            backend=backend,
+            mixdepth=0,
+            amount_sats=50_000,
+            destination=REGTEST_P2WPKH_ADDR,
+            fee_rate=1.0,
+            input_utxos=[f"{'aa' * 32}:0"],
+        )
+
+        backend.get_median_time_past.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_omitting_input_utxos_keeps_automatic_selection(self) -> None:
+        """Backward compatibility: omitting the argument selects as before."""
+        utxos = [_make_utxo(txid="aa" * 32, vout=0, value=200_000)]
+        wallet = _make_mock_wallet(utxos)
+        backend = _make_mock_backend()
+
+        result = await prepare_direct_send(
+            wallet=wallet,
+            backend=backend,
+            mixdepth=0,
+            amount_sats=50_000,
+            destination=REGTEST_P2WPKH_ADDR,
+            fee_rate=1.0,
+        )
+
+        assert result.selected_utxos == [("aa" * 32, 0)]
+        wallet.select_utxos.assert_called_once()
+
+
+class TestDirectSendExplicitInputs:
+    """input_utxos must reach prepare_direct_send through direct_send."""
+
+    @pytest.mark.anyio
+    async def test_passthrough(self) -> None:
+        chosen = _make_utxo(txid="aa" * 32, vout=0, value=200_000)
+        other = _make_utxo(txid="bb" * 32, vout=1, value=900_000)
+        wallet = _make_mock_wallet([chosen, other])
+        backend = _make_mock_backend()
+
+        result = await direct_send(
+            wallet=wallet,
+            backend=backend,
+            mixdepth=0,
+            amount_sats=50_000,
+            destination=REGTEST_P2WPKH_ADDR,
+            fee_rate=1.0,
+            input_utxos=[f"{'aa' * 32}:0"],
+        )
+
+        assert result.num_inputs == 1
+        assert [i["outpoint"] for i in result.inputs] == [f"{'aa' * 32}:0"]
+        backend.broadcast_transaction.assert_called_once()

--- a/jmwalletd/src/jmwalletd/models.py
+++ b/jmwalletd/src/jmwalletd/models.py
@@ -354,12 +354,22 @@ class DirectSendRequest(BaseModel):
 
     ``amount_sats`` is the amount to send in satoshis; ``0`` means sweep the
     entire mixdepth. ``mixdepth`` is the source account index.
+
+    ``input_utxos`` is an optional explicit list of ``"txid:vout"`` strings
+    (issue #587). When given, exactly those UTXOs are spent and automatic
+    coin selection is skipped entirely, including for sweeps
+    (``amount_sats: 0`` + ``input_utxos`` sweeps only the listed inputs).
+    Every listed UTXO must already be unfrozen and belong to ``mixdepth``;
+    anything unusable is rejected with a reason rather than falling back to
+    automatic selection. Omit the field (the default) to keep the previous
+    auto-selecting behavior; an explicit empty list is always an error.
     """
 
     mixdepth: int = Field(..., ge=0)
     amount_sats: int = Field(..., ge=0, le=MAX_MONEY_SATS)
     destination: str
     txfee: int | None = Field(default=None, ge=0)
+    input_utxos: list[str] | None = None
 
 
 class DirectSendResponse(BaseModel):

--- a/jmwalletd/src/jmwalletd/routers/coinjoin.py
+++ b/jmwalletd/src/jmwalletd/routers/coinjoin.py
@@ -125,6 +125,7 @@ async def direct_send(
                 else settings.taker.tx_fee_factor
             ),
             max_fee_rate_sat_vb=settings.wallet.max_fee_rate_sat_vb,
+            input_utxos=body.input_utxos,
         )
     except ValueError as exc:
         raise InvalidRequestFormat(str(exc)) from exc

--- a/jmwalletd/src/jmwalletd/send.py
+++ b/jmwalletd/src/jmwalletd/send.py
@@ -36,6 +36,7 @@ async def do_direct_send(
     fee_target_blocks: int | None = None,
     tx_fee_factor: float = 0.0,
     max_fee_rate_sat_vb: float = DEFAULT_MAX_FEE_RATE_SAT_VB,
+    input_utxos: list[str] | None = None,
 ) -> DirectSendResult:
     """Build, sign, broadcast, and record a direct (non-coinjoin) transaction.
 
@@ -43,6 +44,10 @@ async def do_direct_send(
     drives backend estimation (``None`` keeps the spend module's default
     target). ``tx_fee_factor`` applies the reference fee-rate randomization,
     and ``max_fee_rate_sat_vb`` applies the operator's configured hard cap.
+    ``input_utxos``, when given, spends exactly those ``txid:vout`` outpoints
+    instead of running automatic coin selection (issue #587); see
+    :func:`jmwallet.wallet.spend.prepare_direct_send` for the validation
+    rules.
 
     Follows the same two-phase history-write pattern as the CLI send command:
 
@@ -89,6 +94,7 @@ async def do_direct_send(
         fee_rate=fee_rate,
         tx_fee_factor=tx_fee_factor,
         max_fee_rate_sat_vb=max_fee_rate_sat_vb,
+        input_utxos=input_utxos,
         **extra_kwargs,
     )
 

--- a/jmwalletd/tests/test_coinjoin_router.py
+++ b/jmwalletd/tests/test_coinjoin_router.py
@@ -144,6 +144,89 @@ class TestDirectSend:
         )
         assert resp.status_code == 400
 
+    @patch("jmwalletd.send.do_direct_send")
+    def test_direct_send_forwards_input_utxos(
+        self,
+        mock_send: AsyncMock,
+        authed_client: tuple[TestClient, str],
+    ) -> None:
+        """Explicit input UTXOs (issue #587) reach do_direct_send unchanged."""
+        client, token = authed_client
+        mock_send.return_value = Mock(
+            txid="txid123",
+            tx_hex="rawhex",
+            hex="rawhex",
+            inputs=[],
+            outputs=[],
+            locktime=0,
+            version=2,
+        )
+        outpoint = f"{'aa' * 32}:0"
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/taker/direct-send",
+            json={
+                "mixdepth": 0,
+                "amount_sats": 1000,
+                "destination": "bcrt1qdest",
+                "input_utxos": [outpoint],
+            },
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 200
+        assert mock_send.call_args.kwargs["input_utxos"] == [outpoint]
+
+    @patch("jmwalletd.send.do_direct_send")
+    def test_direct_send_omitted_input_utxos_is_none(
+        self,
+        mock_send: AsyncMock,
+        authed_client: tuple[TestClient, str],
+    ) -> None:
+        client, token = authed_client
+        mock_send.return_value = Mock(
+            txid="txid123",
+            tx_hex="rawhex",
+            hex="rawhex",
+            inputs=[],
+            outputs=[],
+            locktime=0,
+            version=2,
+        )
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/taker/direct-send",
+            json={"mixdepth": 0, "amount_sats": 1000, "destination": "bcrt1qdest"},
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 200
+        assert mock_send.call_args.kwargs["input_utxos"] is None
+
+    @patch("jmwalletd.send.do_direct_send")
+    def test_direct_send_rejects_unusable_input_utxo(
+        self,
+        mock_send: AsyncMock,
+        authed_client: tuple[TestClient, str],
+    ) -> None:
+        """A ValueError from the wallet layer (frozen/not-found/etc.) becomes a 400."""
+        client, token = authed_client
+        mock_send.side_effect = ValueError(f"Input UTXO {'aa' * 32}:0 not found in mixdepth 0")
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/taker/direct-send",
+            json={
+                "mixdepth": 0,
+                "amount_sats": 1000,
+                "destination": "bcrt1qdest",
+                "input_utxos": [f"{'aa' * 32}:0"],
+            },
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 400
+        assert "not found in mixdepth 0" in resp.json()["message"]
+
 
 class TestDoCoinjoin:
     def test_start_coinjoin_requires_mnemonic(self, authed_client: tuple[TestClient, str]) -> None:

--- a/jmwalletd/tests/test_send.py
+++ b/jmwalletd/tests/test_send.py
@@ -212,6 +212,47 @@ async def test_direct_send_forwards_fee_overrides(
 @patch("jmwalletd.send.create_send_history_entry")
 @patch("jmwalletd.send.prepare_direct_send", new_callable=AsyncMock)
 @patch("jmwalletd._backend.get_backend", new_callable=AsyncMock)
+async def test_direct_send_forwards_input_utxos(
+    mock_get_backend: AsyncMock,
+    mock_prepare_direct_send: AsyncMock,
+    mock_create_entry: MagicMock,
+    mock_append_entry: MagicMock,
+    mock_update_entry: MagicMock,
+) -> None:
+    """Explicit input UTXOs (issue #587) reach prepare_direct_send unchanged."""
+    wallet = MagicMock(data_dir=None, network="regtest", wallet_fingerprint="aabbccdd")
+    wallet.sync_with_registered_bonds = AsyncMock()
+    backend = MagicMock()
+    backend.broadcast_transaction = AsyncMock(return_value="txid_123")
+    mock_get_backend.return_value = backend
+    mock_prepare_direct_send.return_value = _make_prepared_tx()
+
+    await do_direct_send(
+        wallet_service=wallet,
+        mixdepth=0,
+        amount_sats=50_000,
+        destination="bcrt1qdestination",
+        input_utxos=[f"{'aa' * 32}:0"],
+    )
+
+    assert mock_prepare_direct_send.call_args.kwargs["input_utxos"] == [f"{'aa' * 32}:0"]
+
+    await do_direct_send(
+        wallet_service=wallet,
+        mixdepth=0,
+        amount_sats=50_000,
+        destination="bcrt1qdestination",
+    )
+
+    assert mock_prepare_direct_send.call_args.kwargs["input_utxos"] is None
+
+
+@pytest.mark.asyncio
+@patch("jmwalletd.send.update_send_awaiting_broadcast")
+@patch("jmwalletd.send.append_history_entry")
+@patch("jmwalletd.send.create_send_history_entry")
+@patch("jmwalletd.send.prepare_direct_send", new_callable=AsyncMock)
+@patch("jmwalletd._backend.get_backend", new_callable=AsyncMock)
 async def test_direct_send_uses_local_txid_when_backend_omits_it(
     mock_get_backend: AsyncMock,
     mock_prepare_direct_send: AsyncMock,


### PR DESCRIPTION
Closes #587 (core + jmwalletd part; CLI support tracked as a follow-up per the issue discussion).

## What
Adds an optional `input_utxos` field (list of `"txid:vout"` strings) to direct-send so a client can pin exactly which coins get spent instead of relying on automatic selection.

## Behaviour
- utxos must already be unfrozen — this endpoint does not freeze/unfreeze anything itself
- every listed utxo must belong to the requested `mixdepth`, error otherwise
- `amount_sats: 0` + `input_utxos` sweeps exactly those inputs, nothing else
- fidelity bonds are only accepted if expired and signable by this wallet, and only when explicitly listed
- if the tx can't be built from exactly the given inputs, it errors with a reason (frozen / not found / wrong mixdepth / insufficient value / bond not expired / bond not signable) — no silent fallback to auto selection
- empty list is always an error, not "no preference"
- omitting the field keeps today's behaviour unchanged

## Where
- `jmwallet/src/jmwallet/wallet/spend.py` — `parse_outpoint`, `resolve_input_utxos`, and `prepare_direct_send`/`direct_send` accept the explicit list
- `jmwalletd/src/jmwalletd/models.py` — `DirectSendRequest.input_utxos`
- `jmwalletd/src/jmwalletd/send.py`, `jmwalletd/src/jmwalletd/routers/coinjoin.py` — pass it through to the wallet layer

## Test plan
- [x] `pytest jmwallet jmwalletd` — full suite green except the 7 pre-existing WSL-only chmod failures in `test_utxo_metadata.py` (unrelated, root bypasses permission checks)
- [x] new unit tests for `parse_outpoint` / `resolve_input_utxos` / `prepare_direct_send` covering exact-spend, sweep, ordering, empty list, frozen, not-found, wrong-mixdepth, duplicates, insufficient value, expired/unexpired/unsignable bonds
- [x] new `jmwalletd` tests covering request forwarding and the ValueError -> 400 mapping
- [x] ruff clean

## Follow-up (separate PR, per discussion in #587)
`--input-utxo TXID:VOUT` on `jm-wallet send` / `jm-taker coinjoin`, mutually exclusive with `--select-utxos`, and eventually the same for `docoinjoin`.