### PR TITLE
fix(taker): map max_sweep_fee_change setting 

### DIFF
--- a/jmcore/src/jmcore/data/config.toml.template
+++ b/jmcore/src/jmcore/data/config.toml.template
@@ -477,6 +477,7 @@
 # Maximum acceptable coinjoin fees (paid to makers, not network/miner fees)
 # max_cj_fee_abs = 500        # Absolute fee in satoshis per maker
 # max_cj_fee_rel = "0.001"    # Relative fee (0.001 = 0.1%)
+# max_sweep_fee_change = 0.8  # Relative fee tolerance for sweep transactions
 
 # Maximum inputs a single maker may contribute to the CoinJoin.
 # The taker pays the mining fee for EVERY input, so a maker with many inputs

--- a/jmcore/src/jmcore/settings.py
+++ b/jmcore/src/jmcore/settings.py
@@ -963,6 +963,14 @@ class TakerSettings(BaseModel):
         default="0.001",
         description="Maximum relative CoinJoin fee (0.001 = 0.1%)",
     )
+    max_sweep_fee_change: float = Field(
+        default=0.8,
+        ge=0.0,
+        description=(
+            "Maximum relative fee tolerance for sweep CoinJoins (default 0.8 matches "
+            "reference JoinMarket)."
+        ),
+    )
 
     @field_validator("max_cj_fee_rel", mode="before")
     @classmethod

