### PR TITLE
feat(jm-wallet): --input-utxo flag for send

### DIFF
--- a/completions/jm-wallet.bash
+++ b/completions/jm-wallet.bash
@@ -69,7 +69,7 @@ _jm_wallet_completion() {
         COMPREPLY=( $(compgen -W "--help --mnemonic-file -f --prompt-bip39-passphrase --network -n --rpc-url --start-height --scan-depth --data-dir --config-file --log-level -l" -- "$cur") )
         ;;
       send)
-        COMPREPLY=( $(compgen -W "--help --amount -a --mnemonic-file -f --prompt-bip39-passphrase --mixdepth -m --fee-rate --block-target --network -n --backend -b --rpc-url --neutrino-url --broadcast --yes -y --select-utxos -s --data-dir --config-file --log-level -l" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--help --amount -a --mnemonic-file -f --prompt-bip39-passphrase --mixdepth -m --fee-rate --block-target --network -n --backend -b --rpc-url --neutrino-url --broadcast --yes -y --select-utxos -s --input-utxo --data-dir --config-file --log-level -l" -- "$cur") )
         ;;
       showseed)
         COMPREPLY=( $(compgen -W "--help --mnemonic-file -f --password -p --numbered --yes -y" -- "$cur") )

--- a/completions/jm-wallet.zsh
+++ b/completions/jm-wallet.zsh
@@ -288,6 +288,7 @@ _jm_wallet() {
             '--broadcast[Broadcast the transaction (use --no-broadcast to skip)]' \
             '--yes[Skip confirmation prompt]' \
             '--select-utxos[Interactively select UTXOs (fzf-like TUI)]' \
+            '--input-utxo=[Explicit input UTXO as txid\:vout (repeatable). Spends exactly the given UTXOs (also for sweeps) instead of auto-selecting; every UTXO must already be unfrozen and belong to --mixdepth. Mutually exclusive with --select-utxos.]: :' \
             '--data-dir=[Data directory (default\: ~/.joinmarket-ng or $JOINMARKET_DATA_DIR)]:file:_files' \
             '--config-file=[Config file path (decoupled from data dir). Defaults to <data-dir>/config.toml]:file:_files' \
             '--log-level=[Log level]: :' \

--- a/jmwallet/src/jmwallet/cli/send.py
+++ b/jmwallet/src/jmwallet/cli/send.py
@@ -208,6 +208,16 @@ def send(
             help="Interactively select UTXOs (fzf-like TUI)",
         ),
     ] = False,
+    input_utxo: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--input-utxo",
+            help="Explicit input UTXO as txid:vout (repeatable). Spends exactly "
+            "the given UTXOs (also for sweeps) instead of auto-selecting; every "
+            "UTXO must already be unfrozen and belong to --mixdepth. Mutually "
+            "exclusive with --select-utxos.",
+        ),
+    ] = None,
     data_dir: Annotated[
         Path | None,
         typer.Option(
@@ -236,6 +246,10 @@ def send(
 
     if fee_rate is not None and block_target is not None:
         logger.error("Cannot specify both --fee-rate and --block-target")
+        raise typer.Exit(1)
+
+    if select_utxos and input_utxo:
+        logger.error("Cannot specify both --select-utxos and --input-utxo")
         raise typer.Exit(1)
 
     # Effective cap comes from settings (with hard-coded fallback). The same
@@ -301,6 +315,7 @@ def send(
             max_fee_rate_sat_vb=max_fee_rate,
             max_sats_freeze_reuse=settings.wallet.max_sats_freeze_reuse,
             reconstruct_history=settings.wallet.reconstruct_history,
+            input_utxos=input_utxo,
         )
     )
 
@@ -322,6 +337,7 @@ async def _send_transaction(
     max_fee_rate_sat_vb: float = MAX_MANUAL_FEE_RATE_SAT_VB,
     max_sats_freeze_reuse: int = -1,
     reconstruct_history: bool = True,
+    input_utxos: list[str] | None = None,
 ) -> None:
     """Send transaction implementation."""
     from jmwallet.backends.descriptor_wallet import (
@@ -437,13 +453,30 @@ async def _send_transaction(
         # backends (neutrino) scan the bond addresses directly inside this call.
         await wallet.sync_with_registered_bonds()
 
-        # Pick the inputs (interactive or automatic; may derive the mixdepth)
-        selection = await _select_input_utxos(
-            wallet, backend_settings, amount, mixdepth, interactive_utxo_selection
-        )
-        if selection is None:
-            return
-        utxos, mixdepth = selection
+        # Pick the inputs: explicit --input-utxo, interactive, or automatic.
+        if input_utxos:
+            from jmwallet.wallet.spend import resolve_input_utxos
+
+            resolved_mixdepth = mixdepth if mixdepth is not None else 0
+            try:
+                utxos, _locktime_cutoff = await resolve_input_utxos(
+                    wallet=wallet,
+                    backend=backend,
+                    mixdepth=resolved_mixdepth,
+                    input_utxos=input_utxos,
+                )
+            except ValueError as e:
+                logger.error(str(e))
+                raise typer.Exit(1)
+            mixdepth = resolved_mixdepth
+            logger.info(f"Using {len(utxos)} explicitly selected UTXO(s) from mixdepth {mixdepth}")
+        else:
+            selection = await _select_input_utxos(
+                wallet, backend_settings, amount, mixdepth, interactive_utxo_selection
+            )
+            if selection is None:
+                return
+            utxos, mixdepth = selection
 
         # Calculate totals based on selected UTXOs
         total_input = sum(u.value for u in utxos)

--- a/jmwallet/tests/test_wallet_cli.py
+++ b/jmwallet/tests/test_wallet_cli.py
@@ -2944,3 +2944,105 @@ def test_rescan_fails_fast_on_neutrino_backend(monkeypatch) -> None:
 
         assert result.exit_code == 2, f"expected exit 2, got {result.exit_code}: {result.stdout}"
         descriptor_ctor.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# send --input-utxo (issue #587)
+# ---------------------------------------------------------------------------
+
+
+def test_send_rejects_select_utxos_and_input_utxo_together():
+    """--select-utxos and --input-utxo are mutually exclusive."""
+    with patch("jmwallet.cli.send.resolve_mnemonic") as mock_resolve:
+        result = runner.invoke(
+            app,
+            [
+                "send",
+                "bcrt1qtestdestination000000000000000000000000000",
+                "--amount",
+                "1000",
+                "--network",
+                "regtest",
+                "--backend",
+                "descriptor_wallet",
+                "--select-utxos",
+                "--input-utxo",
+                f"{'aa' * 32}:0",
+            ],
+            env={
+                "MNEMONIC": "abandon abandon abandon abandon abandon abandon "
+                "abandon abandon abandon abandon abandon about"
+            },
+        )
+
+    assert result.exit_code == 1
+    mock_resolve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_with_input_utxo_spends_only_that_utxo(tmp_path: Path) -> None:
+    """--input-utxo spends exactly the named UTXO, skipping auto-selection."""
+    from jmwallet.wallet.models import UTXOInfo
+
+    with _mock_send_execution(tmp_path) as (backend_settings, mocks):
+        other_utxo = UTXOInfo(
+            txid="b" * 64,
+            vout=1,
+            value=500_000,
+            address="bcrt1qq6hag67dl53wl99vzg42z8eyzfz2xlkvwk6f7m",
+            confirmations=6,
+            scriptpubkey="0014" + "22" * 20,
+            path="m/84'/1'/0'/0/1",
+            mixdepth=0,
+        )
+        existing_utxos = mocks.wallet.get_utxos.return_value
+        mocks.wallet.get_utxos = AsyncMock(return_value=[*existing_utxos, other_utxo])
+
+        from jmwallet.cli.send import _send_transaction
+
+        await _send_transaction(
+            mnemonic="abandon " * 11 + "about",
+            destination="bcrt1qq6hag67dl53wl99vzg42z8eyzfz2xlkvwk6f7m",
+            amount=0,
+            mixdepth=0,
+            fee_rate=1.0,
+            block_target=None,
+            backend_settings=backend_settings,
+            broadcast=True,
+            skip_confirmation=True,
+            interactive_utxo_selection=False,
+            input_utxos=[f"{'a' * 64}:0"],
+        )
+
+    # Only the explicitly named UTXO (value 100_000) was signed and spent;
+    # the other 500_000-sat UTXO must not have been swept in.
+    assert mocks.wallet.sign_input.call_count == 1
+    signed_utxo = mocks.wallet.sign_input.call_args.args[2]
+    assert (signed_utxo.txid, signed_utxo.vout) == ("a" * 64, 0)
+
+
+@pytest.mark.asyncio
+async def test_send_with_unknown_input_utxo_exits_without_broadcasting(tmp_path: Path) -> None:
+    """An input UTXO that doesn't exist must fail loudly, not fall back to auto-selection."""
+    with _mock_send_execution(tmp_path) as (backend_settings, mocks):
+        mocks.wallet.utxo_cache = {}
+
+        from jmwallet.cli.send import _send_transaction
+
+        with pytest.raises(typer.Exit):
+            await _send_transaction(
+                mnemonic="abandon " * 11 + "about",
+                destination="bcrt1qq6hag67dl53wl99vzg42z8eyzfz2xlkvwk6f7m",
+                amount=0,
+                mixdepth=0,
+                fee_rate=1.0,
+                block_target=None,
+                backend_settings=backend_settings,
+                broadcast=True,
+                skip_confirmation=True,
+                interactive_utxo_selection=False,
+                input_utxos=[f"{'c' * 64}:0"],
+            )
+
+    mocks.backend.broadcast_transaction.assert_not_awaited()
+    mocks.wallet.sign_input.assert_not_called()


### PR DESCRIPTION
Follow up to #588 (this is stacked on it, so it depends on that one going in first - diff will look bigger than it actually is until then, sorry about that).

Adds `--input-utxo TXID:VOUT` to `jm-wallet send`, repeatable, mutually exclusive with `--select-utxos`. This is the CLI part i mentioned in #587 - now that `prepare_direct_send`/`resolve_input_utxos` accept an explicit list, the flag itself ended up pretty thin like i expected.

behaviour is the same as the API side:
- every utxo you list has to be unfrozen and belong to `--mixdepth`, otherwise it errors out with why
- works for sweeps too, `--amount 0` + `--input-utxo` sweeps exactly what you listed and nothing else
- fidelity bonds only if expired and this wallet can actually sign them
- no falling back to auto selection if something in the list doesnt work, it just fails

One thing i want to flag: i did NOT touch `jm-taker coinjoin` here even tho m0wer mentioned it too. Reason is the coinjoin utxo selection is more involved - it has to interact with maker fees/podle stuff and can pull in more utxos beyond what you preselected if the value isnt enough (this already happens today with `--select-utxos`). Doing the same "exact set or error" rule there would need its own discussion since it might not even be the right behaviour for coinjoin. Happy to take a stab at it separately once we agree on what it should actually do, or you can if you'd rather.

test plan:
- [x] new unit tests for the `_send_transaction` path with `--input-utxo` (spends only the named utxo, unknown utxo exits without broadcasting) + a CLI-level test for the mutual exclusivity check
- [x] full `jmwallet` `--help` sort test still passes (flag is alphabetically placed)
- [x] regenerated completions for jm-wallet only, ruff clean
- [x] ran the full jmwallet/jmwalletd suite, only the 7 pre-existing WSL chmod failures unrelated to this