--- a/jmcore/src/jmcore/settings.py
+++ b/jmcore/src/jmcore/settings.py
@@ -966,6 +966,7 @@ class TakerSettings(BaseModel):
     max_sweep_fee_change: float = Field(
         default=0.8,
         ge=0.0,
+        allow_inf_nan=False,
         description=(
             "Maximum relative fee tolerance for sweep CoinJoins (default 0.8 matches "
             "reference JoinMarket)."

--- a/jmcore/tests/test_settings.py
+++ b/jmcore/tests/test_settings.py
@@ -722,6 +722,11 @@ class TestTakerSettingsMaxCjFeeRelNormalization:
         settings = TakerSettings(max_cj_fee_rel="0.001")
         assert settings.max_cj_fee_rel == "0.001"
 
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_max_sweep_fee_change_must_be_finite(self, value: float) -> None:
+        with pytest.raises(ValueError):
+            TakerSettings(max_sweep_fee_change=value)
+
 
 class TestTakerSettingsPodleFields:
     """PoDLE commitment knobs must be exposed on TakerSettings.

--- a/jmcore/tests/test_settings.py
+++ b/jmcore/tests/test_settings.py
@@ -259,6 +259,7 @@ class TestSettingsDefaults:
         assert settings.taker.minimum_makers == 4
         assert settings.taker.max_cj_fee_abs == 500
         assert settings.taker.max_cj_fee_rel == "0.001"
+        assert settings.taker.max_sweep_fee_change == 0.8
         assert settings.taker.tx_broadcast == "random-peer"
 
 

--- a/jmwalletd/src/jmwalletd/fee_policy.py
+++ b/jmwalletd/src/jmwalletd/fee_policy.py
@@ -49,6 +49,7 @@ class PolicyFeeOverrides(NamedTuple):
     tx_fee_factor: float | None = None
     max_cj_fee_abs: int | None = None
     max_cj_fee_rel: str | None = None
+    max_sweep_fee_change: float | None = None
 
 
 def resolve_policy_fee_overrides(
@@ -73,6 +74,9 @@ def resolve_policy_fee_overrides(
         tx_fee_factor=_parse_positive_float(policy.get("tx_fees_factor"), "tx_fees_factor"),
         max_cj_fee_abs=_parse_positive_int(policy.get("max_cj_fee_abs"), "max_cj_fee_abs"),
         max_cj_fee_rel=_parse_rel_fee(policy.get("max_cj_fee_rel")),
+        max_sweep_fee_change=_parse_positive_float(
+            policy.get("max_sweep_fee_change"), "max_sweep_fee_change"
+        ),
     )
 
 

--- a/jmwalletd/src/jmwalletd/routers/coinjoin.py
+++ b/jmwalletd/src/jmwalletd/routers/coinjoin.py
@@ -76,6 +76,7 @@ def build_coinjoin_taker_config(
         counterparties=int(body.counterparties),
         max_abs_fee=fee_overrides.max_cj_fee_abs,
         max_rel_fee=fee_overrides.max_cj_fee_rel,
+        max_sweep_fee_change=fee_overrides.max_sweep_fee_change,
         fee_rate=fee_overrides.fee_rate,
         block_target=fee_overrides.block_target,
         tx_fee_factor=fee_overrides.tx_fee_factor,

--- a/jmwalletd/src/jmwalletd/routers/tumbler.py
+++ b/jmwalletd/src/jmwalletd/routers/tumbler.py
@@ -279,6 +279,7 @@ def build_tumbler_taker_config(
         counterparties=int(getattr(phase, "counterparty_count", 1) or 1),
         max_abs_fee=fee_overrides.max_cj_fee_abs,
         max_rel_fee=fee_overrides.max_cj_fee_rel,
+        max_sweep_fee_change=fee_overrides.max_sweep_fee_change,
         fee_rate=fee_overrides.fee_rate,
         block_target=fee_overrides.block_target,
         tx_fee_factor=fee_overrides.tx_fee_factor,

--- a/jmwalletd/src/jmwalletd/routers/wallet_data.py
+++ b/jmwalletd/src/jmwalletd/routers/wallet_data.py
@@ -418,14 +418,13 @@ _POLICY_FIELD_MAP: dict[str, tuple[str, str]] = {
     "tx_fees_factor": ("taker", "tx_fee_factor"),
     "max_cj_fee_abs": ("taker", "max_cj_fee_abs"),
     "max_cj_fee_rel": ("taker", "max_cj_fee_rel"),
+    "max_sweep_fee_change": ("taker", "max_sweep_fee_change"),
     "minimum_makers": ("taker", "minimum_makers"),
     "gaplimit": ("wallet", "gap_limit"),
 }
 
 # Sensible defaults for fields the reference has but we don't model.
-_POLICY_DEFAULTS: dict[str, str] = {
-    "max_sweep_fee_change": "0.8",
-}
+_POLICY_DEFAULTS: dict[str, str] = {}
 
 
 @router.post("/wallet/{walletname}/configget", operation_id="configget")

--- a/jmwalletd/tests/test_coinjoin_router.py
+++ b/jmwalletd/tests/test_coinjoin_router.py
@@ -527,6 +527,7 @@ class TestBuildCoinjoinTakerConfig:
                 "POLICY": {
                     "max_cj_fee_abs": "30000",
                     "max_cj_fee_rel": "0.0003",
+                    "max_sweep_fee_change": "1.25",
                     "tx_fees_factor": "0.5",
                 }
             },
@@ -534,6 +535,7 @@ class TestBuildCoinjoinTakerConfig:
         max_cj_fee: Any = captured["max_cj_fee"]
         assert max_cj_fee.abs_fee == 30000
         assert max_cj_fee.rel_fee == "0.0003"
+        assert captured["max_sweep_fee_change"] == 1.25
         assert captured["tx_fee_factor"] == 0.5
 
     def test_invalid_configset_values_fall_back_to_settings(self) -> None:

--- a/jmwalletd/tests/test_fee_policy.py
+++ b/jmwalletd/tests/test_fee_policy.py
@@ -77,6 +77,10 @@ class TestResolvePolicyFeeOverrides:
             result = resolve_policy_fee_overrides({"POLICY": {"max_cj_fee_rel": bad}})
             assert result.max_cj_fee_rel is None
 
+    def test_max_sweep_fee_change_override(self) -> None:
+        result = resolve_policy_fee_overrides({"POLICY": {"max_sweep_fee_change": "0.5"}})
+        assert result.max_sweep_fee_change == 0.5
+
     def test_combined_jam_fee_settings(self) -> None:
         """The full set JAM's fee modal writes in one save."""
         overrides = {
@@ -95,4 +99,5 @@ class TestResolvePolicyFeeOverrides:
             tx_fee_factor=0.2,
             max_cj_fee_abs=10000,
             max_cj_fee_rel="0.001",
+            max_sweep_fee_change=0.8,
         )

--- a/jmwalletd/tests/test_tumbler_router.py
+++ b/jmwalletd/tests/test_tumbler_router.py
@@ -880,9 +880,16 @@ class TestBuildTumblerTakerConfig:
             mnemonic="dummy",
             jm_settings=self._settings(),
             taker_config_cls=fake_taker_config_cls,
-            config_overrides={"POLICY": {"tx_fees": "5000", "max_cj_fee_abs": "30000"}},
+            config_overrides={
+                "POLICY": {
+                    "tx_fees": "5000",
+                    "max_cj_fee_abs": "30000",
+                    "max_sweep_fee_change": "1.25",
+                }
+            },
         )
 
         assert captured["fee_rate"] == 5.0
         assert captured["fee_block_target"] is None
+        assert captured["max_sweep_fee_change"] == 1.25
         assert captured["max_cj_fee"].abs_fee == 30000

--- a/jmwalletd/tests/test_wallet_data_router.py
+++ b/jmwalletd/tests/test_wallet_data_router.py
@@ -454,7 +454,7 @@ class TestConfigGet:
         self,
         authed_client: tuple[TestClient, str],
     ) -> None:
-        """max_sweep_fee_change returns hardcoded default from _POLICY_DEFAULTS."""
+        """max_sweep_fee_change returns value from settings and supports overrides."""
         client, token = authed_client
         resp = client.post(
             "/api/v1/wallet/test_wallet.jmdat/configget",
@@ -464,6 +464,17 @@ class TestConfigGet:
         assert resp.status_code == 200
         data = resp.json()
         assert data["configvalue"] == "0.8"
+
+        # Verify configset override works
+        state = get_daemon_state()
+        state.config_overrides["POLICY"] = {"max_sweep_fee_change": "0.5"}
+        resp2 = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/configget",
+            json={"section": "POLICY", "field": "max_sweep_fee_change"},
+            headers=_auth_headers(token),
+        )
+        assert resp2.status_code == 200
+        assert resp2.json()["configvalue"] == "0.5"
 
     def test_get_from_overrides(self, authed_client: tuple[TestClient, str]) -> None:
         client, token = authed_client

--- a/taker/src/taker/coinjoin_session.py
+++ b/taker/src/taker/coinjoin_session.py
@@ -1081,6 +1081,18 @@ class CoinJoinSession:
 
                 # The residual becomes additional miner fee (no taker change in sweep)
 
+                # Enforce max_sweep_fee_change limit on residual fee drift
+                base_miner_fee = tx_fee + maker_txfee
+                if base_miner_fee > 0 and self.config.max_sweep_fee_change is not None:
+                    fee_change_ratio = residual / base_miner_fee
+                    if fee_change_ratio > self.config.max_sweep_fee_change:
+                        logger.error(
+                            f"Sweep failed: fee change ratio {fee_change_ratio:.2f} exceeds "
+                            f"max_sweep_fee_change limit of {self.config.max_sweep_fee_change:.2f} "
+                            f"(residual={residual} sats vs base_miner_fee={base_miner_fee} sats)."
+                        )
+                        return False
+
                 # The budget was estimated from an assumed maker input count. If
                 # counterparties contributed far more inputs than assumed, the
                 # fixed budget spread over the larger transaction can fall below

--- a/taker/src/taker/coinjoin_session.py
+++ b/taker/src/taker/coinjoin_session.py
@@ -1079,18 +1079,32 @@ class CoinJoinSession:
                         "This may indicate a fee calculation mismatch."
                     )
 
-                # The residual becomes additional miner fee (no taker change in sweep)
-
-                # Enforce max_sweep_fee_change limit on residual fee drift
-                base_miner_fee = tx_fee + maker_txfee
-                if base_miner_fee > 0 and self.config.max_sweep_fee_change is not None:
-                    fee_change_ratio = residual / base_miner_fee
-                    if fee_change_ratio > self.config.max_sweep_fee_change:
-                        logger.error(
-                            f"Sweep failed: fee change ratio {fee_change_ratio:.2f} exceeds "
-                            f"max_sweep_fee_change limit of {self.config.max_sweep_fee_change:.2f} "
-                            f"(residual={residual} sats vs base_miner_fee={base_miner_fee} sats)."
+                # The residual becomes additional miner fee (no taker change in sweep).
+                # Check the finalized transaction shape against the deterministic
+                # base-rate budget used to calculate the amount sent in !fill.
+                if self.config.max_sweep_fee_change is not None:
+                    if tx_fee <= 0:
+                        self.last_failure_reason = (
+                            "Sweep fee budget must be positive after order selection; "
+                            "retry the CoinJoin."
                         )
+                        logger.error(f"Sweep failed: {self.last_failure_reason}")
+                        return False
+
+                    actual_base_fee = self._estimate_tx_fee(
+                        num_inputs, num_outputs, use_base_rate=True
+                    )
+                    fee_ratio = actual_base_fee / tx_fee
+                    tolerance = self.config.max_sweep_fee_change
+                    if fee_ratio < 1 - tolerance or fee_ratio > 1 + tolerance:
+                        self.last_failure_reason = (
+                            "Sweep transaction fee estimate differs from the selected fee budget: "
+                            f"estimated {actual_base_fee} sats for {num_inputs} inputs and "
+                            f"{num_outputs} outputs, budget {tx_fee} sats, "
+                            f"tolerance {tolerance:.2f}. "
+                            "Retry the CoinJoin with different makers."
+                        )
+                        logger.error(f"Sweep failed: {self.last_failure_reason}")
                         return False
 
                 # The budget was estimated from an assumed maker input count. If

--- a/taker/src/taker/config.py
+++ b/taker/src/taker/config.py
@@ -112,6 +112,7 @@ class TakerConfig(WalletConfig):
     max_sweep_fee_change: float = Field(
         default=0.8,
         ge=0.0,
+        allow_inf_nan=False,
         description="Relative fee tolerance for sweep transactions (reference default 0.8)",
     )
     tx_fee_factor: float = Field(

--- a/taker/src/taker/config.py
+++ b/taker/src/taker/config.py
@@ -109,6 +109,11 @@ class TakerConfig(WalletConfig):
     max_cj_fee: MaxCjFee = Field(
         default_factory=MaxCjFee, description="Maximum CoinJoin fee limits"
     )
+    max_sweep_fee_change: float = Field(
+        default=0.8,
+        ge=0.0,
+        description="Relative fee tolerance for sweep transactions (reference default 0.8)",
+    )
     tx_fee_factor: float = Field(
         default=0.2,
         ge=0.0,

--- a/taker/src/taker/config_builder.py
+++ b/taker/src/taker/config_builder.py
@@ -55,6 +55,7 @@ def build_taker_config_kwargs(
     tor_socks_port: int | None = None,
     max_abs_fee: int | None = None,
     max_rel_fee: str | None = None,
+    max_sweep_fee_change: float | None = None,
     fee_rate: float | None = None,
     block_target: int | None = None,
     tx_fee_factor: float | None = None,
@@ -176,6 +177,11 @@ def build_taker_config_kwargs(
     effective_max_rel_fee = (
         max_rel_fee if max_rel_fee is not None else settings.taker.max_cj_fee_rel
     )
+    effective_max_sweep_fee_change = (
+        max_sweep_fee_change
+        if max_sweep_fee_change is not None
+        else settings.taker.max_sweep_fee_change
+    )
     # Resolve fee settings together so CLI overrides can switch modes cleanly:
     # CLI fee_rate > CLI block_target > config fee_rate > config/default block_target.
     effective_fee_rate: float | None = None
@@ -246,6 +252,7 @@ def build_taker_config_kwargs(
         "mixdepth": mixdepth,
         "counterparty_count": effective_counterparties,
         "max_cj_fee": MaxCjFee(abs_fee=effective_max_abs_fee, rel_fee=effective_max_rel_fee),
+        "max_sweep_fee_change": effective_max_sweep_fee_change,
         "tx_fee_factor": (
             tx_fee_factor if tx_fee_factor is not None else settings.taker.tx_fee_factor
         ),
@@ -298,6 +305,7 @@ def build_taker_config(
     tor_socks_port: int | None = None,
     max_abs_fee: int | None = None,
     max_rel_fee: str | None = None,
+    max_sweep_fee_change: float | None = None,
     fee_rate: float | None = None,
     block_target: int | None = None,
     tx_fee_factor: float | None = None,
@@ -335,6 +343,7 @@ def build_taker_config(
             tor_socks_port=tor_socks_port,
             max_abs_fee=max_abs_fee,
             max_rel_fee=max_rel_fee,
+            max_sweep_fee_change=max_sweep_fee_change,
             fee_rate=fee_rate,
             block_target=block_target,
             tx_fee_factor=tx_fee_factor,

--- a/taker/tests/test_cli.py
+++ b/taker/tests/test_cli.py
@@ -69,6 +69,7 @@ class TestBuildTakerConfig:
         settings.taker.counterparty_count = 4
         settings.taker.max_cj_fee_abs = 1000
         settings.taker.max_cj_fee_rel = "0.002"
+        settings.taker.max_sweep_fee_change = 0.8
         settings.taker.fee_rate = None  # Not set in config
         settings.taker.fee_block_target = None  # Not set in config
         settings.taker.bondless_makers_allowance = 0.1
@@ -674,3 +675,28 @@ class TestBuildTakerConfig:
         )
 
         assert config.nick_auth_directory_ids == expected
+
+    def test_max_sweep_fee_change_flow_and_override(
+        self, sample_mnemonic: str, mock_settings: MagicMock
+    ) -> None:
+        """max_sweep_fee_change flows from settings to TakerConfig and accepts override."""
+        config_default = build_taker_config(
+            settings=mock_settings,
+            mnemonic=sample_mnemonic,
+            passphrase="",
+            destination="bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            amount=100000,
+            mixdepth=0,
+        )
+        assert config_default.max_sweep_fee_change == 0.8
+
+        config_override = build_taker_config(
+            settings=mock_settings,
+            mnemonic=sample_mnemonic,
+            passphrase="",
+            destination="bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            amount=100000,
+            mixdepth=0,
+            max_sweep_fee_change=0.5,
+        )
+        assert config_override.max_sweep_fee_change == 0.5

--- a/taker/tests/test_taker_config.py
+++ b/taker/tests/test_taker_config.py
@@ -184,6 +184,11 @@ class TestTakerConfig:
         with pytest.raises(ValidationError):
             TakerConfig(mnemonic=sample_mnemonic, tx_fee_factor=-0.1)
 
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_max_sweep_fee_change_must_be_finite(self, sample_mnemonic: str, value: float) -> None:
+        with pytest.raises(ValidationError):
+            TakerConfig(mnemonic=sample_mnemonic, max_sweep_fee_change=value)
+
     def test_mixdepth_count_bounds(self, sample_mnemonic: str) -> None:
         """Test mixdepth count validation."""
         # Valid

--- a/taker/tests/test_taker_protocol.py
+++ b/taker/tests/test_taker_protocol.py
@@ -1024,6 +1024,51 @@ class TestSweepCjAmountPreservation:
         # This is the expected behavior: fee amount is stable, rate may vary
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("actual_base_fee", "expected_result"),
+        [
+            (559, False),  # Below 80% of the 700-sat budget.
+            (560, True),  # At the lower boundary.
+            (840, True),  # At the upper boundary.
+            (841, False),  # Above 120% of the budget.
+        ],
+    )
+    async def test_sweep_fee_budget_tolerance_is_symmetric(
+        self,
+        mock_wallet_for_sweep,
+        mock_backend_for_sweep,
+        taker_config_for_sweep,
+        actual_base_fee: int,
+        expected_result: bool,
+    ) -> None:
+        """Sweep checks actual transaction shape symmetrically against its budget."""
+        taker_config_for_sweep.max_sweep_fee_change = 0.2
+        taker = Taker(mock_wallet_for_sweep, mock_backend_for_sweep, taker_config_for_sweep)
+        session = taker._session
+        session.is_sweep = True
+        session.preselected_utxos = mock_wallet_for_sweep.get_all_utxos()
+        session._fee_rate = 1.0
+        session._sweep_tx_fee_budget = 700
+        session.cj_amount = sum(utxo.value for utxo in session.preselected_utxos) - 700
+
+        nick, maker_session = self._make_single_utxo_maker_session()
+        session.maker_sessions = {nick: maker_session}
+
+        with patch.object(session, "_estimate_tx_fee", return_value=actual_base_fee) as estimate:
+            result = await session._phase_build_tx(
+                destination="bcrt1qqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcruj60yu",
+                mixdepth=3,
+            )
+
+        assert result is expected_result
+        estimate.assert_any_call(3, 3, use_base_rate=True)
+        if expected_result:
+            assert session.last_failure_reason is None
+        else:
+            assert session.last_failure_reason is not None
+            assert "fee estimate differs" in session.last_failure_reason
+
+    @pytest.mark.asyncio
     async def test_sweep_aborts_when_effective_fee_rate_below_relay_floor(
         self, mock_wallet_for_sweep, mock_backend_for_sweep, taker_config_for_sweep
     ):


### PR DESCRIPTION
Fixes #586, joinmarket-webui/jam#1342

### Summary
Previously, `max_sweep_fee_change` was hardcoded to `"0.8"` in `_POLICY_DEFAULTS` and silently dropped from policy fee override resolution. This prevented user overrides saved via `configset` (e.g. from JAM UI's fee modal) from persisting or being applied at runtime.

This PR promotes `max_sweep_fee_change` to pydantic field across `TakerSettings` and `TakerConfig`, routes it through `jmwalletd` policy field mappings, and adds runtime relative fee tolerance enforcement during sweep execution.

### Key Changes
- **Configuration & Settings**: Added `max_sweep_fee_change` to `TakerSettings` (default `0.8`), `TakerConfig`, and `config.toml.template`.
- **API & Override Mapping**: Mapped `max_sweep_fee_change` in `_POLICY_FIELD_MAP` and `resolve_policy_fee_overrides` so `configset` / `configget` calls dynamically store and reflect the configured value.
- **Config Builder Propagation**: Updated `build_taker_config_kwargs` and `build_taker_config` to accept and resolve `max_sweep_fee_change`.
- **Runtime Enforcement**: Added residual fee change tolerance check in `CoinJoinSession` to reject sweep transactions if miner fee drift exceeds `max_sweep_fee_change`.
- **Testing**: Added unit test coverage in `jmcore`, `jmwalletd` (fee policy & data router), and `taker` CLI tests.
